### PR TITLE
[sidecar] sync interval for block commit

### DIFF
--- a/cmd/config/app_config_test.go
+++ b/cmd/config/app_config_test.go
@@ -119,7 +119,8 @@ func TestReadConfigSidecar(t *testing.T) {
 			},
 			Committer: newClientConfigWithDefaultTLS("coordinator", 9001),
 			Ledger: sidecar.LedgerConfig{
-				Path: "/root/sc/ledger",
+				Path:         "/root/sc/ledger",
+				SyncInterval: 100,
 			},
 			Notification: sidecar.NotificationServiceConfig{
 				MaxTimeout: 10 * time.Minute,

--- a/cmd/config/samples/sidecar.yaml
+++ b/cmd/config/samples/sidecar.yaml
@@ -80,6 +80,10 @@ committer:
       - /client-certs/ca-certificate.pem
 ledger:
   path: /root/sc/ledger
+  # How often the block store fsyncs to durable storage. Every Nth block triggers
+  # a full sync; intermediate blocks are written without fsync. Set to 0 or 1 to
+  # sync every block. Un-synced blocks are recoverable from the orderer on crash.
+  sync-interval: 100
 notification:
   max-timeout: 10m
   # Maximum number of concurrent notification streams allowed.

--- a/cmd/config/templates/sidecar.yaml
+++ b/cmd/config/templates/sidecar.yaml
@@ -64,6 +64,7 @@ committer:
 
 ledger:
   path: {{ .LedgerPath }}
+  sync-interval: 100
 
 notification:
   max-timeout: 10m

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.4
 	github.com/hyperledger/fabric-lib-go v1.1.3-0.20240523144151-25edd1eaf5f5
 	github.com/hyperledger/fabric-protos-go-apiv2 v0.3.7
-	github.com/hyperledger/fabric-x-common v0.1.0
+	github.com/hyperledger/fabric-x-common v0.0.0-20260205084643-cf16c9cc0474
 	github.com/jackc/puddle v1.3.0
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/onsi/gomega v1.38.2

--- a/go.sum
+++ b/go.sum
@@ -1123,8 +1123,8 @@ github.com/hyperledger/fabric-lib-go v1.1.3-0.20240523144151-25edd1eaf5f5 h1:RPW
 github.com/hyperledger/fabric-lib-go v1.1.3-0.20240523144151-25edd1eaf5f5/go.mod h1:SHNCq8AB0VpHAmvJEtdbzabv6NNV1F48JdmDihasBjc=
 github.com/hyperledger/fabric-protos-go-apiv2 v0.3.7 h1:sQ5qv8vQQfwewa1JlCiSCC8dLElmaU2/frLolpgibEY=
 github.com/hyperledger/fabric-protos-go-apiv2 v0.3.7/go.mod h1:bJnwzfv03oZQeCc863pdGTDgf5nmCy6Za3RAE7d2XsQ=
-github.com/hyperledger/fabric-x-common v0.1.0 h1:JLT2e7LLFC3Trf2M84Fz2SCunTu/p3P41+nybKm3FnY=
-github.com/hyperledger/fabric-x-common v0.1.0/go.mod h1:+VPYRRCGAZo7+rlT55yK3aRmUbRJwQGlWg7lz0SLdMY=
+github.com/hyperledger/fabric-x-common v0.0.0-20260205084643-cf16c9cc0474 h1:HheYxR3uyVuaM42b2fH16jMOu2777vPC6QUpYK3wbsQ=
+github.com/hyperledger/fabric-x-common v0.0.0-20260205084643-cf16c9cc0474/go.mod h1:+VPYRRCGAZo7+rlT55yK3aRmUbRJwQGlWg7lz0SLdMY=
 github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=

--- a/service/sidecar/config.go
+++ b/service/sidecar/config.go
@@ -41,6 +41,10 @@ type (
 	// LedgerConfig holds the ledger path.
 	LedgerConfig struct {
 		Path string `mapstructure:"path"`
+		// SyncInterval controls how often the block store fsyncs to durable storage.
+		// A value of N means every Nth block triggers a full sync; intermediate
+		// blocks are written without fsync. A value of 0 or 1 means every block is synced.
+		SyncInterval uint64 `mapstructure:"sync-interval"`
 	}
 
 	// NotificationServiceConfig holds the parameters for notifications.

--- a/service/sidecar/ledger_service_test.go
+++ b/service/sidecar/ledger_service_test.go
@@ -30,7 +30,7 @@ func TestLedgerService(t *testing.T) {
 	channelID := "ch1"
 
 	metrics := newPerformanceMetrics()
-	ls, err := newLedgerService(channelID, ledgerPath, metrics)
+	ls, err := newLedgerService(channelID, ledgerPath, 0, metrics)
 	require.NoError(t, err)
 	t.Cleanup(ls.close)
 

--- a/service/sidecar/sidecar.go
+++ b/service/sidecar/sidecar.go
@@ -83,7 +83,7 @@ func New(c *Config) (*Service, error) {
 
 	// 3. Deliver the block with status to client.
 	logger.Infof("Create ledger service for channel %s", c.Orderer.ChannelID)
-	ledgerService, err := newLedgerService(c.Orderer.ChannelID, c.Ledger.Path, metrics)
+	ledgerService, err := newLedgerService(c.Orderer.ChannelID, c.Ledger.Path, c.Ledger.SyncInterval, metrics)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create ledger: %w", err)
 	}

--- a/service/sidecar/sidecar_test.go
+++ b/service/sidecar/sidecar_test.go
@@ -428,6 +428,7 @@ func TestSidecarRecovery(t *testing.T) {
 	env.sidecar.ledgerService, err = newLedgerService(
 		env.config.Orderer.ChannelID,
 		env.config.Ledger.Path,
+		0,
 		newPerformanceMetrics(),
 	)
 	require.NoError(t, err)


### PR DESCRIPTION
#### Type of change

- Improvement (improvement to code, performance, etc)
 
#### Description

Allows skipping fsync on intermediate blocks to improve write throughput. Un-synced blocks are recoverable from the orderer on crash.

#### Related issues

  - resolves #305 