### PR TITLE
[loadgen] Clarify sample file usage

### DIFF
--- a/mock/test_exports.go
+++ b/mock/test_exports.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/hyperledger/fabric-protos-go-apiv2/common"
 	commontypes "github.com/hyperledger/fabric-x-common/api/types"
-	"github.com/hyperledger/fabric-x-common/tools/configtxgen"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 
@@ -177,7 +176,7 @@ func (e *OrdererTestEnv) SubmitConfigBlock(t *testing.T, conf *workload.ConfigBl
 	if conf.MetaNamespaceVerificationKey == nil {
 		conf.MetaNamespaceVerificationKey = e.TestConfig.MetaNamespaceVerificationKey
 	}
-	configBlock, err := workload.CreateDefaultConfigBlock(conf, configtxgen.TwoOrgsSampleFabricX)
+	configBlock, err := workload.CreateDefaultConfigBlock(conf)
 	require.NoError(t, err)
 	err = e.Orderer.SubmitBlock(t.Context(), configBlock)
 	require.NoError(t, err)

--- a/service/coordinator/validator_committer_manager_test.go
+++ b/service/coordinator/validator_committer_manager_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/hyperledger/fabric-x-common/protoutil"
-	"github.com/hyperledger/fabric-x-common/tools/configtxgen"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
@@ -214,7 +213,7 @@ func TestValidatorCommitterManagerX(t *testing.T) {
 
 		configBlock, err := workload.CreateDefaultConfigBlock(&workload.ConfigBlock{
 			MetaNamespaceVerificationKey: verificationKey,
-		}, configtxgen.TwoOrgsSampleFabricX)
+		})
 		require.NoError(t, err)
 
 		txBatch := []*dependencygraph.TransactionNode{

--- a/service/verifier/verifier_server_test.go
+++ b/service/verifier/verifier_server_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/hyperledger/fabric-x-common/common/policydsl"
 	commonmsp "github.com/hyperledger/fabric-x-common/msp"
 	"github.com/hyperledger/fabric-x-common/protoutil"
-	"github.com/hyperledger/fabric-x-common/tools/configtxgen"
 	"github.com/hyperledger/fabric-x-common/tools/cryptogen"
 	"github.com/stretchr/testify/require"
 
@@ -230,7 +229,7 @@ func TestSignatureRule(t *testing.T) {
 	_, metaTxVerificationKey := sigtest.NewKeyPair(signature.Ecdsa)
 	configBlock, err := workload.CreateDefaultConfigBlock(&workload.ConfigBlock{
 		MetaNamespaceVerificationKey: metaTxVerificationKey,
-	}, configtxgen.SampleFabricX)
+	})
 	require.NoError(t, err)
 	update = &servicepb.VerifierUpdates{
 		Config: &applicationpb.ConfigTransaction{
@@ -544,7 +543,7 @@ func defaultCryptoParameters(t *testing.T) cryptoParameters {
 	configBlock, err := workload.CreateDefaultConfigBlockWithCrypto(ret.cryptoPath, &workload.ConfigBlock{
 		MetaNamespaceVerificationKey: metaTxVerificationKey,
 		PeerOrganizationCount:        2,
-	}, configtxgen.TwoOrgsSampleFabricX)
+	})
 	require.NoError(t, err)
 	ret.metaTxEndorser, err = sigtest.NewNsEndorserFromKey(signature.Ecdsa, metaTxSigningKey)
 	require.NoError(t, err)


### PR DESCRIPTION
#### Type of change

- Improvement (improvement to code, performance, etc)
 
#### Description

- Use `configtxgen.SampleFabricX` (disable flexibility).
- Add a comment to clarify what is used from the sample file.

#### Related issues

- resolve #221 