### PR TITLE
[grpc] rate limiting for unary calls

### DIFF
--- a/cmd/config/app_config_test.go
+++ b/cmd/config/app_config_test.go
@@ -102,6 +102,7 @@ func TestReadConfigSidecar(t *testing.T) {
 						PermitWithoutStream: false,
 					},
 				},
+				RateLimit: &connection.RateLimitConfig{},
 			},
 			Monitoring: newMonitoringConfig("", 2114),
 			Orderer: ordererconn.Config{
@@ -491,14 +492,16 @@ func newMonitoringConfig(host string, port int) monitoring.Config {
 
 func newServerConfigWithDefaultTLS(port int) *connection.ServerConfig {
 	return &connection.ServerConfig{
-		Endpoint: *newEndpoint("", port),
-		TLS:      defaultServerTLSConfig,
+		Endpoint:  *newEndpoint("", port),
+		TLS:       defaultServerTLSConfig,
+		RateLimit: &connection.RateLimitConfig{},
 	}
 }
 
 func newServerConfig(host string, port int) *connection.ServerConfig {
 	return &connection.ServerConfig{
-		Endpoint: *newEndpoint(host, port),
+		Endpoint:  *newEndpoint(host, port),
+		RateLimit: &connection.RateLimitConfig{},
 	}
 }
 

--- a/cmd/config/create_config_file.go
+++ b/cmd/config/create_config_file.go
@@ -42,15 +42,16 @@ type (
 		DB        DatabaseConfig
 
 		// Per service configurations.
-		BlockSize         uint64                  // orderer, loadgen
-		BlockTimeout      time.Duration           // orderer
-		ConfigBlockPath   string                  // orderer, sidecar, loadgen
-		LedgerPath        string                  // sidecar
-		Policy            *workload.PolicyProfile // loadgen
-		LoadGenBlockLimit uint64                  // loadgen
-		LoadGenTXLimit    uint64                  // loadgen
-		LoadGenWorkers    uint64                  // loadgen
-		Logging           *logging.Config         // for all
+		BlockSize         uint64                      // orderer, loadgen
+		BlockTimeout      time.Duration               // orderer
+		ConfigBlockPath   string                      // orderer, sidecar, loadgen
+		LedgerPath        string                      // sidecar
+		Policy            *workload.PolicyProfile     // loadgen
+		LoadGenBlockLimit uint64                      // loadgen
+		LoadGenTXLimit    uint64                      // loadgen
+		LoadGenWorkers    uint64                      // loadgen
+		Logging           *logging.Config             // for all
+		RateLimit         *connection.RateLimitConfig // query, sidecar
 	}
 
 	// SystemEndpoints represents the endpoints of the system.

--- a/cmd/config/samples/coordinator.yaml
+++ b/cmd/config/samples/coordinator.yaml
@@ -13,6 +13,17 @@ server:
 monitoring:
   server:
     endpoint: :2119
+    # Rate limiting configuration for unary gRPC endpoints.
+    # Uses a token bucket algorithm to limit the number of requests per second.
+    rate-limit:
+      # Maximum number of requests per second allowed.
+      # Set to 0 to disable rate limiting.
+      requests-per-second: 0
+      # Maximum number of requests allowed in a single burst.
+      # When rate limiting is enabled (requests-per-second > 0):
+      #   - Must be greater than 0
+      #   - Must be less than or equal to requests-per-second
+      burst: 0
 
 verifier:
   endpoints:

--- a/cmd/config/samples/loadgen.yaml
+++ b/cmd/config/samples/loadgen.yaml
@@ -13,6 +13,17 @@ server:
 monitoring:
   server:
     endpoint: :2118
+    # Rate limiting configuration for unary gRPC endpoints.
+    # Uses a token bucket algorithm to limit the number of requests per second.
+    rate-limit:
+      # Maximum number of requests per second allowed.
+      # Set to 0 to disable rate limiting.
+      requests-per-second: 0
+      # Maximum number of requests allowed in a single burst.
+      # When rate limiting is enabled (requests-per-second > 0):
+      #   - Must be greater than 0
+      #   - Must be less than or equal to requests-per-second
+      burst: 0
   latency:
     sampler:
       portion: 0.01

--- a/cmd/config/samples/query.yaml
+++ b/cmd/config/samples/query.yaml
@@ -12,9 +12,23 @@ server:
     key-path: /server-certs/private-key.pem
     ca-cert-paths:
       - /server-certs/ca-certificate.pem
+  # Rate limiting configuration for unary gRPC endpoints.
+  # Uses a token bucket algorithm to limit the number of requests per second.
+  rate-limit:
+    # Maximum number of requests per second allowed.
+    # Set to 0 to disable rate limiting.
+    requests-per-second: 0
+    # Maximum number of requests allowed in a single burst.
+    # When rate limiting is enabled (requests-per-second > 0):
+    #   - Must be greater than 0
+    #   - Must be less than or equal to requests-per-second
+    burst: 0
 monitoring:
   server:
     endpoint: :2117
+    rate-limit:
+      requests-per-second: 0
+      burst: 0
 
 database:
   endpoints:

--- a/cmd/config/samples/sidecar.yaml
+++ b/cmd/config/samples/sidecar.yaml
@@ -17,9 +17,23 @@ server:
     enforcement-policy:
       min-time: 60s
       permit-without-stream: false
+  # Rate limiting configuration for unary gRPC endpoints.
+  # Uses a token bucket algorithm to limit the number of requests per second.
+  rate-limit:
+    # Maximum number of requests per second allowed.
+    # Set to 0 to disable rate limiting.
+    requests-per-second: 0
+    # Maximum number of requests allowed in a single burst.
+    # When rate limiting is enabled (requests-per-second > 0):
+    #   - Must be greater than 0
+    #   - Must be less than or equal to requests-per-second
+    burst: 0
 monitoring:
   server:
     endpoint: :2114
+    rate-limit:
+      requests-per-second: 0
+      burst: 0
 
 orderer:
   connection:

--- a/cmd/config/samples/vc.yaml
+++ b/cmd/config/samples/vc.yaml
@@ -15,6 +15,17 @@ server:
 monitoring:
   server:
     endpoint: :2116
+    # Rate limiting configuration for unary gRPC endpoints.
+    # Uses a token bucket algorithm to limit the number of requests per second.
+    rate-limit:
+      # Maximum number of requests per second allowed.
+      # Set to 0 to disable rate limiting.
+      requests-per-second: 0
+      # Maximum number of requests allowed in a single burst.
+      # When rate limiting is enabled (requests-per-second > 0):
+      #   - Must be greater than 0
+      #   - Must be less than or equal to requests-per-second
+      burst: 0
 database:
   endpoints:
     - db:5433

--- a/cmd/config/samples/verifier.yaml
+++ b/cmd/config/samples/verifier.yaml
@@ -13,6 +13,17 @@ server:
 monitoring:
   server:
     endpoint: :2115
+    # Rate limiting configuration for unary gRPC endpoints.
+    # Uses a token bucket algorithm to limit the number of requests per second.
+    rate-limit:
+      # Maximum number of requests per second allowed.
+      # Set to 0 to disable rate limiting.
+      requests-per-second: 0
+      # Maximum number of requests allowed in a single burst.
+      # When rate limiting is enabled (requests-per-second > 0):
+      #   - Must be greater than 0
+      #   - Must be less than or equal to requests-per-second
+      burst: 0
 
 parallel-executor:
   batch-size-cutoff: 50

--- a/cmd/config/templates/query.yaml
+++ b/cmd/config/templates/query.yaml
@@ -13,6 +13,17 @@ server:
       {{- range .ServiceTLS.CACertPaths }}
       - {{ . }}
       {{- end }}
+  {{- if .RateLimit }}
+  # Rate limiting configuration for unary gRPC endpoints.
+  # Uses a token bucket algorithm to limit the number of requests per second.
+  rate-limit:
+    # Maximum number of requests per second allowed.
+    # Set to 0 to disable rate limiting.
+    requests-per-second: {{ .RateLimit.RequestsPerSecond }}
+    # Maximum number of requests allowed in a single burst.
+    # Must be greater than 0 and less than or equal to requests-per-second.
+    burst: {{ .RateLimit.Burst }}
+  {{- end }}
 monitoring:
   server:
     endpoint: {{ .ServiceEndpoints.Metrics | default "localhost:0" }}

--- a/cmd/config/viper.go
+++ b/cmd/config/viper.go
@@ -84,6 +84,9 @@ func NewViperWithServiceDefault(servicePort, monitoringPort int) *viper.Viper {
 	v := NewViperWithLoggingDefault()
 	v.SetDefault("server.endpoint", &connection.Endpoint{Host: "localhost", Port: servicePort})
 	v.SetDefault("monitoring.server.endpoint", &connection.Endpoint{Host: "localhost", Port: monitoringPort})
+	// Rate limiting disabled by default (0 = disabled)
+	v.SetDefault("server.rate-limit", &connection.RateLimitConfig{})
+	v.SetDefault("monitoring.server.rate-limit", &connection.RateLimitConfig{})
 	return v
 }
 

--- a/integration/runner/runtime.go
+++ b/integration/runner/runtime.go
@@ -90,6 +90,9 @@ type (
 
 		// CrashTest is true to indicate a service crash is expected, and not a failure.
 		CrashTest bool
+
+		// RateLimit configures rate limiting for services that support it (query, sidecar).
+		RateLimit *connection.RateLimitConfig
 	}
 )
 
@@ -140,7 +143,8 @@ func NewRuntime(t *testing.T, conf *Config) *CommitterRuntime {
 				NamespacePolicies:  make(map[string]*workload.Policy),
 				CryptoMaterialPath: t.TempDir(),
 			},
-			Logging: &logging.DefaultConfig,
+			Logging:   &logging.DefaultConfig,
+			RateLimit: conf.RateLimit,
 		},
 		CommittedBlock:   make(chan *common.Block, 100),
 		SeedForCryptoGen: rand.New(rand.NewSource(10)),

