### PR TITLE
[coordinator] Productization of the simple dependency manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ archbin
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
+# Profile output.
+*.prof
+
 # Output of the build and experiment runs
 out/
 

--- a/Makefile
+++ b/Makefile
@@ -159,7 +159,7 @@ bench-loadgen: FORCE
 
 # Run dependency detector benchmarks with added op/sec column.
 bench-dep: FORCE
-	$(go_cmd) test ./service/coordinator/dependencygraph/... -bench "BenchmarkDependencyGraph.*" -run="^$$" | awk -f scripts/bench-tx-per-sec.awk
+	$(go_cmd) test ./service/coordinator/dependencygraph/... -timeout 60m -bench "BenchmarkDependencyGraph.*" -run="^$$" | awk -f scripts/bench-tx-per-sec.awk
 
 # Run dependency detector benchmarks with added op/sec column.
 bench-preparer: FORCE

--- a/cmd/config/app_config_test.go
+++ b/cmd/config/app_config_test.go
@@ -118,9 +118,8 @@ func TestReadConfigCoordinator(t *testing.T) {
 			Server:     makeServer("localhost", 9001),
 			Monitoring: makeMonitoring("localhost", 2119),
 			DependencyGraphConfig: &coordinator.DependencyGraphConfig{
-				NumOfLocalDepConstructors:       1,
-				WaitingTxsLimit:                 100_000,
-				NumOfWorkersForGlobalDepManager: 1,
+				NumOfLocalDepConstructors: 1,
+				WaitingTxsLimit:           100_000,
 			},
 			ChannelBufferSizePerGoroutine: 10,
 		},
@@ -137,9 +136,8 @@ func TestReadConfigCoordinator(t *testing.T) {
 				Endpoints: []*connection.Endpoint{makeEndpoint("validator-persister", 6001)},
 			},
 			DependencyGraphConfig: &coordinator.DependencyGraphConfig{
-				NumOfLocalDepConstructors:       1,
-				WaitingTxsLimit:                 10_000,
-				NumOfWorkersForGlobalDepManager: 1,
+				NumOfLocalDepConstructors: 1,
+				WaitingTxsLimit:           100_000,
 			},
 			ChannelBufferSizePerGoroutine: 10,
 		},

--- a/cmd/config/samples/coordinator.yaml
+++ b/cmd/config/samples/coordinator.yaml
@@ -17,8 +17,7 @@ validator-committer:
 
 dependency-graph:
   num-of-local-dep-constructors: 1
-  waiting-txs-limit: 10_000
-  num-of-workers-for-global-dep-manager: 1
+  waiting-txs-limit: 100_000
   per-channel-buffer-size-per-goroutine: 10
 
 logging:

--- a/cmd/config/templates/coordinator.yaml
+++ b/cmd/config/templates/coordinator.yaml
@@ -21,8 +21,7 @@ validator-committer:
 
 dependency-graph:
   num-of-local-dep-constructors: 1
-  waiting-txs-limit: 10_000
-  num-of-workers-for-global-dep-manager: 1
+  waiting-txs-limit: 100_000
   # Add monitoring configuration here if applicable
 per-channel-buffer-size-per-goroutine: 10
 

--- a/cmd/config/viper.go
+++ b/cmd/config/viper.go
@@ -20,7 +20,6 @@ func NewViperWithCoordinatorDefaults() *viper.Viper {
 	v := NewViperWithServiceDefault(9001, 2119)
 	v.SetDefault("dependency-graph.num-of-local-dep-constructors", 1)
 	v.SetDefault("dependency-graph.waiting-txs-limit", 100_000)
-	v.SetDefault("dependency-graph.num-of-workers-for-global-dep-manager", 1)
 	v.SetDefault("per-channel-buffer-size-per-goroutine", 10)
 	return v
 }

--- a/loadgen/client_test.go
+++ b/loadgen/client_test.go
@@ -141,9 +141,8 @@ func TestLoadGenForCoordinator(t *testing.T) {
 				VerifierConfig:           *test.ServerToClientConfig(sigVerServer.Configs...),
 				ValidatorCommitterConfig: *test.ServerToClientConfig(vcServer.Configs...),
 				DependencyGraphConfig: &coordinator.DependencyGraphConfig{
-					NumOfLocalDepConstructors:       1,
-					WaitingTxsLimit:                 10_000,
-					NumOfWorkersForGlobalDepManager: 1,
+					NumOfLocalDepConstructors: 1,
+					WaitingTxsLimit:           100_000,
 				},
 				ChannelBufferSizePerGoroutine: 10,
 			}

