### PR TITLE
[loadgen] Close broadcast streams only after the workload has completed

### DIFF
--- a/integration/runner/runtime.go
+++ b/integration/runner/runtime.go
@@ -243,14 +243,14 @@ func NewRuntime(t *testing.T, conf *Config) *CommitterRuntime {
 		ConsensusType: ordererconn.Bft,
 	})
 	require.NoError(t, err)
-	t.Cleanup(c.ordererStream.Close)
+	t.Cleanup(c.ordererStream.CloseConnections)
 
 	c.sidecarClient, err = sidecarclient.New(&sidecarclient.Parameters{
 		ChannelID: s.Policy.ChannelID,
 		Client:    test.NewTLSClientConfig(s.ClientTLS, s.Endpoints.Sidecar.Server),
 	})
 	require.NoError(t, err)
-	t.Cleanup(c.sidecarClient.Close)
+	t.Cleanup(c.sidecarClient.CloseConnections)
 	return c
 }
 

--- a/loadgen/adapters/sigverifier.go
+++ b/loadgen/adapters/sigverifier.go
@@ -69,6 +69,7 @@ func (c *SvAdapter) RunWorkload(ctx context.Context, txStream *workload.StreamWi
 	}
 
 	for _, stream := range streams {
+		stream := stream
 		g.Go(func() error {
 			return sendBlocks(gCtx, &c.commonAdapter, txStream, workload.MapToVerifierBatch, stream.Send)
 		})

--- a/loadgen/adapters/vcservice.go
+++ b/loadgen/adapters/vcservice.go
@@ -78,6 +78,7 @@ func (c *VcAdapter) RunWorkload(ctx context.Context, txStream *workload.StreamWi
 	defer dCancel()
 	g, gCtx := errgroup.WithContext(dCtx)
 	for _, stream := range streams {
+		stream := stream
 		g.Go(func() error {
 			return sendBlocks(ctx, &c.commonAdapter, txStream, workload.MapToVcBatch, stream.Send)
 		})

--- a/loadgen/client_test.go
+++ b/loadgen/client_test.go
@@ -302,6 +302,7 @@ func TestLoadGenForOnlyOrderer(t *testing.T) {
 						Endpoints: endpoints,
 					},
 					ChannelID:     clientConf.LoadProfile.Transaction.Policy.ChannelID,
+					Identity:      clientConf.LoadProfile.Transaction.Policy.Identity,
 					ConsensusType: ordererconn.Bft,
 				},
 				BroadcastParallelism: 5,

--- a/service/sidecar/sidecarclient/client.go
+++ b/service/sidecar/sidecarclient/client.go
@@ -73,9 +73,9 @@ func New(config *Parameters) (*Client, error) {
 	}, nil
 }
 
-// Close closes all the connections.
-func (c *Client) Close() {
-	c.ConnectionManager.Close()
+// CloseConnections closes all the connections.
+func (c *Client) CloseConnections() {
+	c.ConnectionManager.CloseConnections()
 }
 
 // Deliver start receiving blocks starting from config.StartBlkNum to config.OutputBlock.

--- a/utils/connection/client_util.go
+++ b/utils/connection/client_util.go
@@ -201,7 +201,7 @@ func Connect(config *DialConfig) (*grpc.ClientConn, error) {
 
 // OpenConnections opens connections with multiple remotes.
 func OpenConnections(config MultiClientConfig) ([]*grpc.ClientConn, error) {
-	logger.Infof("Opening connections to %d endpoints: %v.\n", len(config.Endpoints), config.Endpoints)
+	logger.Infof("Opening connections to %d endpoints: %v.", len(config.Endpoints), config.Endpoints)
 	dialConfigs, err := NewDialConfigPerEndpoint(&config)
 	if err != nil {
 		return nil, errors.Wrapf(err, "error while creating dial configs")

--- a/utils/deliver/client.go
+++ b/utils/deliver/client.go
@@ -52,9 +52,9 @@ func New(config *ordererconn.Config) (*Client, error) {
 	}, nil
 }
 
-// Close closes all the connections for the client.
-func (s *Client) Close() {
-	s.connectionManager.Close()
+// CloseConnections closes all the connections for the client.
+func (s *Client) CloseConnections() {
+	s.connectionManager.CloseConnections()
 }
 
 // UpdateConnections updates the connection config.

--- a/utils/deliver/client_test.go
+++ b/utils/deliver/client_test.go
@@ -48,7 +48,7 @@ func TestBroadcastDeliver(t *testing.T) {
 	conf.Connection.Endpoints = allEndpoints[:6]
 	client, err := New(&conf)
 	require.NoError(t, err)
-	t.Cleanup(client.Close)
+	t.Cleanup(client.CloseConnections)
 
 	ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
 	t.Cleanup(cancel)
@@ -152,7 +152,7 @@ func submit(
 	defer cancel()
 	stream, err := test.NewBroadcastStream(ctx, conf)
 	require.NoError(t, err)
-	defer stream.Close()
+	defer stream.CloseConnections()
 
 	err = stream.SendBatch(workload.MapToEnvelopeBatch(0, []*protoloadgen.TX{tx}))
 	if err != nil {
@@ -233,7 +233,7 @@ func waitUntilGrpcServerIsReady(ctx context.Context, t *testing.T, endpoint *con
 
 func waitUntilGrpcServerIsDown(ctx context.Context, t *testing.T, endpoint *connection.Endpoint) {
 	t.Helper()
-	newConn, err := connection.Connect(connection.NewInsecureDialConfig(endpoint))
+	newConn, err := connection.Connect(test.NewInsecureDialConfig(endpoint))
 	require.NoError(t, err)
 	defer connection.CloseConnectionsLog(newConn)
 	test.WaitUntilGrpcServerIsDown(ctx, t, newConn)

--- a/utils/test/broadcast_stream.go
+++ b/utils/test/broadcast_stream.go
@@ -85,9 +85,15 @@ func NewBroadcastStream(ctx context.Context, config *ordererconn.Config) (*Broad
 	return stream, nil
 }
 
-// Close closes all the connections for the stream.
-func (s *BroadcastStream) Close() {
-	s.ConnectionManager.Close()
+// CloseConnections closes all the connections for the stream.
+func (s *BroadcastStream) CloseConnections() {
+	s.ConnectionManager.CloseConnections()
+}
+
+// Close is included to implement the [io.Closer] interface.
+func (s *BroadcastStream) Close() error {
+	s.CloseConnections()
+	return nil
 }
 
 // SendBatch sends a batch one by one.


### PR DESCRIPTION
#### Type of change

- Bug fix
 
#### Description

- Fix bug in load-geneator: Close broadcast streams only after the workload has completed.
This ensures that any pending messages in the stream’s internal queue are fully processed. Even if all transactions have already been submitted, additional time may be required for them to be transmitted.
- Use a connection cache when opening all the connections in the connection manager to avoid re-opening the same connection multiple times.
- Fix broken rebase from prior commit.

#### Related issues

- resolves #117 