--- a/integration/test/rate_limit_test.go
+++ b/integration/test/rate_limit_test.go
@@ -1,0 +1,115 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package test
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/hyperledger/fabric-x-common/api/committerpb"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/hyperledger/fabric-x-committer/integration/runner"
+	"github.com/hyperledger/fabric-x-committer/utils/connection"
+	"github.com/hyperledger/fabric-x-committer/utils/test"
+)
+
+func TestRateLimit(t *testing.T) {
+	t.Parallel()
+
+	c := runner.NewRuntime(t, &runner.Config{
+		NumVerifiers: 1,
+		NumVCService: 1,
+		BlockTimeout: 2 * time.Second,
+		RateLimit: &connection.RateLimitConfig{
+			RequestsPerSecond: 2,
+			Burst:             1,
+		},
+	})
+
+	c.Start(t, runner.FullTxPathWithQuery)
+
+	numParallelRequests := 5
+
+	t.Run("WithoutRetry_ReturnsResourceExhausted", func(t *testing.T) {
+		t.Parallel()
+		// Create a connection without retry policy to observe rate limiting behavior.
+		// The default test connection has a retry policy that includes RESOURCE_EXHAUSTED,
+		// which would mask the rate limit behavior by automatically retrying failed requests.
+		clientCreds, err := c.SystemConfig.ClientTLS.ClientCredentials()
+		require.NoError(t, err)
+		conn, err := grpc.NewClient(
+			c.SystemConfig.Endpoints.Query.Server.Address(),
+			grpc.WithTransportCredentials(clientCreds),
+		)
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = conn.Close() })
+
+		_, rateLimitedCount, _ := makeParallelRequests(t, numParallelRequests, conn, 10*time.Second)
+		require.Positive(t, rateLimitedCount)
+	})
+
+	t.Run("WithRetry_AllRequestsSucceed", func(t *testing.T) {
+		t.Parallel()
+		// Create a connection with the default retry policy.
+		// The retry policy includes RESOURCE_EXHAUSTED, so rate-limited requests
+		// will be automatically retried and should eventually succeed.
+		conn := test.NewSecuredConnection(t, c.SystemConfig.Endpoints.Query.Server, c.SystemConfig.ClientTLS)
+
+		successCount, rateLimitedCount, otherErrorCount := makeParallelRequests(
+			t, numParallelRequests, conn, 30*time.Second)
+
+		// With retry policy, all requests should eventually succeed
+		require.Equal(t, int32(numParallelRequests), successCount) //nolint:gosec // int to int32
+		require.Equal(t, int32(0), rateLimitedCount+otherErrorCount)
+	})
+}
+
+func makeParallelRequests(t *testing.T, numParallelRequests int, conn *grpc.ClientConn, timeout time.Duration) (
+	success, rateLimited, otherErrors int32,
+) {
+	t.Helper()
+
+	client := committerpb.NewQueryServiceClient(conn)
+
+	var successCount, rateLimitedCount, otherErrorCount atomic.Int32
+	var wg sync.WaitGroup
+
+	reqCtx, cancel := context.WithTimeout(t.Context(), timeout)
+	defer cancel()
+
+	for range numParallelRequests {
+		wg.Go(
+			func() {
+				_, err := client.GetTransactionStatus(reqCtx, &committerpb.TxStatusQuery{
+					TxIds: []string{"test-tx-id"},
+				})
+				if err == nil {
+					successCount.Add(1)
+					return
+				}
+
+				st, ok := status.FromError(err)
+				if ok && st.Code() == codes.ResourceExhausted {
+					rateLimitedCount.Add(1)
+				} else {
+					otherErrorCount.Add(1)
+				}
+			},
+		)
+	}
+
+	wg.Wait()
+
+	return successCount.Load(), rateLimitedCount.Load(), otherErrorCount.Load()
+}

