### PR TITLE
[sidecar] sync for processCommittedBlockInOrder()

### DIFF
--- a/service/sidecar/mapping_test.go
+++ b/service/sidecar/mapping_test.go
@@ -69,5 +69,6 @@ func TestBlockMapping(t *testing.T) {
 	require.Equal(t, expectedBlockSize+1, txIDToHeight.Count())
 	require.Len(t, mappedBlock.block.Txs, expectedBlockSize-expectedRejected)
 	require.Len(t, mappedBlock.block.Rejected, expectedRejected)
-	require.Equal(t, expectedBlockSize, mappedBlock.withStatus.pendingCount)
+	//nolint:gosec // int -> int32
+	require.Equal(t, int32(expectedBlockSize), mappedBlock.withStatus.pendingCount.Load())
 }

--- a/service/sidecar/notify_test.go
+++ b/service/sidecar/notify_test.go
@@ -85,7 +85,7 @@ func BenchmarkNotifier(b *testing.B) {
 	for notifiedCount < expectedCount {
 		res, ok := q.ReadWithTimeout(5 * time.Minute)
 		if !ok {
-			b.Fatalf("expected notification")
+			b.Fatal("expected notification")
 		}
 		notifiedCount += len(res.TxStatusEvents)
 	}


### PR DESCRIPTION
#### Type of change

- Bug fix
 
#### Description

While each individual operation in `processCommittedBlockInOrder()` is thread-safe, the combination is not. Concurrent execution of this method from `sendBlocksToCoordinator()` and `processStatusBatch()` can cause:

1. Both goroutines load the same `nextBlockNumberToBeCommitted` (e.g., 100)
2. Both load the same block from the SyncMap, both see `pendingCount` == 0
3. Both delete and both increment — `nextBlockNumberToBeCommitted` jumps from 100 to 102, skipping block 101
4. Both write the same block to `outgoingCommittedBlock` — try to commit block 100 twice to the ledger but it would result in an error and the sidecar executable would eventually stops.

This commit introduces mutex to synchronize the execution of `processingCommittedBlockInOrder()`. Further, it makes the `pendingCount` as atomic Int.

#### Related issues

  - resolves #269 