### PR TITLE
fixed dashboards for `loadgen` throughput and committer transactions

### DIFF
--- a/docker/deployment/loadgen/config/grafana/dashboards/perf-dashboard.json
+++ b/docker/deployment/loadgen/config/grafana/dashboards/perf-dashboard.json
@@ -24,6 +24,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
+  "id": 1,
   "links": [
     {
       "icon": "info",
@@ -43,7 +44,6 @@
       "url": "http://prometheus.io/docs/introduction/overview/"
     }
   ],
-  "liveNow": false,
   "panels": [
     {
       "collapsed": false,
@@ -76,6 +76,7 @@
             "axisPlacement": "auto",
             "axisSoftMin": 0,
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 25,
             "gradientMode": "none",
@@ -106,8 +107,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -117,7 +117,32 @@
           },
           "unit": "reqps"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "__systemRef": "hideSeriesFrom",
+            "matcher": {
+              "id": "byNames",
+              "options": {
+                "mode": "exclude",
+                "names": [
+                  "{instance=\"host.docker.internal:2119\", job=\"blockgens_service\"}"
+                ],
+                "prefix": "All except:",
+                "readOnly": true
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                }
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 9,
@@ -135,10 +160,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
+      "pluginVersion": "11.6.0",
       "targets": [
         {
           "datasource": {
@@ -148,7 +175,7 @@
           "disableTextWrap": false,
           "editorMode": "builder",
           "exemplar": true,
-          "expr": "rate(loadgen_transaction_received_total[5s])",
+          "expr": "rate(loadgen_transaction_received_total[10s])",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": false,
@@ -165,7 +192,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "rate(loadgen_transaction_sent_total[5s])",
+          "expr": "rate(loadgen_transaction_sent_total[10s])",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": false,
@@ -196,6 +223,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 25,
             "gradientMode": "none",
@@ -226,8 +254,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -254,11 +281,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
-      "pluginVersion": "9.2.2",
+      "pluginVersion": "11.6.0",
       "targets": [
         {
           "datasource": {
@@ -329,6 +357,7 @@
             "axisPlacement": "auto",
             "axisSoftMax": 200,
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
@@ -359,8 +388,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -387,10 +415,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
+      "pluginVersion": "11.6.0",
       "targets": [
         {
           "datasource": {
@@ -431,6 +461,7 @@
             "axisPlacement": "auto",
             "axisSoftMax": -5,
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
@@ -466,8 +497,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -494,10 +524,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
+      "pluginVersion": "11.6.0",
       "targets": [
         {
           "datasource": {
@@ -507,7 +539,7 @@
           "disableTextWrap": false,
           "editorMode": "builder",
           "exemplar": true,
-          "expr": "rate(coordinator_grpc_sent_transaction_committed_status_total[$__interval])",
+          "expr": "rate(coordinator_grpc_committed_transaction_total[$__interval])",
           "fullMetaSearch": false,
           "hide": true,
           "includeNullMetadata": false,
@@ -604,6 +636,7 @@
             "axisPlacement": "auto",
             "axisSoftMin": 0,
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
@@ -634,8 +667,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -661,10 +693,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
+      "pluginVersion": "11.6.0",
       "targets": [
         {
           "datasource": {
@@ -674,7 +708,7 @@
           "disableTextWrap": false,
           "editorMode": "builder",
           "exemplar": true,
-          "expr": "rate(coordinator_grpc_sent_transaction_committed_status_total[$__interval])",
+          "expr": "rate(coordinator_grpc_committed_transaction_total[$__interval])",
           "fullMetaSearch": false,
           "includeNullMetadata": false,
           "instant": false,
@@ -704,6 +738,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
@@ -734,8 +769,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -761,10 +795,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
+      "pluginVersion": "11.6.0",
       "targets": [
         {
           "datasource": {
@@ -804,6 +840,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
@@ -834,8 +871,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -861,10 +897,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
+      "pluginVersion": "11.6.0",
       "targets": [
         {
           "datasource": {
@@ -904,6 +942,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
@@ -934,8 +973,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -961,10 +999,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
+      "pluginVersion": "11.6.0",
       "targets": [
         {
           "datasource": {
@@ -1004,6 +1044,7 @@
             "axisLabel": "Number of Transaction Batches",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
@@ -1034,8 +1075,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1062,10 +1102,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
+      "pluginVersion": "11.6.0",
       "targets": [
         {
           "datasource": {
@@ -1142,6 +1184,7 @@
             "axisPlacement": "auto",
             "axisSoftMin": 0,
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
@@ -1172,8 +1215,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1200,10 +1242,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
+      "pluginVersion": "11.6.0",
       "targets": [
         {
           "datasource": {
@@ -1261,6 +1305,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
@@ -1291,8 +1336,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1321,7 +1365,7 @@
                 "value": {
                   "legend": false,
                   "tooltip": false,
-                  "viz": true
+                  "viz": false
                 }
               }
             ]
@@ -1344,10 +1388,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
+      "pluginVersion": "11.6.0",
       "targets": [
         {
           "datasource": {
@@ -1425,6 +1471,7 @@
             "axisPlacement": "auto",
             "axisSoftMin": 0,
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
@@ -1455,8 +1502,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1483,10 +1529,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
+      "pluginVersion": "11.6.0",
       "targets": [
         {
           "datasource": {
@@ -1526,6 +1574,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
@@ -1556,8 +1605,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1585,10 +1633,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
+      "pluginVersion": "11.6.0",
       "targets": [
         {
           "datasource": {
@@ -1628,6 +1678,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
@@ -1658,8 +1709,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1687,10 +1737,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
+      "pluginVersion": "11.6.0",
       "targets": [
         {
           "datasource": {
@@ -1730,6 +1782,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
@@ -1760,8 +1813,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1789,10 +1841,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
+      "pluginVersion": "11.6.0",
       "targets": [
         {
           "datasource": {
@@ -1832,6 +1886,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
@@ -1862,8 +1917,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1891,10 +1945,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
+      "pluginVersion": "11.6.0",
       "targets": [
         {
           "datasource": {
@@ -1934,6 +1990,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
@@ -1964,8 +2021,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -1993,10 +2049,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
+      "pluginVersion": "11.6.0",
       "targets": [
         {
           "datasource": {
@@ -2038,6 +2096,7 @@
             "axisSoftMax": 0.5,
             "axisSoftMin": 0,
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
@@ -2068,8 +2127,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -2096,10 +2154,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
+      "pluginVersion": "11.6.0",
       "targets": [
         {
           "datasource": {
@@ -2109,7 +2169,7 @@
           "disableTextWrap": false,
           "editorMode": "builder",
           "exemplar": true,
-          "expr": "(rate(coordinator_global_dependency_graph_construction_seconds_sum[5s])) / rate(coordinator_global_dependency_graph_construction_seconds_count[5s]) * 1000",
+          "expr": "(rate(coordinator_global_dependency_graph_construction_seconds_sum[10s])) / rate(coordinator_global_dependency_graph_construction_seconds_count[10s]) * 1000",
           "fullMetaSearch": false,
           "includeNullMetadata": false,
           "instant": false,
@@ -2125,7 +2185,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "builder",
-          "expr": "rate(coordinator_global_dependency_graph_constructor_wait_for_lock_seconds_sum[5s]) * 1000 / rate(coordinator_global_dependency_graph_constructor_wait_for_lock_seconds_count[5s])",
+          "expr": "rate(coordinator_global_dependency_graph_constructor_wait_for_lock_seconds_sum[10s]) * 1000 / rate(coordinator_global_dependency_graph_constructor_wait_for_lock_seconds_count[10s])",
           "fullMetaSearch": false,
           "hide": false,
           "includeNullMetadata": false,
@@ -2141,7 +2201,7 @@
             "uid": "PBFA97CFB590B2093"
           },
           "editorMode": "code",
-          "expr": "(rate(coordinator_global_dependency_graph_add_tx_batch_to_graph_seconds_sum[5s]) * 1000) / rate(coordinator_global_dependency_graph_add_tx_batch_to_graph_seconds_count[5s])",
+          "expr": "(rate(coordinator_global_dependency_graph_add_tx_batch_to_graph_seconds_sum[10s]) * 1000) / rate(coordinator_global_dependency_graph_add_tx_batch_to_graph_seconds_count[10s])",
           "hide": false,
           "instant": false,
           "legendFormat": "Add Tx Batch To Graph",
@@ -2154,7 +2214,7 @@
             "uid": "PBFA97CFB590B2093"
           },
           "editorMode": "code",
-          "expr": "(rate(coordinator_global_dependency_graph_update_dependency_detector_seconds_sum[5s]) * 1000) / rate(coordinator_global_dependency_graph_update_dependency_detector_seconds_count[5s])",
+          "expr": "(rate(coordinator_global_dependency_graph_update_dependency_detector_seconds_sum[10s]) * 1000) / rate(coordinator_global_dependency_graph_update_dependency_detector_seconds_count[10s])",
           "hide": false,
           "instant": false,
           "legendFormat": "Add Tx Batch to Dependency Detector",
@@ -2184,6 +2244,7 @@
             "axisSoftMax": 0.01,
             "axisSoftMin": 0,
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
@@ -2214,8 +2275,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -2242,10 +2302,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
+      "pluginVersion": "11.6.0",
       "targets": [
         {
           "datasource": {
@@ -2255,7 +2317,7 @@
           "disableTextWrap": false,
           "editorMode": "code",
           "exemplar": true,
-          "expr": "(rate(coordinator_global_dependency_graph_validated_tx_batch_processing_seconds_sum[5s]) * 1000) / rate(coordinator_global_dependency_graph_validated_tx_batch_processing_seconds_count[5s])",
+          "expr": "(rate(coordinator_global_dependency_graph_validated_tx_batch_processing_seconds_sum[10s]) * 1000) / rate(coordinator_global_dependency_graph_validated_tx_batch_processing_seconds_count[10s])",
           "fullMetaSearch": false,
           "includeNullMetadata": false,
           "instant": false,
@@ -2270,7 +2332,7 @@
             "uid": "PBFA97CFB590B2093"
           },
           "editorMode": "code",
-          "expr": "(rate(coordinator_global_dependency_graph_validated_tx_batch_processor_wait_for_lock_seconds_sum[5s]) * 1000) / rate(coordinator_global_dependency_graph_validated_tx_batch_processor_wait_for_lock_seconds_count[5s])",
+          "expr": "(rate(coordinator_global_dependency_graph_validated_tx_batch_processor_wait_for_lock_seconds_sum[10s]) * 1000) / rate(coordinator_global_dependency_graph_validated_tx_batch_processor_wait_for_lock_seconds_count[10s])",
           "hide": false,
           "instant": false,
           "legendFormat": "Waiting For Lock",
@@ -2283,7 +2345,7 @@
             "uid": "PBFA97CFB590B2093"
           },
           "editorMode": "code",
-          "expr": "(rate(coordinator_global_dependency_graph_remove_dependents_of_validated_tx_batch_seconds_sum[5s]) * 1000) / rate(coordinator_global_dependency_graph_remove_dependents_of_validated_tx_batch_seconds_count[5s])",
+          "expr": "(rate(coordinator_global_dependency_graph_remove_dependents_of_validated_tx_batch_seconds_sum[10s]) * 1000) / rate(coordinator_global_dependency_graph_remove_dependents_of_validated_tx_batch_seconds_count[10s])",
           "hide": false,
           "instant": false,
           "legendFormat": "Remove Dependents and Find Freed Txs",
@@ -2296,7 +2358,7 @@
             "uid": "PBFA97CFB590B2093"
           },
           "editorMode": "code",
-          "expr": "(rate(coordinator_global_dependency_graph_add_freed_tx_batch_seconds_sum[5s]) * 1000) / rate(coordinator_global_dependency_graph_add_freed_tx_batch_seconds_count[5s])",
+          "expr": "(rate(coordinator_global_dependency_graph_add_freed_tx_batch_seconds_sum[10s]) * 1000) / rate(coordinator_global_dependency_graph_add_freed_tx_batch_seconds_count[10s])",
           "hide": false,
           "instant": false,
           "legendFormat": "Add Freed Transactions",
@@ -2325,6 +2387,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 25,
             "gradientMode": "none",
@@ -2356,8 +2419,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -2663,7 +2725,6 @@
       },
       "id": 138,
       "interval": "1",
-      "links": [],
       "options": {
         "legend": {
           "calcs": [],
@@ -2673,11 +2734,12 @@
           "width": 250
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "multi",
           "sort": "none"
         }
       },
-      "pluginVersion": "9.1.6",
+      "pluginVersion": "11.6.0",
       "targets": [
         {
           "datasource": {
@@ -2718,6 +2780,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 25,
             "gradientMode": "none",
@@ -2750,8 +2813,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -3138,7 +3200,6 @@
         "y": 92
       },
       "id": 130,
-      "links": [],
       "options": {
         "legend": {
           "calcs": [],
@@ -3148,11 +3209,12 @@
           "width": 350
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "multi",
           "sort": "none"
         }
       },
-      "pluginVersion": "9.1.6",
+      "pluginVersion": "11.6.0",
       "targets": [
         {
           "datasource": {
@@ -3256,6 +3318,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 25,
             "gradientMode": "none",
@@ -3287,8 +3350,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -3665,7 +3727,6 @@
         "y": 99
       },
       "id": 132,
-      "links": [],
       "options": {
         "legend": {
           "calcs": [],
@@ -3674,11 +3735,12 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "multi",
           "sort": "none"
         }
       },
-      "pluginVersion": "9.1.6",
+      "pluginVersion": "11.6.0",
       "targets": [
         {
           "datasource": {
@@ -3732,6 +3794,7 @@
             "axisLabel": "%util",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 25,
             "gradientMode": "none",
@@ -3764,8 +3827,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -3812,25 +3874,20 @@
         "y": 99
       },
       "id": 134,
-      "links": [],
       "options": {
         "legend": {
-          "calcs": [
-            "mean",
-            "lastNotNull",
-            "max",
-            "min"
-          ],
+          "calcs": ["mean", "lastNotNull", "max", "min"],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "mode": "multi",
           "sort": "none"
         }
       },
-      "pluginVersion": "9.2.2",
+      "pluginVersion": "11.6.0",
       "targets": [
         {
           "datasource": {
@@ -3937,9 +3994,7 @@
               "placement": "bottom",
               "showLegend": true
             },
-            "timezone": [
-              ""
-            ],
+            "timezone": [""],
             "tooltip": {
               "mode": "single",
               "sort": "none"
@@ -4320,7 +4375,6 @@
             "y": 116
           },
           "id": 120,
-          "links": [],
           "options": {
             "legend": {
               "calcs": [],
@@ -4789,7 +4843,6 @@
             "y": 116
           },
           "id": 122,
-          "links": [],
           "options": {
             "legend": {
               "calcs": [],
@@ -5310,7 +5363,6 @@
             "y": 123
           },
           "id": 124,
-          "links": [],
           "options": {
             "legend": {
               "calcs": [],
@@ -5454,15 +5506,9 @@
             "y": 123
           },
           "id": 126,
-          "links": [],
           "options": {
             "legend": {
-              "calcs": [
-                "mean",
-                "lastNotNull",
-                "max",
-                "min"
-              ],
+              "calcs": ["mean", "lastNotNull", "max", "min"],
               "displayMode": "table",
               "placement": "bottom",
               "showLegend": true
@@ -5829,9 +5875,7 @@
             "justifyMode": "auto",
             "orientation": "auto",
             "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
+              "calcs": ["lastNotNull"],
               "fields": "",
               "values": false
             },
@@ -6013,8 +6057,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -6040,9 +6083,7 @@
           "placement": "bottom",
           "showLegend": true
         },
-        "timezone": [
-          ""
-        ],
+        "timezone": [""],
         "tooltip": {
           "mode": "single",
           "sort": "none"
@@ -6096,8 +6137,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -6147,15 +6187,12 @@
         "y": 108
       },
       "id": 2,
-      "links": [],
       "options": {
         "minVizHeight": 200,
         "minVizWidth": 200,
         "orientation": "auto",
         "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
+          "calcs": ["lastNotNull"],
           "fields": "",
           "values": false
         },
@@ -6230,8 +6267,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -6329,8 +6365,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -6635,7 +6670,6 @@
         "y": 126
       },
       "id": 140,
-      "links": [],
       "options": {
         "legend": {
           "calcs": [],
@@ -6717,8 +6751,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -7105,7 +7138,6 @@
         "y": 126
       },
       "id": 114,
-      "links": [],
       "options": {
         "legend": {
           "calcs": [],
@@ -7249,8 +7281,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -7627,7 +7658,6 @@
         "y": 133
       },
       "id": 116,
-      "links": [],
       "options": {
         "legend": {
           "calcs": [],
@@ -7724,8 +7754,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -7772,15 +7801,9 @@
         "y": 133
       },
       "id": 118,
-      "links": [],
       "options": {
         "legend": {
-          "calcs": [
-            "mean",
-            "lastNotNull",
-            "max",
-            "min"
-          ],
+          "calcs": ["mean", "lastNotNull", "max", "min"],
           "displayMode": "table",
           "placement": "bottom",
           "showLegend": true
@@ -7860,8 +7883,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -7877,9 +7899,7 @@
               "id": "byNames",
               "options": {
                 "mode": "exclude",
-                "names": [
-                  "parallel_executor > output"
-                ],
+                "names": ["parallel_executor > output"],
                 "prefix": "All except:",
                 "readOnly": true
               }
@@ -7890,7 +7910,7 @@
                 "value": {
                   "legend": false,
                   "tooltip": false,
-                  "viz": true
+                  "viz": false
                 }
               }
             ]
@@ -7979,8 +7999,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -8074,8 +8093,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               },
               {
                 "color": "red",
@@ -8101,9 +8119,7 @@
           "placement": "right",
           "showLegend": true
         },
-        "timezone": [
-          ""
-        ],
+        "timezone": [""],
         "tooltip": {
           "mode": "single",
           "sort": "none"
@@ -8138,17 +8154,14 @@
       "type": "timeseries"
     }
   ],
+  "preload": false,
   "refresh": "auto",
-  "revision": "1.0",
-  "schemaVersion": 39,
-  "tags": [
-    "prometheus"
-  ],
+  "schemaVersion": 41,
+  "tags": ["prometheus"],
   "templating": {
     "list": [
       {
         "current": {
-          "selected": false,
           "text": "sigservice",
           "value": "sigservice"
         },
@@ -8157,7 +8170,6 @@
           "uid": "PBFA97CFB590B2093"
         },
         "definition": "sc_component_type{component=\"sigverifier\"}",
-        "hide": 0,
         "includeAll": false,
         "label": "Sig Verifier Servers",
         "multi": true,
@@ -8169,26 +8181,18 @@
         },
         "refresh": 1,
         "regex": "/.*instance=\"(.*):\\d+\".*/",
-        "skipUrlSync": false,
-        "sort": 0,
         "type": "query"
       },
       {
         "current": {
-          "selected": true,
-          "text": [
-            "None"
-          ],
-          "value": [
-            ""
-          ]
+          "text": ["None"],
+          "value": [""]
         },
         "datasource": {
           "type": "prometheus",
           "uid": "PBFA97CFB590B2093"
         },
         "definition": "sc_component_type{component=\"coordinator\"}",
-        "hide": 0,
         "includeAll": false,
         "label": "Coordinator Servers",
         "multi": true,
@@ -8200,14 +8204,11 @@
         },
         "refresh": 1,
         "regex": "/.*instance=\"(.*):\\d+\".*/",
-        "skipUrlSync": false,
-        "sort": 0,
         "type": "query"
       },
       {
         "current": {
           "isNone": true,
-          "selected": false,
           "text": "None",
           "value": ""
         },
@@ -8216,7 +8217,6 @@
           "uid": "PBFA97CFB590B2093"
         },
         "definition": "sc_component_type{component=\"shards-service\"}",
-        "hide": 0,
         "includeAll": false,
         "label": "Shard Servers",
         "multi": true,
@@ -8228,14 +8228,11 @@
         },
         "refresh": 1,
         "regex": "/.*instance=\"(.*):\\d+\".*/",
-        "skipUrlSync": false,
-        "sort": 0,
         "type": "query"
       },
       {
         "current": {
           "isNone": true,
-          "selected": false,
           "text": "None",
           "value": ""
         },
@@ -8244,10 +8241,8 @@
           "uid": "PBFA97CFB590B2093"
         },
         "definition": "sc_component_type{component=\"generator\"}",
-        "hide": 0,
         "includeAll": false,
         "label": "Generator Servers",
-        "multi": false,
         "name": "generator_instance",
         "options": [],
         "query": {
@@ -8256,8 +8251,6 @@
         },
         "refresh": 1,
         "regex": "/.*instance=\"(.*):\\d+\".*/",
-        "skipUrlSync": false,
-        "sort": 0,
         "type": "query"
       }
     ]
@@ -8266,35 +8259,9 @@
     "from": "now-5m",
     "to": "now"
   },
-  "timepicker": {
-    "now": true,
-    "refresh_intervals": [
-      "5s",
-      "10s",
-      "30s",
-      "1m",
-      "5m",
-      "15m",
-      "30m",
-      "1h",
-      "2h",
-      "1d"
-    ],
-    "time_options": [
-      "5m",
-      "15m",
-      "1h",
-      "6h",
-      "12h",
-      "24h",
-      "2d",
-      "7d",
-      "30d"
-    ]
-  },
+  "timepicker": {},
   "timezone": "browser",
-  "title": "Committer perf dashboard",
+  "title": "Fabric-X-Committer Performance Dashboard",
   "uid": "UDdpyzz7zav2",
-  "version": 1,
-  "weekStart": ""
+  "version": 1
 }


### PR DESCRIPTION
#### Type of change

- Bug fix
 
#### Description

<!--- Describe your changes in detail, including motivation. -->

The `loadgen` Throughput dashboard was not showing the throughput correctly. The issue was related to the sampling window set on grafana, e.g. 5sec, which was too little to collect enough samples and allow the `rate()` function to work properly.
This dashboard has been tested with `fabric-x-committer:0.1.5` and it works.
