### PR TITLE
[testing] Switch to bitnamilegacy/postgresql and testing improvements

### DIFF
--- a/integration/runner/postgres.go
+++ b/integration/runner/postgres.go
@@ -24,7 +24,10 @@ const (
 	// The image includes built-in scripts and environment variables that handle replication configuration
 	// out of the box, which reduces complexity and potential
 	// misconfigurations compared to setting it up manually with the official image.
-	postgresImage             = "bitnami/postgresql"
+	// Bitnami has migrated the bitnami/postgresql image to bitnamilegacy/postgresql,
+	// where it no longer receives updates or security patches.
+	// Since this image is used only for testing purposes, we can retain it for now.
+	postgresImage             = "bitnamilegacy/postgresql"
 	defaultPostgresDBName     = "postgres"
 	defaultBitnamiPostgresTag = "latest"
 

--- a/utils/test/secure_connection.go
+++ b/utils/test/secure_connection.go
@@ -140,18 +140,17 @@ func RunSecureConnectionTest(
 			rpcAttemptFunc := starter(t, serverTLS)
 			// for each server secure mode, build the client's test cases.
 			for _, clientTestCase := range tc.cases {
-				clientTc := clientTestCase
-				t.Run(clientTc.testDescription, func(t *testing.T) {
+				t.Run(clientTestCase.testDescription, func(t *testing.T) {
 					t.Parallel()
 
 					cfg := baseClientTLS
-					cfg.Mode = clientTc.clientSecureMode
+					cfg.Mode = clientTestCase.clientSecureMode
 
 					ctx, cancel := context.WithTimeout(t.Context(), 90*time.Second)
 					t.Cleanup(cancel)
 
 					err := rpcAttemptFunc(ctx, t, cfg)
-					if clientTc.shouldFail {
+					if clientTestCase.shouldFail {
 						require.Error(t, err)
 					} else {
 						require.NoError(t, err)

--- a/utils/test/secure_connection.go
+++ b/utils/test/secure_connection.go
@@ -149,7 +149,7 @@ func RunSecureConnectionTest(
 				cfg := baseClientTLS
 				cfg.Mode = clientTc.clientSecureMode
 
-				ctx, cancel := context.WithTimeout(t.Context(), 90*time.Second)
+				ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 				t.Cleanup(cancel)
 
 				err := rpcAttemptFunc(ctx, t, cfg)

--- a/utils/test/secure_connection.go
+++ b/utils/test/secure_connection.go
@@ -135,7 +135,7 @@ func RunSecureConnectionTest(
 	} {
 		t.Run(fmt.Sprintf("server-tls:%s", tc.serverMode), func(t *testing.T) {
 			t.Parallel()
-			// create server's tls config and start it according to the serverSecureMode.
+			// create server's tls config and start it according to the server tls mode.
 			serverTLS := tlsMgr.CreateServerCredentials(t, tc.serverMode, defaultHostName)
 			rpcAttemptFunc := starter(t, serverTLS)
 			// for each server secure mode, build the client's test cases.

--- a/utils/test/secure_connection.go
+++ b/utils/test/secure_connection.go
@@ -133,33 +133,32 @@ func RunSecureConnectionTest(
 			},
 		},
 	} {
-		// create server's tls config and start it according to the serverSecureMode.
-		serverTLS := tlsMgr.CreateServerCredentials(t, tc.serverMode, defaultHostName)
-		rpcAttemptFunc := starter(t, serverTLS)
-		// for each server secure mode, build the client's test cases.
-		for _, clientTestCase := range tc.cases {
-			clientTc := clientTestCase
-			t.Run(fmt.Sprintf(
-				"tls-mode:%s/%s",
-				tc.serverMode,
-				clientTc.testDescription,
-			), func(t *testing.T) {
-				t.Parallel()
+		t.Run(fmt.Sprintf("server-tls:%s", tc.serverMode), func(t *testing.T) {
+			t.Parallel()
+			// create server's tls config and start it according to the serverSecureMode.
+			serverTLS := tlsMgr.CreateServerCredentials(t, tc.serverMode, defaultHostName)
+			rpcAttemptFunc := starter(t, serverTLS)
+			// for each server secure mode, build the client's test cases.
+			for _, clientTestCase := range tc.cases {
+				clientTc := clientTestCase
+				t.Run(fmt.Sprintf("%s", clientTc.testDescription), func(t *testing.T) {
+					t.Parallel()
 
-				cfg := baseClientTLS
-				cfg.Mode = clientTc.clientSecureMode
+					cfg := baseClientTLS
+					cfg.Mode = clientTc.clientSecureMode
 
-				ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
-				t.Cleanup(cancel)
+					ctx, cancel := context.WithTimeout(t.Context(), 90*time.Second)
+					t.Cleanup(cancel)
 
-				err := rpcAttemptFunc(ctx, t, cfg)
-				if clientTc.shouldFail {
-					require.Error(t, err)
-				} else {
-					require.NoError(t, err)
-				}
-			})
-		}
+					err := rpcAttemptFunc(ctx, t, cfg)
+					if clientTc.shouldFail {
+						require.Error(t, err)
+					} else {
+						require.NoError(t, err)
+					}
+				})
+			}
+		})
 	}
 }
 
@@ -173,7 +172,12 @@ func CreateClientWithTLS[T any](
 	protoClient func(grpc.ClientConnInterface) T,
 ) T {
 	t.Helper()
-	conn, err := connection.Connect(NewSecuredDialConfig(t, endpoint, tlsCfg))
+	dialConfig := NewSecuredDialConfig(t, endpoint, tlsCfg)
+	// prevents secure connection tests from hanging until the context times out.
+	dialConfig.SetRetryProfile(&connection.RetryProfile{
+		MaxElapsedTime: 3 * time.Second,
+	})
+	conn, err := connection.Connect(dialConfig)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		require.NoError(t, conn.Close())

--- a/utils/test/secure_connection.go
+++ b/utils/test/secure_connection.go
@@ -141,7 +141,7 @@ func RunSecureConnectionTest(
 			// for each server secure mode, build the client's test cases.
 			for _, clientTestCase := range tc.cases {
 				clientTc := clientTestCase
-				t.Run(fmt.Sprintf("%s", clientTc.testDescription), func(t *testing.T) {
+				t.Run(clientTc.testDescription, func(t *testing.T) {
 					t.Parallel()
 
 					cfg := baseClientTLS


### PR DESCRIPTION
#### Type of change

- Bug fix
- Test update

#### Description

- Switched from the bitnami/postgresql image to bitnamilegacy/postgresql.  
- Reduced the retry profile's maximum elapsed time for service clients.  
- Added an additional level of parallelism for the secure client test.

#### Related issues

- resolves #140
- resolves #138 