--- a/utils/connection/ratelimit.go
+++ b/utils/connection/ratelimit.go
@@ -1,0 +1,41 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package connection
+
+import (
+	"context"
+
+	"golang.org/x/time/rate"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// NewRateLimiter creates a rate limiter based on the configuration.
+func NewRateLimiter(config *RateLimitConfig) *rate.Limiter {
+	if config == nil || config.RequestsPerSecond <= 0 {
+		return nil
+	}
+	return rate.NewLimiter(rate.Limit(config.RequestsPerSecond), config.Burst)
+}
+
+// RateLimitInterceptor returns a UnaryServerInterceptor that implements
+// rate limiting using a token bucket algorithm.
+func RateLimitInterceptor(limiter *rate.Limiter) grpc.UnaryServerInterceptor {
+	return func(
+		ctx context.Context,
+		req any,
+		info *grpc.UnaryServerInfo,
+		handler grpc.UnaryHandler,
+	) (any, error) {
+		if limiter != nil && !limiter.Allow() {
+			logger.Warnf("Rate limit exceeded, rejecting request for method: %s", info.FullMethod)
+			return nil, status.Error(codes.ResourceExhausted, "rate limit exceeded")
+		}
+		return handler(ctx, req)
+	}
+}

--- a/utils/connection/ratelimit_test.go
+++ b/utils/connection/ratelimit_test.go
@@ -1,0 +1,170 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package connection
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"golang.org/x/time/rate"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestNewRateLimiter(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil config returns nil limiter", func(t *testing.T) {
+		t.Parallel()
+		limiter := NewRateLimiter(nil)
+		require.Nil(t, limiter)
+	})
+
+	t.Run("zero rate returns nil limiter", func(t *testing.T) {
+		t.Parallel()
+		limiter := NewRateLimiter(&RateLimitConfig{RequestsPerSecond: 0})
+		require.Nil(t, limiter)
+	})
+
+	t.Run("negative rate returns nil limiter", func(t *testing.T) {
+		t.Parallel()
+		limiter := NewRateLimiter(&RateLimitConfig{RequestsPerSecond: -1})
+		require.Nil(t, limiter)
+	})
+
+	t.Run("positive rate returns valid limiter with configured burst", func(t *testing.T) {
+		t.Parallel()
+		limiter := NewRateLimiter(&RateLimitConfig{RequestsPerSecond: 100, Burst: 50})
+		require.NotNil(t, limiter)
+		require.Equal(t, int(100), int(limiter.Limit()))
+		require.Equal(t, 50, limiter.Burst())
+	})
+}
+
+func TestRateLimitConfigValidate(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil config is valid", func(t *testing.T) {
+		t.Parallel()
+		var config *RateLimitConfig
+		require.NoError(t, config.Validate())
+	})
+
+	t.Run("disabled rate limiting is valid", func(t *testing.T) {
+		t.Parallel()
+		config := &RateLimitConfig{RequestsPerSecond: 0, Burst: 100}
+		require.NoError(t, config.Validate())
+	})
+
+	t.Run("burst less than requests-per-second is valid", func(t *testing.T) {
+		t.Parallel()
+		config := &RateLimitConfig{RequestsPerSecond: 1000, Burst: 200}
+		require.NoError(t, config.Validate())
+	})
+
+	t.Run("burst equal to requests-per-second is valid", func(t *testing.T) {
+		t.Parallel()
+		config := &RateLimitConfig{RequestsPerSecond: 200, Burst: 200}
+		require.NoError(t, config.Validate())
+	})
+
+	t.Run("burst zero is invalid when rate limiting is enabled", func(t *testing.T) {
+		t.Parallel()
+		config := &RateLimitConfig{RequestsPerSecond: 100, Burst: 0}
+		err := config.Validate()
+		require.Error(t, err)
+		require.ErrorContains(t, err, "burst must be greater than 0")
+	})
+
+	t.Run("burst greater than requests-per-second is invalid", func(t *testing.T) {
+		t.Parallel()
+		config := &RateLimitConfig{RequestsPerSecond: 100, Burst: 200}
+		err := config.Validate()
+		require.Error(t, err)
+		require.ErrorContains(t, err, "burst (200) must be less than or equal to requests-per-second")
+	})
+}
+
+func TestRateLimitInterceptor(t *testing.T) {
+	t.Parallel()
+
+	const s = "success"
+	handler := func(_ context.Context, _ any) (any, error) {
+		return s, nil
+	}
+
+	t.Run("nil limiter allows all requests", func(t *testing.T) {
+		t.Parallel()
+		interceptor := RateLimitInterceptor(nil)
+		for range 10 {
+			resp, err := interceptor(t.Context(), nil, &grpc.UnaryServerInfo{}, handler)
+			require.NoError(t, err)
+			require.Equal(t, s, resp)
+		}
+	})
+
+	t.Run("rate limited returns ResourceExhausted", func(t *testing.T) {
+		t.Parallel()
+		limiter := rate.NewLimiter(rate.Limit(1), 1)
+		interceptor := RateLimitInterceptor(limiter)
+
+		// First request should succeed (uses the burst)
+		resp, err := interceptor(t.Context(), nil, &grpc.UnaryServerInfo{}, handler)
+		require.NoError(t, err)
+		require.Equal(t, "success", resp)
+
+		// Second immediate request should be rate limited
+		_, err = interceptor(t.Context(), nil, &grpc.UnaryServerInfo{}, handler)
+		require.Error(t, err)
+
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		require.Equal(t, codes.ResourceExhausted, st.Code())
+		require.Equal(t, "rate limit exceeded", st.Message())
+	})
+
+	t.Run("handler errors are passed through", func(t *testing.T) {
+		t.Parallel()
+		limiter := rate.NewLimiter(rate.Inf, 1)
+		interceptor := RateLimitInterceptor(limiter)
+		expectedErr := status.Error(codes.Internal, "handler error")
+		handlerRetErr := func(_ context.Context, _ any) (any, error) {
+			return nil, expectedErr
+		}
+
+		resp, err := interceptor(t.Context(), nil, &grpc.UnaryServerInfo{}, handlerRetErr)
+		require.Nil(t, resp)
+		require.Equal(t, expectedErr, err)
+	})
+
+	t.Run("concurrent requests exhaust burst and get rate limited", func(t *testing.T) {
+		t.Parallel()
+		limiter := rate.NewLimiter(rate.Limit(5), 5)
+		interceptor := RateLimitInterceptor(limiter)
+
+		successCount := 0
+		rateLimitedCount := 0
+
+		// Make 10 immediate requests - first 5 should succeed, rest should be rate limited
+		for range 10 {
+			_, err := interceptor(t.Context(), nil, &grpc.UnaryServerInfo{}, handler)
+			if err != nil {
+				st, ok := status.FromError(err)
+				if ok && st.Code() == codes.ResourceExhausted {
+					rateLimitedCount++
+				}
+			} else {
+				successCount++
+			}
+		}
+
+		require.Equal(t, 5, successCount)
+		require.Equal(t, 5, rateLimitedCount)
+	})
+}


### PR DESCRIPTION
#### Type of change

- Improvement (improvement to code, performance, etc)
 
#### Description

We currently lack rate limiting for unary gRPC calls, leaving the service vulnerable to resource exhaustion and DoS attacks. This commit implements a mechanism to throttle unary requests based on a configurable threshold (e.g., requests per second and burst).

#### Related issues

  - resolves #233 