### PR TITLE
Use a single mock instance for each mock type

### DIFF
--- a/cmd/config/cobra_test_exports.go
+++ b/cmd/config/cobra_test_exports.go
@@ -43,7 +43,7 @@ type CommandTest struct {
 // StartDefaultSystem starts a system with mocks for CMD testing.
 func StartDefaultSystem(t *testing.T) SystemConfig {
 	t.Helper()
-	_, verifier := mock.StartMockSVService(t, 1)
+	_, verifier := mock.StartMockVerifierService(t, 1)
 	_, vc := mock.StartMockVCService(t, 1)
 	_, orderer := mock.StartMockOrderingServices(t, &mock.OrdererConfig{NumService: 1})
 	_, coordinator := mock.StartMockCoordinatorService(t)

--- a/loadgen/client_test.go
+++ b/loadgen/client_test.go
@@ -160,7 +160,7 @@ func TestLoadGenForCoordinator(t *testing.T) {
 					t.Parallel()
 					clientConf := DefaultClientConf(t)
 					clientConf.Limit = limit
-					_, sigVerServer := mock.StartMockSVService(t, 1)
+					_, sigVerServer := mock.StartMockVerifierService(t, 1)
 					_, vcServer := mock.StartMockVCService(t, 1)
 
 					cConf := &coordinator.Config{

--- a/mock/coordinator.go
+++ b/mock/coordinator.go
@@ -28,7 +28,7 @@ import (
 	"github.com/hyperledger/fabric-x-committer/utils/grpcerror"
 )
 
-// Coordinator is a mock coordinator.
+// Coordinator is a mock implementation of servicepb.CoordinatorServer.
 type Coordinator struct {
 	servicepb.CoordinatorServer
 	lastCommittedBlock atomic.Pointer[servicepb.BlockRef]

--- a/mock/vcservice.go
+++ b/mock/vcservice.go
@@ -29,7 +29,7 @@ import (
 	"github.com/hyperledger/fabric-x-committer/utils/grpcerror"
 )
 
-// VcService implements the [protovcservice.ValidationAndCommitServiceServer] interface.
+// VcService is a mock implementation of servicepb.ValidationAndCommitServiceServer.
 // It is used for testing the client which is the coordinator service.
 type VcService struct {
 	servicepb.ValidationAndCommitServiceServer

--- a/service/coordinator/validator_committer_manager_test.go
+++ b/service/coordinator/validator_committer_manager_test.go
@@ -203,7 +203,8 @@ func TestValidatorCommitterManagerX(t *testing.T) {
 	t.Run("namespace transaction should update signature verifier", func(t *testing.T) {
 		t.Parallel()
 		env := newVcMgrTestEnv(t, 2)
-		for _, mockSvService := range env.sigVerTestEnv.mockSvService {
+		verifierStreams := requireStreams(t, env.sigVerTestEnv.mockVerifier, 2)
+		for _, mockSvService := range verifierStreams {
 			require.Empty(t, mockSvService.GetUpdates())
 		}
 
@@ -296,10 +297,10 @@ func TestValidatorCommitterManagerRecovery(t *testing.T) {
 	env.requireConnectionMetrics(t, 0, connection.Disconnected, 1)
 
 	env.mockVcService.MockFaultyNodeDropSize = 0
-	env.mockVCGrpcServers = mock.StartMockVCServiceFromListWithConfig(
+	env.mockVCGrpcServers = mock.StartMockVCServiceFromServerConfig(
 		t,
-		[]*mock.VcService{env.mockVcService},
-		env.mockVCGrpcServers.Configs,
+		env.mockVcService,
+		env.mockVCGrpcServers.Configs...,
 	)
 	env.requireConnectionMetrics(t, 0, connection.Connected, 1)
 	env.requireRetriedTxsTotal(t, 4)

--- a/service/sidecar/sidecar_test.go
+++ b/service/sidecar/sidecar_test.go
@@ -471,7 +471,7 @@ func TestSidecarRecoveryAfterCoordinatorFailure(t *testing.T) {
 	txs := env.sendGeneratedTransactionsForBlock(ctx, t)
 
 	t.Log("4. Restart the coordinator and validate processing block 11")
-	env.coordinatorServer = mock.StartMockCoordinatorServiceFromListWithConfig(t, env.coordinator,
+	env.coordinatorServer = mock.StartMockCoordinatorServiceServerConfig(t, env.coordinator,
 		env.coordinatorServer.Configs[0])
 
 	monitoring.RequireConnectionMetrics(
@@ -503,7 +503,7 @@ func TestSidecarStartWithoutCoordinator(t *testing.T) {
 	)
 
 	t.Log("Restart the coordinator")
-	env.coordinatorServer = mock.StartMockCoordinatorServiceFromListWithConfig(t, env.coordinator,
+	env.coordinatorServer = mock.StartMockCoordinatorServiceServerConfig(t, env.coordinator,
 		env.coordinatorServer.Configs[0])
 	monitoring.RequireConnectionMetrics(
 		t, coordLabel,

--- a/utils/connection/endpoint.go
+++ b/utils/connection/endpoint.go
@@ -68,5 +68,5 @@ func NewEndpoint(hostPort string) (*Endpoint, error) {
 
 // NewLocalHost returns a default endpoint "localhost:0".
 func NewLocalHost() *Endpoint {
-	return &Endpoint{Host: "localhost"}
+	return &Endpoint{Host: "127.0.0.1"}
 }

--- a/utils/grpcerror/codes_test.go
+++ b/utils/grpcerror/codes_test.go
@@ -67,7 +67,7 @@ func TestHasCodeWithGRPCService(t *testing.T) {
 	t.Parallel()
 	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Minute)
 	defer cancel()
-	server := test.StartGrpcServersForTest(ctx, t, 1, func(server *grpc.Server, _ int) {
+	server := test.StartGrpcServersForTest(ctx, t, 1, func(server *grpc.Server) {
 		healthgrpc.RegisterHealthServer(server, &healthgrpc.UnimplementedHealthServer{})
 	})
 

--- a/utils/test/secure_connection.go
+++ b/utils/test/secure_connection.go
@@ -46,7 +46,7 @@ type (
 )
 
 const (
-	defaultHostName = "localhost"
+	defaultHostName = "127.0.0.1"
 
 	//nolint:revive // represents the default certificate's names.
 	PrivateKey       = "private-key.pem"

--- a/utils/test/utils.go
+++ b/utils/test/utils.go
@@ -111,31 +111,29 @@ func StartGrpcServersForTest(
 	ctx context.Context,
 	t *testing.T,
 	numService int,
-	register func(*grpc.Server, int),
+	register func(*grpc.Server),
 ) *GrpcServers {
 	t.Helper()
 	sc := make([]*connection.ServerConfig, numService)
 	for i := range sc {
 		sc[i] = connection.NewLocalHostServerWithTLS(InsecureTLSConfig)
 	}
-	return StartGrpcServersWithConfigForTest(ctx, t, sc, register)
+	return StartGrpcServersWithConfigForTest(ctx, t, register, sc...)
 }
 
 // StartGrpcServersWithConfigForTest starts multiple GRPC servers with given configurations.
 func StartGrpcServersWithConfigForTest(
-	ctx context.Context, t *testing.T, sc []*connection.ServerConfig, register func(*grpc.Server, int),
+	ctx context.Context, t *testing.T, register func(*grpc.Server), sc ...*connection.ServerConfig,
 ) *GrpcServers {
 	t.Helper()
 	grpcServers := make([]*grpc.Server, len(sc))
+	if register == nil {
+		register = func(server *grpc.Server) {
+			healthgrpc.RegisterHealthServer(server, connection.DefaultHealthCheckService())
+		}
+	}
 	for i, s := range sc {
-		i := i
-		grpcServers[i] = RunGrpcServerForTest(ctx, t, s, func(server *grpc.Server) {
-			if register != nil {
-				register(server, i)
-			} else {
-				healthgrpc.RegisterHealthServer(server, connection.DefaultHealthCheckService())
-			}
-		})
+		grpcServers[i] = RunGrpcServerForTest(ctx, t, s, register)
 	}
 	return &GrpcServers{
 		Servers: grpcServers,

--- a/utils/test/utils_test.go
+++ b/utils/test/utils_test.go
@@ -7,12 +7,10 @@ SPDX-License-Identifier: Apache-2.0
 package test_test
 
 import (
-	"context"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"google.golang.org/grpc"
 
 	"github.com/hyperledger/fabric-x-committer/mock"
 	"github.com/hyperledger/fabric-x-committer/utils/test"
@@ -20,13 +18,8 @@ import (
 
 func TestCheckServerStopped(t *testing.T) {
 	t.Parallel()
-	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Minute)
-	t.Cleanup(cancel)
 
-	mockSigVer := mock.NewMockSigVerifier()
-	sigVerServers := test.StartGrpcServersForTest(ctx, t, 1, func(server *grpc.Server, _ int) {
-		mockSigVer.RegisterService(server)
-	})
+	_, sigVerServers := mock.StartMockVerifierService(t, 1)
 
 	addr := sigVerServers.Configs[0].Endpoint.Address()
 	require.Eventually(t, func() bool {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package utils
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -14,6 +15,7 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/errors"
+	"google.golang.org/grpc/peer"
 )
 
 // ErrActiveStream represents the error when attempting to create a new stream while one is already active.
@@ -87,4 +89,13 @@ func CountAppearances[T comparable](items []T) map[T]int {
 		countMap[item]++
 	}
 	return countMap
+}
+
+// ExtractServerAddress returns the stream's server (local) address.
+func ExtractServerAddress(ctx context.Context) string {
+	p, ok := peer.FromContext(ctx)
+	if !ok || p == nil || p.LocalAddr == nil {
+		return ""
+	}
+	return p.LocalAddr.String()
 }


### PR DESCRIPTION
#### Type of change

- Test update
 
#### Description

Modify the mock verifier:
- Use a single mock instance for each mock type
- Remove redundant methods
- Rename to `Verifier`

#### Related issues

- resolves #212 
- resolves #227 
