### PR TITLE
Added Utils unit tests - envelope and crypto

### DIFF
--- a/utils/serialization/envelope_wrapper.go
+++ b/utils/serialization/envelope_wrapper.go
@@ -28,6 +28,7 @@ func WrapEnvelopePayload(data []byte, header *common.Header) []byte {
 	})
 }
 
+// WrapEnvelope wraps a payload with it's header and returns an envelope.
 func WrapEnvelope(data []byte, header *common.Header) []byte {
 	payloadBytes := WrapEnvelopePayload(data, header)
 

--- a/utils/serialization/envelope_wrapper_test.go
+++ b/utils/serialization/envelope_wrapper_test.go
@@ -1,0 +1,86 @@
+package serialization_test
+
+import (
+	"testing"
+
+	"github.com/hyperledger/fabric-protos-go-apiv2/common"
+	"github.com/hyperledger/fabric-x-committer/utils/serialization"
+	"github.com/hyperledger/fabric-x-committer/utils/test"
+	"github.com/hyperledger/fabric/protoutil"
+	"github.com/stretchr/testify/require"
+)
+
+// UnwrapEnvelope function with invalid inputs
+func TestUnwrapEnvelopeBadInput(t *testing.T) {
+	t.Run("Not an envelope", func(t *testing.T) {
+		_, _, err := serialization.UnwrapEnvelope([]byte("invalid input"))
+		require.Error(t, err)
+	})
+
+	t.Run("OK Header with an invalid payload", func(t *testing.T) {
+		envelope := &common.Envelope{
+			Payload: []byte("not-a-payload"),
+		}
+
+		envelopeBytes := protoutil.MarshalOrPanic(envelope)
+
+		_, _, err := serialization.UnwrapEnvelope(envelopeBytes)
+		require.Error(t, err)
+	})
+
+	t.Run(" OK Payload with a nil Header", func(t *testing.T) {
+		payload := &common.Payload{
+			Header: nil,
+			Data:   []byte("some data"),
+		}
+		payloadBytes := protoutil.MarshalOrPanic(payload)
+
+		envelope := &common.Envelope{
+			Payload: payloadBytes,
+		}
+		envelopeBytes := protoutil.MarshalOrPanic(envelope)
+
+		_, _, err := serialization.UnwrapEnvelope(envelopeBytes)
+		require.Error(t, err)
+	})
+
+	t.Run("OK payload but invalid ChannelHeader", func(t *testing.T) {
+		header := &common.Header{
+			ChannelHeader: []byte("not-a-channel-header"),
+		}
+		payload := &common.Payload{
+			Header: header,
+			Data:   []byte("some data"),
+		}
+		payloadBytes := protoutil.MarshalOrPanic(payload)
+
+		envelope := &common.Envelope{
+			Payload: payloadBytes,
+		}
+		envelopeBytes := protoutil.MarshalOrPanic(envelope)
+
+		_, _, err := serialization.UnwrapEnvelope(envelopeBytes)
+		require.Error(t, err)
+	})
+}
+
+// Test properly wrapped envelope is unwrapped correctly
+func TestUnwrapEnvelopeGoodInput(t *testing.T) {
+
+	// -1- Check unwrap envelope has no error
+	originalPayload := []byte("test payload")
+	originalChannelHeader := &common.ChannelHeader{
+		ChannelId: "test-channel",
+	}
+	originalHeader := &common.Header{
+		ChannelHeader: protoutil.MarshalOrPanic(originalChannelHeader),
+	}
+
+	wrappedEnvelope := serialization.WrapEnvelope(originalPayload, originalHeader)
+	payload, channelHeader, err := serialization.UnwrapEnvelope(wrappedEnvelope)
+
+	// -2- Check we get the correct Payload & Header
+	require.NoError(t, err)
+	require.Equal(t, originalPayload, payload)
+	test.RequireProtoEqual(t, originalChannelHeader, channelHeader)
+}

--- a/utils/serialization/envelope_wrapper_test.go
+++ b/utils/serialization/envelope_wrapper_test.go
@@ -1,23 +1,32 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
 package serialization_test
 
 import (
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/hyperledger/fabric-protos-go-apiv2/common"
+	"github.com/hyperledger/fabric/protoutil"
+
 	"github.com/hyperledger/fabric-x-committer/utils/serialization"
 	"github.com/hyperledger/fabric-x-committer/utils/test"
-	"github.com/hyperledger/fabric/protoutil"
-	"github.com/stretchr/testify/require"
 )
 
-// UnwrapEnvelope function with invalid inputs
+// TestUnwrapEnvelopeBadInput tests UnwrapEnvelope function with invalid inputs.
 func TestUnwrapEnvelopeBadInput(t *testing.T) {
 	t.Run("Not an envelope", func(t *testing.T) {
+		t.Parallel()
 		_, _, err := serialization.UnwrapEnvelope([]byte("invalid input"))
 		require.Error(t, err)
 	})
 
 	t.Run("OK Header with an invalid payload", func(t *testing.T) {
+		t.Parallel()
 		envelope := &common.Envelope{
 			Payload: []byte("not-a-payload"),
 		}
@@ -29,6 +38,7 @@ func TestUnwrapEnvelopeBadInput(t *testing.T) {
 	})
 
 	t.Run(" OK Payload with a nil Header", func(t *testing.T) {
+		t.Parallel()
 		payload := &common.Payload{
 			Header: nil,
 			Data:   []byte("some data"),
@@ -45,6 +55,7 @@ func TestUnwrapEnvelopeBadInput(t *testing.T) {
 	})
 
 	t.Run("OK payload but invalid ChannelHeader", func(t *testing.T) {
+		t.Parallel()
 		header := &common.Header{
 			ChannelHeader: []byte("not-a-channel-header"),
 		}
@@ -64,9 +75,9 @@ func TestUnwrapEnvelopeBadInput(t *testing.T) {
 	})
 }
 
-// Test properly wrapped envelope is unwrapped correctly
+// TestUnwrapEnvelopeGoodInput Tests properly wrapped envelope is unwrapped correctly.
 func TestUnwrapEnvelopeGoodInput(t *testing.T) {
-
+	t.Parallel()
 	// -1- Check unwrap envelope has no error
 	originalPayload := []byte("test payload")
 	originalChannelHeader := &common.ChannelHeader{
@@ -75,7 +86,6 @@ func TestUnwrapEnvelopeGoodInput(t *testing.T) {
 	originalHeader := &common.Header{
 		ChannelHeader: protoutil.MarshalOrPanic(originalChannelHeader),
 	}
-
 	wrappedEnvelope := serialization.WrapEnvelope(originalPayload, originalHeader)
 	payload, channelHeader, err := serialization.UnwrapEnvelope(wrappedEnvelope)
 

--- a/utils/signature/sigtest/crypto.go
+++ b/utils/signature/sigtest/crypto.go
@@ -32,10 +32,16 @@ func SerializeVerificationKey(key *ecdsa.PublicKey) ([]byte, error) {
 
 // SerializeSigningKey encodes a ECDSA private key into a PEM file.
 func SerializeSigningKey(key *ecdsa.PrivateKey) ([]byte, error) {
+
+	if key == nil {
+		return nil, errors.New("key is nil")
+	}
+
 	x509encodedPri, err := x509.MarshalECPrivateKey(key)
 	if err != nil {
 		return nil, errors.Wrap(err, "cannot serialize private key")
 	}
+
 	return pem.EncodeToMemory(&pem.Block{
 		Type:  "EC PRIVATE KEY",
 		Bytes: x509encodedPri,

--- a/utils/signature/sigtest/crypto.go
+++ b/utils/signature/sigtest/crypto.go
@@ -32,7 +32,6 @@ func SerializeVerificationKey(key *ecdsa.PublicKey) ([]byte, error) {
 
 // SerializeSigningKey encodes a ECDSA private key into a PEM file.
 func SerializeSigningKey(key *ecdsa.PrivateKey) ([]byte, error) {
-
 	if key == nil {
 		return nil, errors.New("key is nil")
 	}

--- a/utils/signature/sigtest/crypto_test.go
+++ b/utils/signature/sigtest/crypto_test.go
@@ -1,16 +1,21 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
 package sigtest
 
 import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
 
 func TestSerializeVerificationKey(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		curve   elliptic.Curve
@@ -43,6 +48,7 @@ func TestSerializeVerificationKey(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			privKey, err := ecdsa.GenerateKey(tt.curve, rand.Reader)
 			require.NoError(t, err)
 
@@ -57,7 +63,6 @@ func TestSerializeVerificationKey(t *testing.T) {
 }
 
 func TestSerializeSigningKey(t *testing.T) {
-
 	// Panic can happen from unwanted side effects when nil and empty Keys are passed
 	defer func() {
 		if r := recover(); r != nil {
@@ -66,31 +71,37 @@ func TestSerializeSigningKey(t *testing.T) {
 	}()
 
 	t.Run("Key Empty", func(t *testing.T) {
+		t.Parallel()
 		emptyKey := &ecdsa.PrivateKey{}
 		_, err := SerializeSigningKey(emptyKey)
 		require.Error(t, err)
 	})
 	t.Run("Key is nil", func(t *testing.T) {
+		t.Parallel()
 		_, err := SerializeSigningKey(nil)
 		require.Error(t, err)
 	})
 
 	t.Run("Key OK", func(t *testing.T) {
+		t.Parallel()
 		privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		require.NoError(t, err)
 		key, err := SerializeSigningKey(privateKey)
-		fmt.Println(key)
+		require.NotNil(t, key)
 		require.NoError(t, err)
 	})
-
 }
 
 func TestParseSigningKey(t *testing.T) {
 	t.Run("Key is nil", func(t *testing.T) {
+		t.Parallel()
 		_, err := ParseSigningKey(nil)
 		require.Error(t, err)
 	})
 	t.Run("Key OK", func(t *testing.T) {
+		t.Parallel()
 		privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		require.NoError(t, err)
 		key, err := SerializeSigningKey(privateKey)
 		require.NoError(t, err)
 		_, err = ParseSigningKey(key)

--- a/utils/signature/sigtest/crypto_test.go
+++ b/utils/signature/sigtest/crypto_test.go
@@ -1,0 +1,99 @@
+package sigtest
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSerializeVerificationKey(t *testing.T) {
+	tests := []struct {
+		name    string
+		curve   elliptic.Curve
+		wantErr bool
+	}{
+		{
+			name:  "P256",
+			curve: elliptic.P256(),
+		},
+		{
+			name:  "P384",
+			curve: elliptic.P384(),
+		},
+		{
+			name:  "P224",
+			curve: elliptic.P224(),
+		},
+		{
+			name:  "P521",
+			curve: elliptic.P521(),
+		},
+
+		// {
+		// 	//  ? TODO find an invalid example?
+		// 	name:    "Invalid input",
+		// 	curve:   elliptic.(),
+		// 	wantErr: true,
+		// },
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			privKey, err := ecdsa.GenerateKey(tt.curve, rand.Reader)
+			require.NoError(t, err)
+
+			_, err = SerializeVerificationKey(&privKey.PublicKey)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestSerializeSigningKey(t *testing.T) {
+
+	// Panic can happen from unwanted side effects when nil and empty Keys are passed
+	defer func() {
+		if r := recover(); r != nil {
+			t.Errorf("SerializeSigningKey() panics: %v", r)
+		}
+	}()
+
+	t.Run("Key Empty", func(t *testing.T) {
+		emptyKey := &ecdsa.PrivateKey{}
+		_, err := SerializeSigningKey(emptyKey)
+		require.Error(t, err)
+	})
+	t.Run("Key is nil", func(t *testing.T) {
+		_, err := SerializeSigningKey(nil)
+		require.Error(t, err)
+	})
+
+	t.Run("Key OK", func(t *testing.T) {
+		privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		key, err := SerializeSigningKey(privateKey)
+		fmt.Println(key)
+		require.NoError(t, err)
+	})
+
+}
+
+func TestParseSigningKey(t *testing.T) {
+	t.Run("Key is nil", func(t *testing.T) {
+		_, err := ParseSigningKey(nil)
+		require.Error(t, err)
+	})
+	t.Run("Key OK", func(t *testing.T) {
+		privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		key, err := SerializeSigningKey(privateKey)
+		require.NoError(t, err)
+		_, err = ParseSigningKey(key)
+		require.NoError(t, err)
+	})
+}


### PR DESCRIPTION
Copyright IBM Corp. All Rights Reserved.

SPDX-License-Identifier: Apache-2.0

- Test update

1. `envelope wrapper`: nil check + unit tests + minor refactor
2. `crypto`: nil check + unit tests

See: [Issue 11](https://github.com/hyperledger/fabric-x-committer/issues/11)