### PR TITLE
[services] Add registration method per service

### DIFF
--- a/cmd/loadgen/main.go
+++ b/cmd/loadgen/main.go
@@ -13,9 +13,7 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/hyperledger/fabric/protoutil"
 	"github.com/spf13/cobra"
-	"google.golang.org/grpc"
 
-	"github.com/hyperledger/fabric-x-committer/api/protoloadgen"
 	"github.com/hyperledger/fabric-x-committer/cmd/config"
 	"github.com/hyperledger/fabric-x-committer/loadgen"
 	"github.com/hyperledger/fabric-x-committer/loadgen/adapters"
@@ -79,9 +77,7 @@ func loadGenCMD() *cobra.Command {
 			if err != nil {
 				return errors.Wrap(err, "failed to create loadgen client")
 			}
-			return connection.StartService(cmd.Context(), client, conf.Server, func(s *grpc.Server) {
-				protoloadgen.RegisterLoadGenServiceServer(s, client)
-			})
+			return connection.StartService(cmd.Context(), client, conf.Server)
 		},
 	}
 	utils.Must(config.SetDefaultFlags(v, cmd, &configPath))

--- a/service/coordinator/coordinator_test.go
+++ b/service/coordinator/coordinator_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/grpc"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/hyperledger/fabric-x-committer/api/protoblocktx"
@@ -103,9 +102,7 @@ func (e *coordinatorTestEnv) start(ctx context.Context, t *testing.T) {
 			Port: 0,
 		},
 	}
-	test.RunServiceAndGrpcForTest(ctx, t, cs, sc, func(server *grpc.Server) {
-		protocoordinatorservice.RegisterCoordinatorServer(server, cs)
-	})
+	test.RunServiceAndGrpcForTest(ctx, t, cs, sc)
 
 	conn, err := connection.Connect(connection.NewInsecureDialConfig(&sc.Endpoint))
 	require.NoError(t, err)

--- a/service/query/query_service.go
+++ b/service/query/query_service.go
@@ -13,11 +13,15 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/health"
+	healthgrpc "google.golang.org/grpc/health/grpc_health_v1"
 
 	"github.com/hyperledger/fabric-x-committer/api/protoblocktx"
 	"github.com/hyperledger/fabric-x-committer/api/protoqueryservice"
 	"github.com/hyperledger/fabric-x-committer/service/vc"
 	"github.com/hyperledger/fabric-x-committer/utils/channel"
+	"github.com/hyperledger/fabric-x-committer/utils/connection"
 	"github.com/hyperledger/fabric-x-committer/utils/monitoring/promutil"
 )
 
@@ -28,19 +32,21 @@ type (
 	// Service is a gRPC service that implements the QueryServiceServer interface.
 	Service struct {
 		protoqueryservice.UnimplementedQueryServiceServer
-		batcher viewsBatcher
-		config  *Config
-		metrics *perfMetrics
-		ready   *channel.Ready
+		batcher     viewsBatcher
+		config      *Config
+		metrics     *perfMetrics
+		ready       *channel.Ready
+		healthcheck *health.Server
 	}
 )
 
 // NewQueryService create a new QueryService given a configuration.
 func NewQueryService(config *Config) *Service {
 	return &Service{
-		config:  config,
-		metrics: newQueryServiceMetrics(),
-		ready:   channel.NewReady(),
+		config:      config,
+		metrics:     newQueryServiceMetrics(),
+		ready:       channel.NewReady(),
+		healthcheck: connection.DefaultHealthCheckService(),
 	}
 }
 
@@ -78,6 +84,12 @@ func (q *Service) Run(ctx context.Context) error {
 	// We don't use the error here as we avoid stopping the service due to monitoring error.
 	<-ctx.Done()
 	return nil
+}
+
+// RegisterService registers for the query-service's GRPC services.
+func (q *Service) RegisterService(server *grpc.Server) {
+	protoqueryservice.RegisterQueryServiceServer(server, q)
+	healthgrpc.RegisterHealthServer(server, q.healthcheck)
 }
 
 // BeginView implements the query-service interface.

