### PR TITLE
[makefile] replace realpath with sed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,7 @@ endif
 
 arch_output_dir_rel = $(arch_output_dir:${project_dir}/%=%)
 
-PYTHON_CMD ?= python
+PYTHON_CMD ?= $(shell command -v python3 2>/dev/null || command -v python 2>/dev/null)
 
 # Set additional parameter to build the test-node for different platforms and push
 # E.g., make multiplatform=true docker_push=true build-test-node-image
@@ -203,7 +203,7 @@ lint-proto: FORCE
 		--config .apilinter.yaml \
 		--set-exit-status \
 		--output-format github \
-		$(shell find ${project_dir}/api -name '*.proto' -exec realpath --relative-to ${project_dir}/api {} \;)
+		$(shell find ${project_dir}/api -name '*.proto' | sed 's|${project_dir}/api/||')
 
 #########################
 # Binaries


### PR DESCRIPTION
#### Type of change

- Improvement (improvement to code, performance, etc)
 
#### Description

The realpath in mac OS does not support `--relative-to`. We have to install `coreutils` and set alias for GNU grealpath. As these steps are unnecessary and adds overhead for new developers, this commit removes this extra dependency by using a sed command.