### PR TITLE
[Copilot Autofix] Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ on:
   pull_request:
     branches: ["**"]
 
+permissions:
+  contents: read
+
 env:
   DB_DEPLOYMENT: local
 


### PR DESCRIPTION
Potential fix for [https://github.com/hyperledger/fabric-x-committer/security/code-scanning/11](https://github.com/hyperledger/fabric-x-committer/security/code-scanning/11)

In general, the problem is fixed by explicitly adding a `permissions` block that restricts the `GITHUB_TOKEN` to the least privilege needed. For simple CI/test/build jobs that only need to read the repository contents, `permissions: contents: read` at the job or workflow level is a good default. Jobs that require more (like the `analyze` CodeQL job) can override or extend permissions as needed.

The best fix here, without changing existing behavior, is to add a workflow-level `permissions` block setting `contents: read`. This will apply to all jobs that don’t already have permissions defined. The `analyze` job already has its own `permissions` block, so it will be unaffected. The `container-test` job (and the other test jobs) will then use a restricted, read-only token instead of inheriting possibly broader repository defaults. Concretely, in `.github/workflows/ci.yml`, add:

```yaml
permissions:
  contents: read
```

just after the `on:` block (after line 11/12), before the `env:` section. No additional imports or dependencies are needed; this is pure YAML configuration for GitHub Actions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