--- a/service/coordinator/config.go
+++ b/service/coordinator/config.go
@@ -24,8 +24,7 @@ type (
 
 	// DependencyGraphConfig is the configuration for dependency graph manager. It contains resource limits.
 	DependencyGraphConfig struct {
-		NumOfLocalDepConstructors       int `mapstructure:"num-of-local-dep-constructors"`
-		WaitingTxsLimit                 int `mapstructure:"waiting-txs-limit"`
-		NumOfWorkersForGlobalDepManager int `mapstructure:"num-of-workers-for-global-dep-manager"`
+		NumOfLocalDepConstructors int `mapstructure:"num-of-local-dep-constructors"`
+		WaitingTxsLimit           int `mapstructure:"waiting-txs-limit"`
 	}
 )

--- a/service/coordinator/coordinator.go
+++ b/service/coordinator/coordinator.go
@@ -140,7 +140,7 @@ func NewCoordinatorService(c *Config) *Service {
 	metrics := newPerformanceMetrics()
 
 	depMgr := dependencygraph.NewManager(
-		&dependencygraph.Config{
+		&dependencygraph.Parameters{
 			IncomingTxs:               queues.coordinatorToDepGraphTxs,
 			OutgoingDepFreeTxsNode:    queues.depGraphToSigVerifierFreeTxs,
 			IncomingValidatedTxsNode:  queues.vcServiceToDepGraphValidatedTxs,

--- a/service/coordinator/coordinator_test.go
+++ b/service/coordinator/coordinator_test.go
@@ -74,9 +74,8 @@ func newCoordinatorTestEnv(t *testing.T, tConfig *testConfig) *coordinatorTestEn
 		VerifierConfig:           *test.ServerToClientConfig(svServers.Configs...),
 		ValidatorCommitterConfig: *test.ServerToClientConfig(vcServerConfigs...),
 		DependencyGraphConfig: &DependencyGraphConfig{
-			NumOfLocalDepConstructors:       3,
-			WaitingTxsLimit:                 10,
-			NumOfWorkersForGlobalDepManager: 3,
+			NumOfLocalDepConstructors: 3,
+			WaitingTxsLimit:           10,
 		},
 		ChannelBufferSizePerGoroutine: 2000,
 		Monitoring: monitoring.Config{

--- a/service/coordinator/dependencygraph/local_dependency_constructor_test.go
+++ b/service/coordinator/dependencygraph/local_dependency_constructor_test.go
@@ -8,6 +8,7 @@ package dependencygraph
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -299,7 +300,7 @@ func TestLocalDependencyConstructorWithOrder(t *testing.T) {
 func makeTestKeys(_ *testing.T, numKeys int) [][]byte {
 	keys := make([][]byte, numKeys)
 	for i := range numKeys {
-		keys[i] = []byte{byte(i)}
+		keys[i] = fmt.Appendf(nil, "%d", i)
 	}
 	return keys
 }

--- a/service/coordinator/dependencygraph/manager_test.go
+++ b/service/coordinator/dependencygraph/manager_test.go
@@ -12,6 +12,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger/fabric-x-committer/api/protoblocktx"
+	"github.com/hyperledger/fabric-x-committer/api/types"
 	"github.com/hyperledger/fabric-x-committer/loadgen/workload"
 	"github.com/hyperledger/fabric-x-committer/utils"
 	"github.com/hyperledger/fabric-x-committer/utils/channel"
@@ -32,153 +36,352 @@ func BenchmarkDependencyGraph(b *testing.B) {
 	// Parameters
 	latency := 10 * time.Second
 	batchSize := 1024
+	nums := utils.Range(0, uint32(batchSize)) //nolint:gosec // int -> uint32.
 
-	testDependencies := make([]workload.DependencyDescription, 10)
+	testKeysCount := []int{2, 4, 6}
 	allDep := []string{workload.DependencyReadOnly, workload.DependencyReadWrite, workload.DependencyBlindWrite}
+
 	// We start with one to have no dependencies.
-	i := 1
+	testDependencies := make([]workload.DependencyDescription, 1, 1+len(allDep)*len(allDep))
 	for _, src := range allDep {
 		for _, dst := range allDep {
-			testDependencies[i] = workload.DependencyDescription{
+			testDependencies = append(testDependencies, workload.DependencyDescription{
 				Probability: 0.3,
 				Gap:         workload.NewNormalDistribution(500, 10),
 				Src:         src,
 				Dst:         dst,
-			}
-			i++
+			})
 		}
 	}
 
-	for idx, dep := range testDependencies {
-		p := workload.DefaultProfile(8)
-		name := "no-dep"
-		if idx > 0 {
-			p.Conflicts.Dependencies = []workload.DependencyDescription{dep}
-			name = fmt.Sprintf("%s AND %s", dep.Src, dep.Dst)
-		}
+	for _, keyCount := range testKeysCount {
+		b.Run(fmt.Sprintf("%d-keys", keyCount), func(b *testing.B) {
+			for idx, dep := range testDependencies {
+				p := workload.DefaultProfile(8)
+				name := "no-dep"
+				if idx > 0 {
+					p.Conflicts.Dependencies = []workload.DependencyDescription{dep}
+					name = fmt.Sprintf("%s AND %s", dep.Src, dep.Dst)
+				}
+				p.Transaction.ReadWriteCount = workload.NewConstantDistribution(float64(keyCount))
+				g := workload.StartGenerator(b, p)
 
-		b.Run(name, func(b *testing.B) {
-			g := workload.StartGenerator(b, p)
+				b.Run(name, func(b *testing.B) {
+					for _, tc := range []struct {
+						kind    string
+						workers int
+					}{
+						{kind: "simple", workers: 2},
+						{kind: "global-local", workers: 2},
+						{kind: "global-local", workers: 4},
+					} {
+						name := fmt.Sprintf("%s-%d", tc.kind, tc.workers)
+						b.Run(name, func(b *testing.B) {
+							// The main queues.
+							in := make(chan *TransactionBatch, 8)
+							out := make(chan TxNodeBatch, 8)
+							val := make(chan TxNodeBatch, 8)
 
-			for _, item := range []struct {
-				name    string
-				exec    func(t testing.TB, c *Config)
-				workers int
-			}{
-				{
-					name:    "simple-dep-graph",
-					exec:    startSimpleDependency,
-					workers: 1,
-				},
-				{
-					name:    "dep-graph-2",
-					exec:    startDependencyManager,
-					workers: 2,
-				},
-				{
-					name:    "dep-graph-4",
-					exec:    startDependencyManager,
-					workers: 4,
-				},
-				{
-					name:    "dep-graph-8",
-					exec:    startDependencyManager,
-					workers: 8,
-				},
-			} {
-				b.Run(item.name, func(b *testing.B) {
-					// The main queues.
-					in := make(chan *TransactionBatch, 8)
-					out := make(chan TxNodeBatch, 8)
-					val := make(chan TxNodeBatch, 8)
-
-					// Starts the dependency manager.
-					item.exec(b, defaultManagerConfig(in, out, val, item.workers))
-
-					outCtx := channel.NewReader(b.Context(), out)
-					valCtx := channel.NewWriter(b.Context(), val)
-					inCtx := channel.NewWriter(b.Context(), in)
-					latencySimulatorQueue := channel.Make[*batchWithLatency](b.Context(), 1024*1024)
-
-					// Simulates the batch processing latency.
-					go func() {
-						for b.Context().Err() == nil {
-							wtl, ok := latencySimulatorQueue.Read()
-							if !ok {
-								return
-							}
-							waitFor := time.Until(wtl.done)
-							if waitFor > 0 {
-								select {
-								case <-time.After(waitFor):
-								case <-b.Context().Done():
-								}
-							}
-							valCtx.Write(wtl.batch)
-						}
-					}()
-
-					nums := utils.Range(0, uint32(batchSize)) //nolint:gosec // int -> uint32.
-					b.ResetTimer()
-					// Generates the load to the manager's queue.
-					go func() {
-						var i uint64
-						for b.Context().Err() == nil {
-							txs := g.NextN(b.Context(), batchSize)
-							inCtx.Write(&TransactionBatch{
-								ID:          i,
-								BlockNumber: i,
-								Txs:         txs,
-								TxsNum:      nums,
+							// Starts the dependency manager.
+							startManager(b, tc.kind, &Parameters{
+								IncomingTxs:               in,
+								OutgoingDepFreeTxsNode:    out,
+								IncomingValidatedTxsNode:  val,
+								NumOfLocalDepConstructors: tc.workers,
+								WaitingTxsLimit:           20_000_000,
+								PrometheusMetricsProvider: monitoring.NewProvider(),
 							})
-							i++
-						}
-					}()
-					// Reads the output of the manager, and forward it to the latency simulator.
-					var total int
-					for total < b.N {
-						batch, ok := outCtx.Read()
-						if !ok {
-							return
-						}
-						latencySimulatorQueue.Write(&batchWithLatency{
-							batch: batch,
-							done:  time.Now().Add(latency),
+
+							ctx := b.Context()
+							outCtx := channel.NewReader(ctx, out)
+							valCtx := channel.NewWriter(ctx, val)
+							inCtx := channel.NewWriter(ctx, in)
+							latencySimulatorQueue := channel.Make[*batchWithLatency](ctx, 1024*1024)
+
+							// Simulates the batch processing latency.
+							go func() {
+								for ctx.Err() == nil {
+									wtl, ok := latencySimulatorQueue.Read()
+									if !ok {
+										return
+									}
+									waitFor := time.Until(wtl.done)
+									if waitFor > 0 {
+										select {
+										case <-time.After(waitFor):
+										case <-ctx.Done():
+										}
+									}
+									valCtx.Write(wtl.batch)
+								}
+							}()
+
+							b.ResetTimer()
+							// Generates the load to the manager's queue.
+							go func() {
+								var i uint64
+								for ctx.Err() == nil {
+									txs := g.NextN(ctx, batchSize)
+									inCtx.Write(&TransactionBatch{
+										ID:          i,
+										BlockNumber: i,
+										Txs:         txs,
+										TxsNum:      nums,
+									})
+									i++
+								}
+							}()
+							// Reads the output of the manager, and forward it to the latency simulator.
+							var total int
+							for total < b.N {
+								batch, ok := outCtx.Read()
+								if !ok {
+									return
+								}
+								latencySimulatorQueue.Write(&batchWithLatency{
+									batch: batch,
+									done:  time.Now().Add(latency),
+								})
+								total += len(batch)
+							}
+							b.StopTimer()
 						})
-						total += len(batch)
 					}
-					b.StopTimer()
 				})
 			}
 		})
 	}
 }
 
-func startDependencyManager(tb testing.TB, c *Config) {
-	tb.Helper()
-	m := NewManager(c)
-	test.RunServiceForTest(tb.Context(), tb, func(ctx context.Context) error {
-		m.Run(ctx)
-		return nil
-	}, nil)
-}
+func TestDependencyGraphManager(t *testing.T) {
+	t.Parallel()
 
-func startSimpleDependency(tb testing.TB, c *Config) {
-	tb.Helper()
-	m := NewSimpleManager(c)
-	test.RunServiceForTest(tb.Context(), tb, func(ctx context.Context) error {
-		m.Run(ctx)
-		return nil
-	}, nil)
-}
-
-func defaultManagerConfig(in chan *TransactionBatch, out, val chan TxNodeBatch, workers int) *Config {
-	return &Config{
-		IncomingTxs:               in,
-		OutgoingDepFreeTxsNode:    out,
-		IncomingValidatedTxsNode:  val,
-		NumOfLocalDepConstructors: workers,
-		WaitingTxsLimit:           20_000_000,
-		PrometheusMetricsProvider: monitoring.NewProvider(),
+	keysPoll := makeTestKeys(t, 10)
+	keys := func(idx ...int) [][]byte {
+		k := make([][]byte, len(idx))
+		for i := range idx {
+			k[i] = keysPoll[idx[i]]
+		}
+		return k
 	}
+
+	for _, manType := range []string{"global-local", "simple"} {
+		t.Run(manType, func(t *testing.T) {
+			t.Parallel()
+			incomingTxs := make(chan *TransactionBatch, 10)
+			outgoingTxs := make(chan TxNodeBatch, 10)
+			validatedTxs := make(chan TxNodeBatch, 10)
+
+			manService, metrics := startManager(t, manType, &Parameters{
+				IncomingTxs:               incomingTxs,
+				OutgoingDepFreeTxsNode:    outgoingTxs,
+				IncomingValidatedTxsNode:  validatedTxs,
+				NumOfLocalDepConstructors: 2,
+				WaitingTxsLimit:           20,
+				PrometheusMetricsProvider: monitoring.NewProvider(),
+			})
+
+			t.Log("check reads and writes dependency tracking")
+			test.RequireIntMetricValue(t, 0, metrics.dependentTransactionsQueueSize)
+
+			// t2 depends on t1
+			t1 := createTxForTest(t, nsID1ForTest, keys(0, 1), keys(2, 3), keys(4, 5))
+			t2 := createTxForTest(t, nsID1ForTest, keys(4, 5), keys(2, 6), keys(3, 7))
+
+			incomingTxs <- &TransactionBatch{
+				ID:     1,
+				Txs:    []*protoblocktx.Tx{t1, t2},
+				TxsNum: []uint32{0, 1},
+			}
+
+			test.EventuallyIntMetric(t, 1, metrics.dependentTransactionsQueueSize, 5*time.Second, 100*time.Millisecond)
+
+			// t3 depends on t2 and t1
+			t3 := createTxForTest(t, nsID1ForTest, keys(7), keys(2, 3), keys(8, 5))
+			// t4 depends on t2 and t1
+			t4 := createTxForTest(t, nsID1ForTest, keys(7, 6), keys(4, 1), keys(0, 9))
+
+			incomingTxs <- &TransactionBatch{
+				ID:     2,
+				Txs:    []*protoblocktx.Tx{t3, t4},
+				TxsNum: []uint32{0, 1},
+			}
+
+			test.EventuallyIntMetric(t, 3, metrics.dependentTransactionsQueueSize, 5*time.Second, 100*time.Millisecond)
+
+			// only t1 is dependency free
+			depFreeTxs := <-outgoingTxs
+			require.Len(t, depFreeTxs, 1)
+			actualT1 := depFreeTxs[0]
+			require.Equal(t, t1.Id, actualT1.Tx.ID)
+			ensureNoOutputs(t, outgoingTxs)
+
+			validatedTxs <- TxNodeBatch{actualT1}
+
+			// after t1 is validated, t2 is dependency free
+			depFreeTxs = <-outgoingTxs
+			require.Len(t, depFreeTxs, 1)
+			actualT2 := depFreeTxs[0]
+			require.Equal(t, t2.Id, actualT2.Tx.ID)
+			ensureNoOutputs(t, outgoingTxs)
+
+			test.RequireIntMetricValue(t, 2, metrics.dependentTransactionsQueueSize)
+
+			validatedTxs <- TxNodeBatch{actualT2}
+
+			// after t2 is validated, both t3 and t4 are dependency free
+			depFreeTxs = <-outgoingTxs
+			require.Len(t, depFreeTxs, 2)
+			var actualT3, actualT4 *TransactionNode
+			if t3.Id == depFreeTxs[0].Tx.ID {
+				actualT3 = depFreeTxs[0]
+				actualT4 = depFreeTxs[1]
+			} else {
+				actualT3 = depFreeTxs[1]
+				actualT4 = depFreeTxs[0]
+			}
+			require.Equal(t, t3.Id, actualT3.Tx.ID)
+			require.Equal(t, t4.Id, actualT4.Tx.ID)
+			ensureNoOutputs(t, outgoingTxs)
+
+			test.RequireIntMetricValue(t, 0, metrics.dependentTransactionsQueueSize)
+
+			validatedTxs <- TxNodeBatch{actualT3, actualT4}
+
+			ensureProcessedAndValidatedMetrics(t, metrics, 4, 4)
+			// after validating all txs, the dependency detector should be empty
+			ensureEmptyManager(t, manService)
+
+			t.Log("check dependency in namespace")
+			// t2 depends on t1, t1 depends on t0.
+			t0 := createTxForTest(
+				t, types.ConfigNamespaceID, nil, nil, [][]byte{[]byte(types.ConfigKey)},
+			)
+			t1 = createTxForTest(
+				t, types.MetaNamespaceID, nil, [][]byte{[]byte(nsID1ForTest)}, nil,
+			)
+			t2 = createTxForTest(
+				t, nsID1ForTest, keys(4, 5), keys(2, 6), keys(3, 7),
+			)
+
+			incomingTxs <- &TransactionBatch{
+				ID:     3,
+				Txs:    []*protoblocktx.Tx{t0, t1, t2},
+				TxsNum: []uint32{0, 1, 2},
+			}
+
+			// t3 depends on t2, t1, and t0
+			t3 = createTxForTest(
+				t, types.MetaNamespaceID, nil, [][]byte{[]byte(nsID1ForTest)}, nil,
+			)
+			// t4 depends on t3, t2 and t1
+			t4 = createTxForTest(t, nsID1ForTest, keys(7, 6), keys(4, 1), keys(0, 9))
+
+			incomingTxs <- &TransactionBatch{
+				ID:     4,
+				Txs:    []*protoblocktx.Tx{t3, t4},
+				TxsNum: []uint32{0, 1},
+			}
+
+			// only t0 is dependency free
+			depFreeTxs = <-outgoingTxs
+			require.Len(t, depFreeTxs, 1)
+			actualT0 := depFreeTxs[0]
+			require.Equal(t, t0.Id, actualT0.Tx.ID)
+			ensureNoOutputs(t, outgoingTxs)
+
+			validatedTxs <- TxNodeBatch{actualT0}
+
+			// only t1 is dependency free
+			depFreeTxs = <-outgoingTxs
+			require.Len(t, depFreeTxs, 1)
+			actualT1 = depFreeTxs[0]
+			require.Equal(t, t1.Id, actualT1.Tx.ID)
+			ensureNoOutputs(t, outgoingTxs)
+
+			validatedTxs <- TxNodeBatch{actualT1}
+
+			// after t1 is validated, t2 is dependency free
+			depFreeTxs = <-outgoingTxs
+			require.Len(t, depFreeTxs, 1)
+			actualT2 = depFreeTxs[0]
+			require.Equal(t, t2.Id, actualT2.Tx.ID)
+			ensureNoOutputs(t, outgoingTxs)
+
+			validatedTxs <- TxNodeBatch{actualT2}
+
+			// after t2 is validated, t3 becomes dependency free
+			depFreeTxs = <-outgoingTxs
+			require.Len(t, depFreeTxs, 1)
+			actualT3 = depFreeTxs[0]
+			require.Equal(t, t3.Id, actualT3.Tx.ID)
+			ensureNoOutputs(t, outgoingTxs)
+
+			validatedTxs <- TxNodeBatch{actualT3}
+
+			// after t3 is validated, t4 becomes dependency free
+			depFreeTxs = <-outgoingTxs
+			require.Len(t, depFreeTxs, 1)
+			actualT4 = depFreeTxs[0]
+			require.Equal(t, t4.Id, actualT4.Tx.ID)
+			ensureNoOutputs(t, outgoingTxs)
+
+			validatedTxs <- TxNodeBatch{actualT4}
+
+			ensureProcessedAndValidatedMetrics(t, metrics, 9, 9)
+			// after validating all txs, the dependency detector should be empty
+			ensureEmptyManager(t, manService)
+		})
+	}
+}
+
+func ensureEmptyManager(t *testing.T, m any) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		switch mt := m.(type) {
+		case *Manager:
+			d := mt.globalDepManager.dependencyDetector
+			w := len(d.readOnlyKeyToWaitingTxs) + len(d.writeOnlyKeyToWaitingTxs) + len(d.readWriteKeyToWaitingTxs)
+			return w == 0
+		case *SimpleManager:
+			return mt.waitingTXs == 0
+		default:
+			return false
+		}
+	}, 2*time.Second, 100*time.Millisecond)
+}
+
+func ensureNoOutputs(t *testing.T, outgoingTxs <-chan TxNodeBatch) {
+	t.Helper()
+	select {
+	case badDepTXs := <-outgoingTxs:
+		t.Fatalf("got transactions: %v", badDepTXs)
+	case <-time.After(time.Second):
+		// Fantastic.
+	}
+}
+
+func startManager(tb testing.TB, kind string, p *Parameters) (any, *perfMetrics) {
+	tb.Helper()
+	var manService interface {
+		Run(context.Context)
+	}
+	var metrics *perfMetrics
+	switch kind {
+	case "global-local":
+		m := NewManager(p)
+		manService = m
+		metrics = m.metrics
+	case "simple":
+		m := NewSimpleManager(p)
+		manService = m
+		metrics = m.metrics
+	default:
+		return nil, nil
+	}
+	test.RunServiceForTest(tb.Context(), tb, func(ctx context.Context) error {
+		manService.Run(ctx)
+		return nil
+	}, nil)
+	return manService, metrics
 }

--- a/service/coordinator/dependencygraph/parameters.go
+++ b/service/coordinator/dependencygraph/parameters.go
@@ -1,0 +1,30 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package dependencygraph
+
+import "github.com/hyperledger/fabric-x-committer/utils/monitoring"
+
+// Parameters holds the configuration for the dependency graph manager.
+type Parameters struct {
+	// IncomingTxs is the channel for dependency manager to receive
+	// incoming transactions.
+	IncomingTxs <-chan *TransactionBatch
+	// OutgoingDepFreeTxsNode is the channel dependency manager to send
+	// dependency free transactions for validation and commit.
+	OutgoingDepFreeTxsNode chan<- TxNodeBatch
+	// IncomingValidatedTxsNode is the channel for dependency manager
+	// to receive validated transactions.
+	IncomingValidatedTxsNode <-chan TxNodeBatch
+	// NumOfLocalDepConstructors defines the number of local
+	// dependency constructors.
+	NumOfLocalDepConstructors int
+	// WaitingTxsLimit defines the maximum number of transactions
+	// that can be waiting at the dependency manager.
+	WaitingTxsLimit int
+	// PrometheusMetricsProvider is the provider for Prometheus metrics.
+	PrometheusMetricsProvider *monitoring.Provider
+}

--- a/service/coordinator/dependencygraph/simple.go
+++ b/service/coordinator/dependencygraph/simple.go
@@ -11,22 +11,27 @@ import (
 	"sync"
 
 	"github.com/hyperledger/fabric-x-committer/utils/channel"
+	"github.com/hyperledger/fabric-x-committer/utils/monitoring/promutil"
 )
 
 type (
 	// SimpleManager is the simpler version of the dependency graph module.
-	// It uses only 3 go routines, and a single map.
+	// It uses only 3 go routines, and a single regular map.
 	SimpleManager struct {
 		in              <-chan *TransactionBatch
 		out             chan<- TxNodeBatch
 		val             <-chan TxNodeBatch
-		taskQueue       chan task
+		waitingTxsLimit int
+		batchQueue      chan TxNodeBatch
+		valQueue        chan validatedBatch
 		keyToWaitingTXs map[string]*waiting
+		waitingTXs      int
+		metrics         *perfMetrics
 	}
 
-	task struct {
-		txs       []*TransactionNode
-		validated []*waiting
+	validatedBatch struct {
+		txCount int
+		waiting []*waiting
 	}
 
 	waiting struct {
@@ -42,13 +47,16 @@ type (
 )
 
 // NewSimpleManager create a simple dependency graph manager.
-func NewSimpleManager(c *Config) *SimpleManager {
+func NewSimpleManager(p *Parameters) *SimpleManager {
 	return &SimpleManager{
-		in:              c.IncomingTxs,
-		out:             c.OutgoingDepFreeTxsNode,
-		val:             c.IncomingValidatedTxsNode,
-		taskQueue:       make(chan task, cap(c.IncomingTxs)),
+		in:              p.IncomingTxs,
+		out:             p.OutgoingDepFreeTxsNode,
+		val:             p.IncomingValidatedTxsNode,
+		waitingTxsLimit: p.WaitingTxsLimit,
+		batchQueue:      make(chan TxNodeBatch, cap(p.IncomingTxs)),
+		valQueue:        make(chan validatedBatch, cap(p.IncomingValidatedTxsNode)),
 		keyToWaitingTXs: make(map[string]*waiting),
+		metrics:         newPerformanceMetrics(p.PrometheusMetricsProvider),
 	}
 }
 
@@ -57,12 +65,14 @@ func (m *SimpleManager) Run(ctx context.Context) {
 	wg := sync.WaitGroup{}
 	wg.Add(3)
 	go func() {
+		// This manager must have a single incoming pre-processing
+		// worker to maintain the original TX order.
 		defer wg.Done()
-		m.txInToTask(ctx)
+		m.preProcessIn(ctx)
 	}()
 	go func() {
 		defer wg.Done()
-		m.validatedInToTask(ctx)
+		m.preProcessVal(ctx)
 	}()
 	go func() {
 		defer wg.Done()
@@ -71,69 +81,79 @@ func (m *SimpleManager) Run(ctx context.Context) {
 	wg.Wait()
 }
 
-// txInToTask -- in (TransactionBatch) -> taskQueue (TxNodeBatch).
-func (m *SimpleManager) txInToTask(ctx context.Context) {
+// preProcessIn maps the data.
+// - in  (TransactionBatch) -> batchQueue (TxNodeBatch).
+func (m *SimpleManager) preProcessIn(ctx context.Context) {
 	in := channel.NewReader(ctx, m.in)
-	taskQueue := channel.NewWriter(ctx, m.taskQueue)
+	batchQueue := channel.NewWriter(ctx, m.batchQueue)
 	for ctx.Err() == nil {
 		batch, ok := in.Read()
 		if !ok {
 			return
 		}
-
 		depTX := make([]*TransactionNode, len(batch.Txs))
 		for i, tx := range batch.Txs {
 			node := newTransactionNode(batch.BlockNumber, batch.TxsNum[i], tx)
 			node.waitingKeys = make([]*waiting, 0, node.rwKeys.size())
 			depTX[i] = node
 		}
-		taskQueue.Write(task{txs: depTX})
+		batchQueue.Write(depTX)
 	}
 }
 
-// validatedInToTask -- val (TxNodeBatch) -> taskQueue (keys).
-func (m *SimpleManager) validatedInToTask(ctx context.Context) {
+// preProcessVal maps the data.
+// - val (TxNodeBatch)      -> valQueue   (validated).
+func (m *SimpleManager) preProcessVal(ctx context.Context) {
 	val := channel.NewReader(ctx, m.val)
-	taskQueue := channel.NewWriter(ctx, m.taskQueue)
+	valQueue := channel.NewWriter(ctx, m.valQueue)
 	for ctx.Err() == nil {
 		batch, ok := val.Read()
 		if !ok {
 			return
 		}
-
 		var ws []*waiting
 		for _, node := range batch {
 			ws = append(ws, node.waitingKeys...)
 		}
-		if len(ws) > 0 {
-			taskQueue.Write(task{validated: ws})
-		}
+		valQueue.Write(validatedBatch{
+			txCount: len(batch),
+			waiting: ws,
+		})
 	}
 }
 
 // taskProcessing -- taskQueue (TxNodeBatch/keys) -> out (TxNodeBatch).
 func (m *SimpleManager) taskProcessing(ctx context.Context) {
-	taskQueue := channel.NewReader(ctx, m.taskQueue)
 	out := channel.NewWriter(ctx, m.out)
 	for ctx.Err() == nil {
-		t, ok := taskQueue.Read()
-		if !ok {
-			return
+		batchQueue := m.batchQueue
+		if m.waitingTXs > m.waitingTxsLimit {
+			// When we passed the waiting TX limit, we only fetch from the validation queue.
+			batchQueue = nil
 		}
 
 		var depFree TxNodeBatch
-		if len(t.txs) > 0 {
-			depFree = m.processBatch(t.txs)
-		} else if len(t.validated) > 0 {
-			depFree = m.processValidatedKeys(t.validated)
+		select {
+		case <-ctx.Done():
+			return
+		case batch := <-batchQueue:
+			depFree = m.processTxBatch(batch)
+			promutil.AddToCounter(m.metrics.gdgTxProcessedTotal, len(batch))
+			promutil.AddToGauge(m.metrics.dependentTransactionsQueueSize, len(batch)-len(depFree))
+		case batch := <-m.valQueue:
+			depFree = m.processValidatedBatch(batch)
+			promutil.AddToCounter(m.metrics.gdgValidatedTxProcessedTotal, batch.txCount)
+			promutil.SubFromGauge(m.metrics.dependentTransactionsQueueSize, len(depFree))
 		}
+		promutil.SetGauge(m.metrics.gdgWaitingTxQueueSize, m.waitingTXs)
 		if len(depFree) > 0 {
 			out.Write(depFree)
 		}
 	}
 }
 
-func (m *SimpleManager) processBatch(batch []*TransactionNode) TxNodeBatch {
+func (m *SimpleManager) processTxBatch(batch TxNodeBatch) TxNodeBatch {
+	m.waitingTXs += len(batch)
 	depFree := make(TxNodeBatch, 0, len(batch))
 	for _, depTX := range batch {
 		// With writes.
@@ -154,10 +174,11 @@ func (m *SimpleManager) processBatch(batch []*TransactionNode) TxNodeBatch {
 	return depFree
 }
 
-func (m *SimpleManager) processValidatedKeys(ws []*waiting) TxNodeBatch {
-	depFree := make(TxNodeBatch, 0, len(ws))
-	for _, w := range ws {
-		depFree = m.appendFree(w, depFree)
+func (m *SimpleManager) processValidatedBatch(val validatedBatch) TxNodeBatch {
+	m.waitingTXs -= val.txCount
+	depFree := make(TxNodeBatch, 0, len(val.waiting))
+	for _, w := range val.waiting {
+		depFree = m.appendFree(depFree, w)
 	}
 	return depFree
 }
@@ -182,7 +203,7 @@ func (m *SimpleManager) checkTXFree(tx *TransactionNode, k string, writer bool) 
 }
 
 // appendFree indicate a key processing item is done, and appends free nodes if applicable.
-func (m *SimpleManager) appendFree(w *waiting, out TxNodeBatch) TxNodeBatch {
+func (m *SimpleManager) appendFree(out TxNodeBatch, w *waiting) TxNodeBatch {
 	nextWaiters, noMoreWait := w.popAndGetNext()
 	if noMoreWait {
 		delete(m.keyToWaitingTXs, w.key)

--- a/service/coordinator/validator_committer_manager_test.go
+++ b/service/coordinator/validator_committer_manager_test.go
@@ -199,7 +199,7 @@ func TestValidatorCommitterManager(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		txBatch := dependencygraph.TxNodeBatch{
+		txBatch := []*dependencygraph.TransactionNode{
 			{
 				Tx: &protovcservice.Transaction{
 					ID: "create config",


### PR DESCRIPTION
#### Type of change

- Improvement (improvement to code, performance, etc)
 
#### Description

Simple manager:
- Add support for waiting TX limit
- Add metrics 
- Add test
- Optimize `constructCompositeKey()`

#### Performance

Benchmarking was done on an Apple M1 machine.
When dependency was introduced, it was with 30% dependent TXs.
The following tests are conducted with 2, 4, or 6 independent read-write keys, and dependent keys are added accordingly.
All combinations of dependencies were tested. However, all conflicts with write had the same performance as write-write conflicts.

![image](https://github.com/user-attachments/assets/9c005872-1779-4b5b-b600-b075e89afe30)

Benchmark on i9-14900K
![image](https://github.com/user-attachments/assets/a74a4eac-f7c8-4297-b637-fbef9e04b24c)

#### Related issues

- resolves #56 