--- a/service/query/query_service_test.go
+++ b/service/query/query_service_test.go
@@ -322,9 +322,7 @@ func newQueryServiceTestEnv(t *testing.T) *queryServiceTestEnv {
 	sConfig := &connection.ServerConfig{
 		Endpoint: connection.Endpoint{Host: "localhost", Port: 0},
 	}
-	test.RunServiceAndGrpcForTest(t.Context(), t, qs, sConfig, func(server *grpc.Server) {
-		protoqueryservice.RegisterQueryServiceServer(server, qs)
-	})
+	test.RunServiceAndGrpcForTest(t.Context(), t, qs, sConfig)
 
 	clientConn, err := connection.Connect(connection.NewInsecureDialConfig(&sConfig.Endpoint))
 	require.NoError(t, err)

--- a/service/sidecar/sidecar_test.go
+++ b/service/sidecar/sidecar_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/hyperledger/fabric/protoutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/grpc"
 	"google.golang.org/protobuf/proto"
 
 	"github.com/hyperledger/fabric-x-committer/api/protoblocktx"
@@ -152,9 +151,7 @@ func newSidecarTestEnv(t *testing.T, conf sidecarTestConfig) *sidecarTestEnv {
 
 func (env *sidecarTestEnv) start(ctx context.Context, t *testing.T, startBlkNum int64) {
 	t.Helper()
-	test.RunServiceAndGrpcForTest(ctx, t, env.sidecar, env.config.Server, func(server *grpc.Server) {
-		peer.RegisterDeliverServer(server, env.sidecar.GetLedgerService())
-	})
+	test.RunServiceAndGrpcForTest(ctx, t, env.sidecar, env.config.Server)
 	env.committedBlock = sidecarclient.StartSidecarClient(ctx, t, &sidecarclient.Config{
 		ChannelID: env.config.Orderer.ChannelID,
 		Endpoint:  &env.config.Server.Endpoint,

--- a/service/vc/test_exports.go
+++ b/service/vc/test_exports.go
@@ -15,10 +15,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/grpc"
 
 	"github.com/hyperledger/fabric-x-committer/api/protoblocktx"
-	"github.com/hyperledger/fabric-x-committer/api/protovcservice"
 	"github.com/hyperledger/fabric-x-committer/api/types"
 	"github.com/hyperledger/fabric-x-committer/service/vc/dbtest"
 	"github.com/hyperledger/fabric-x-committer/utils/connection"
@@ -90,9 +88,7 @@ func NewValidatorAndCommitServiceTestEnv(
 		vcs, err := NewValidatorCommitterService(initCtx, config)
 		require.NoError(t, err)
 		t.Cleanup(vcs.Close)
-		test.RunServiceAndGrpcForTest(t.Context(), t, vcs, config.Server, func(server *grpc.Server) {
-			protovcservice.RegisterValidationAndCommitServiceServer(server, vcs)
-		})
+		test.RunServiceAndGrpcForTest(t.Context(), t, vcs, config.Server)
 		vcservices[i] = vcs
 		configs[i] = config
 		endpoints[i] = &config.Server.Endpoint

--- a/service/verifier/verifier_server_test.go
+++ b/service/verifier/verifier_server_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/grpc"
 
 	"github.com/hyperledger/fabric-x-committer/api/protoblocktx"
 	"github.com/hyperledger/fabric-x-committer/api/protosigverifierservice"
@@ -389,9 +388,7 @@ type State struct {
 func newTestState(t *testing.T, config *Config) *State {
 	t.Helper()
 	service := New(config)
-	test.RunServiceAndGrpcForTest(t.Context(), t, service, config.Server, func(grpcServer *grpc.Server) {
-		protosigverifierservice.RegisterVerifierServer(grpcServer, service)
-	})
+	test.RunServiceAndGrpcForTest(t.Context(), t, service, config.Server)
 
 	clientConnection, err := connection.Connect(connection.NewInsecureDialConfig(&config.Server.Endpoint))
 	require.NoError(t, err)

--- a/utils/broadcastdeliver/client_test.go
+++ b/utils/broadcastdeliver/client_test.go
@@ -13,9 +13,7 @@ import (
 	"time"
 
 	"github.com/hyperledger/fabric-protos-go-apiv2/common"
-	ab "github.com/hyperledger/fabric-protos-go-apiv2/orderer"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/grpc"
 
 	"github.com/hyperledger/fabric-x-committer/api/protoblocktx"
 	"github.com/hyperledger/fabric-x-committer/mock"
@@ -97,7 +95,7 @@ func TestBroadcastDeliver(t *testing.T) {
 	})
 
 	t.Log("One incorrect server")
-	fakeServer := test.RunGrpcServerForTest(ctx, t, servers[2].Configs[0])
+	fakeServer := test.RunGrpcServerForTest(ctx, t, servers[2].Configs[0], nil)
 	waitUntilGrpcServerIsReady(ctx, t, &servers[2].Configs[0].Endpoint)
 
 	submit(t, stream, outputBlocks, expectedSubmit{
@@ -108,9 +106,7 @@ func TestBroadcastDeliver(t *testing.T) {
 
 	t.Log("All good again")
 	fakeServer.Stop()
-	servers[2].Servers[0] = test.RunGrpcServerForTest(ctx, t, servers[2].Configs[0], func(server *grpc.Server) {
-		ab.RegisterAtomicBroadcastServer(server, ordererService)
-	})
+	servers[2].Servers[0] = test.RunGrpcServerForTest(ctx, t, servers[2].Configs[0], ordererService.RegisterService)
 	waitUntilGrpcServerIsReady(ctx, t, &servers[2].Configs[0].Endpoint)
 	submit(t, stream, outputBlocks, expectedSubmit{
 		id:      "5",

--- a/utils/connection/client_util_test.go
+++ b/utils/connection/client_util_test.go
@@ -41,14 +41,11 @@ func TestGRPCRetry(t *testing.T) {
 	})
 
 	t.Log("Starting service")
-	regService := func(server *grpc.Server) {
-		protovcservice.RegisterValidationAndCommitServiceServer(server, mock.NewMockVcService())
-	}
 	serverConfig := connection.NewLocalHostServer()
 
 	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Minute)
 	t.Cleanup(cancel)
-	vcGrpc := test.RunGrpcServerForTest(ctx, t, serverConfig, regService)
+	vcGrpc := test.RunGrpcServerForTest(ctx, t, serverConfig, mock.NewMockVcService().RegisterService)
 
 	t.Log("Setup dial config")
 	dialConfig := connection.NewInsecureDialConfig(&serverConfig.Endpoint)
@@ -76,7 +73,7 @@ func TestGRPCRetry(t *testing.T) {
 	go func() {
 		time.Sleep(30 * time.Second)
 		t.Log("Service is starting")
-		test.RunGrpcServerForTest(ctx, t, serverConfig, regService)
+		test.RunGrpcServerForTest(ctx, t, serverConfig, mock.NewMockVcService().RegisterService)
 	}()
 
 	t.Log("Attempting to connect with default GRPC config")
@@ -104,7 +101,7 @@ func TestGRPCRetry(t *testing.T) {
 	go func() {
 		time.Sleep(30 * time.Second)
 		t.Log("Service is starting")
-		test.RunGrpcServerForTest(ctx, t, serverConfig, regService)
+		test.RunGrpcServerForTest(ctx, t, serverConfig, mock.NewMockVcService().RegisterService)
 	}()
 
 	t.Log("Attempting to connect again with lower timeout")
@@ -122,14 +119,11 @@ func TestGRPCRetryMultiEndpoints(t *testing.T) {
 	})
 
 	t.Log("Starting service")
-	regService := func(server *grpc.Server) {
-		protovcservice.RegisterValidationAndCommitServiceServer(server, mock.NewMockVcService())
-	}
 	serverConfig := connection.NewLocalHostServer()
 
 	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Minute)
 	t.Cleanup(cancel)
-	test.RunGrpcServerForTest(ctx, t, serverConfig, regService)
+	test.RunGrpcServerForTest(ctx, t, serverConfig, mock.NewMockVcService().RegisterService)
 
 	t.Log("Connecting")
 	conn, err := connection.Connect(connection.NewInsecureDialConfig(&serverConfig.Endpoint))

--- a/utils/connection/server_util.go
+++ b/utils/connection/server_util.go
@@ -17,6 +17,8 @@ import (
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/health"
+	healthgrpc "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/keepalive"
 
 	"github.com/hyperledger/fabric-x-committer/utils"
@@ -32,6 +34,8 @@ type (
 		// WaitForReady waits for the service resources to initialize.
 		// If the context ended before the service is ready, returns false.
 		WaitForReady(ctx context.Context) bool
+		// RegisterService registers the supported APIs for this service.
+		RegisterService(server *grpc.Server)
 	}
 )
 
@@ -102,8 +106,8 @@ func (c *ServerConfig) PreAllocateListener() (net.Listener, error) {
 	return listener, nil
 }
 
-// RunGrpcServerMainWithError runs a server and returns error if failed.
-func RunGrpcServerMainWithError(
+// RunGrpcServer runs a server and returns error if failed.
+func RunGrpcServer(
 	ctx context.Context,
 	serverConfig *ServerConfig,
 	register func(server *grpc.Server),
@@ -125,13 +129,12 @@ func RunGrpcServerMainWithError(
 	return g.Wait()
 }
 
-// StartService runs a service, waits until it is ready, and register the gRPC server.
+// StartService runs a service, waits until it is ready, and register the gRPC server(s).
 // It will stop if either the service ended or its respective gRPC server.
 func StartService(
 	ctx context.Context,
 	service Service,
-	serverConfig *ServerConfig,
-	register func(server *grpc.Server),
+	serverConfigs ...*ServerConfig,
 ) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -150,14 +153,20 @@ func StartService(
 		return fmt.Errorf("service is not ready: %w", g.Wait())
 	}
 
-	if register != nil && serverConfig != nil {
+	for _, server := range serverConfigs {
+		server := server
 		g.Go(func() error {
-			// If the GRPC server stops, there is no reason to continue the service.
+			// If the GRPC servers stop, there is no reason to continue the service.
 			defer cancel()
-			return RunGrpcServerMainWithError(gCtx, serverConfig, func(server *grpc.Server) {
-				register(server)
-			})
+			return RunGrpcServer(gCtx, server, service.RegisterService)
 		})
 	}
 	return g.Wait()
+}
+
+// DefaultHealthCheckService returns a health-check service that returns SERVING for all services.
+func DefaultHealthCheckService() *health.Server {
+	healthcheck := health.NewServer()
+	healthcheck.SetServingStatus("", healthgrpc.HealthCheckResponse_SERVING)
+	return healthcheck
 }

--- a/utils/test/utils_test.go
+++ b/utils/test/utils_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 
-	"github.com/hyperledger/fabric-x-committer/api/protosigverifierservice"
 	"github.com/hyperledger/fabric-x-committer/mock"
 	"github.com/hyperledger/fabric-x-committer/utils/test"
 )
@@ -25,12 +24,9 @@ func TestCheckServerStopped(t *testing.T) {
 	t.Cleanup(cancel)
 
 	mockSigVer := mock.NewMockSigVerifier()
-
-	sigVerServers := test.StartGrpcServersForTest(ctx, t, 1,
-		func(server *grpc.Server, _ int) {
-			protosigverifierservice.RegisterVerifierServer(server, mockSigVer)
-		},
-	)
+	sigVerServers := test.StartGrpcServersForTest(ctx, t, 1, func(server *grpc.Server, _ int) {
+		mockSigVer.RegisterService(server)
+	})
 
 	addr := sigVerServers.Configs[0].Endpoint.Address()
 	require.Eventually(t, func() bool {


### PR DESCRIPTION
#### Type of change

- Improvement (improvement to code, performance, etc)
 
#### Description

- Add method per service to register the gRPC APIs
- Add health-check service to all services
- Add missing mock-coordinator to the mock CMD

#### Related issues

- resolves #89 
