### PR TITLE
[loadgen] Create orderer node for each orderer endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ docker/runner/out
 test/**/*.log
 
 .DS_Store
+venv

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/hyperledger/fabric-lib-go v1.1.3-0.20240523144151-25edd1eaf5f5
 	github.com/hyperledger/fabric-protos-go-apiv2 v0.3.7
-	github.com/hyperledger/fabric-x-common v0.0.0-20260109131417-74e7c6d06351
+	github.com/hyperledger/fabric-x-common v0.0.0-20260119153301-8898987593e4
 	github.com/jackc/puddle v1.3.0
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/onsi/gomega v1.38.2

--- a/go.sum
+++ b/go.sum
@@ -918,8 +918,8 @@ github.com/hyperledger/fabric-lib-go v1.1.3-0.20240523144151-25edd1eaf5f5 h1:RPW
 github.com/hyperledger/fabric-lib-go v1.1.3-0.20240523144151-25edd1eaf5f5/go.mod h1:SHNCq8AB0VpHAmvJEtdbzabv6NNV1F48JdmDihasBjc=
 github.com/hyperledger/fabric-protos-go-apiv2 v0.3.7 h1:sQ5qv8vQQfwewa1JlCiSCC8dLElmaU2/frLolpgibEY=
 github.com/hyperledger/fabric-protos-go-apiv2 v0.3.7/go.mod h1:bJnwzfv03oZQeCc863pdGTDgf5nmCy6Za3RAE7d2XsQ=
-github.com/hyperledger/fabric-x-common v0.0.0-20260109131417-74e7c6d06351 h1:aD0fj/b7SwCaJFwdrk8dI26PSmOSfYG+FUNkUii2TpA=
-github.com/hyperledger/fabric-x-common v0.0.0-20260109131417-74e7c6d06351/go.mod h1:XtzBYOhJ0cLKdsvHBko5qzmPSLeCxgARPzWnqkXz9h0=
+github.com/hyperledger/fabric-x-common v0.0.0-20260119153301-8898987593e4 h1:IWJwS7HFb0gdvuCXOZF4Q5qeTELlhJHq2gihq/rgKiA=
+github.com/hyperledger/fabric-x-common v0.0.0-20260119153301-8898987593e4/go.mod h1:XtzBYOhJ0cLKdsvHBko5qzmPSLeCxgARPzWnqkXz9h0=
 github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=

--- a/mock/test_exports.go
+++ b/mock/test_exports.go
@@ -66,8 +66,8 @@ func StartMockCoordinatorService(t *testing.T) (
 	return mockCoordinator, coordinatorGrpc
 }
 
-// StartMockCoordinatorServiceServerConfig starts a mock coordinator service using the given config.
-func StartMockCoordinatorServiceServerConfig(
+// StartMockCoordinatorServiceFromServerConfig starts a mock coordinator service using the given config.
+func StartMockCoordinatorServiceFromServerConfig(
 	t *testing.T,
 	coordService *Coordinator,
 	sc *connection.ServerConfig,

--- a/service/sidecar/sidecar_test.go
+++ b/service/sidecar/sidecar_test.go
@@ -471,7 +471,7 @@ func TestSidecarRecoveryAfterCoordinatorFailure(t *testing.T) {
 	txs := env.sendGeneratedTransactionsForBlock(ctx, t)
 
 	t.Log("4. Restart the coordinator and validate processing block 11")
-	env.coordinatorServer = mock.StartMockCoordinatorServiceServerConfig(t, env.coordinator,
+	env.coordinatorServer = mock.StartMockCoordinatorServiceFromServerConfig(t, env.coordinator,
 		env.coordinatorServer.Configs[0])
 
 	monitoring.RequireConnectionMetrics(
@@ -503,7 +503,7 @@ func TestSidecarStartWithoutCoordinator(t *testing.T) {
 	)
 
 	t.Log("Restart the coordinator")
-	env.coordinatorServer = mock.StartMockCoordinatorServiceServerConfig(t, env.coordinator,
+	env.coordinatorServer = mock.StartMockCoordinatorServiceFromServerConfig(t, env.coordinator,
 		env.coordinatorServer.Configs[0])
 	monitoring.RequireConnectionMetrics(
 		t, coordLabel,


### PR DESCRIPTION
#### Type of change

- Improvement (improvement to code, performance, etc)
 
#### Description

- Create an orderer node for each orderer endpoint using the endpoint's host as the SANS for this node.

#### Related issues

- resolves #247 