### PR TITLE
[vc] split tables into predefined number of tablets

### DIFF
--- a/.sqlfluff
+++ b/.sqlfluff
@@ -6,7 +6,7 @@
 
 # Supported dialects https://docs.sqlfluff.com/en/stable/perma/dialects.html
 # Or run 'sqlfluff dialects'
-dialect = snowflake
+dialect = postgres
 
 # One of [raw|jinja|python|placeholder]
 templater = placeholder
@@ -15,7 +15,8 @@ templater = placeholder
 # See https://docs.sqlfluff.com/en/stable/perma/rule_disabling.html
 # AM04 (ambiguous.column_count) and ST06 (structure.column_order) are
 # two of the more controversial rules included to illustrate usage.
-exclude_rules = ambiguous.column_count, structure.column_order, LT01, LT02
+# RF04 is excluded because we use reserved keywords as column names (key, value, references)
+exclude_rules = ambiguous.column_count, structure.column_order, LT01, LT02, RF04
 
 # The standard max_line_length is 80 in line with the convention of
 # other tools and several style guides. Many projects however prefer
@@ -38,7 +39,7 @@ project_dir = ./
 [sqlfluff:indentation]
 # While implicit indents are not enabled by default. Many of the
 # SQLFluff maintainers do use them in their projects.
-allow_implicit_indents = True
+implicit_indents = allow
 
 [sqlfluff:rules:aliasing.length]
 min_alias_length = 3
@@ -73,6 +74,11 @@ preferred_not_equal_style = c_style
 
 [sqlfluff:templater:placeholder]
 param_regex = \$\{(?P<param_name>[\w_]+)\}
+# SQL templates use Go embed + strings.ReplaceAll at runtime (see service/vc/dbinit.go).
+# These placeholder values produce valid PostgreSQL so sqlfluff can parse and lint the templates.
+NAMESPACE_ID = placeholder_namespace
+# Empty: strips YugabyteDB-specific "SPLIT INTO N TABLETS" clause, leaving standard PostgreSQL.
+SPLIT_INTO_TABLETS =
 
 [sqlfluff:rules]
 allow_scalar = True

--- a/cmd/config/samples/vc.yaml
+++ b/cmd/config/samples/vc.yaml
@@ -41,6 +41,16 @@ database:
   max-connections: 10 # The maximum size of the connection pool
   min-connections: 5 # The minimum size of the connection pool.
   load-balance: false # Should be enabled for DB cluster.
+
+  # Number of tablets to pre-split each table into at creation time (YugabyteDB only).
+  # Pre-splitting distributes a table's data across multiple tablet servers from the start,
+  # preventing the "hot tablet" bottleneck where a single tablet handles all initial writes
+  # before YugabyteDB's automatic splitting kicks in, which causes unpredictable latency spikes.
+  # Recommended value: set to the number of tablet servers in the cluster, or a small multiple
+  # of it (e.g., 1x-2x the number of tservers), so each tserver gets an equal share of tablets.
+  # For example, with 3 tservers, set table-pre-split-tablets to 3 or 6.
+  # When the underlying database is PostgreSQL, this setting is automatically ignored even if set.
+  table-pre-split-tablets: 0
   retry: # The exponential backoff retry strategy for database operation.
          # This strategy increases the delay between retry attempts exponentially.
          # When using YugabyteDB as the backend, it is needed to handle retryable errors.

--- a/service/vc/config.go
+++ b/service/vc/config.go
@@ -24,15 +24,16 @@ type Config struct {
 
 // DatabaseConfig is the configuration for the database.
 type DatabaseConfig struct {
-	Endpoints      []*connection.Endpoint   `mapstructure:"endpoints"`
-	Username       string                   `mapstructure:"username"`
-	Password       string                   `mapstructure:"password"`
-	Database       string                   `mapstructure:"database"`
-	MaxConnections int32                    `mapstructure:"max-connections"`
-	MinConnections int32                    `mapstructure:"min-connections"`
-	LoadBalance    bool                     `mapstructure:"load-balance"`
-	Retry          *connection.RetryProfile `mapstructure:"retry"`
-	TLS            dbconn.DatabaseTLSConfig `mapstructure:"tls"`
+	Endpoints            []*connection.Endpoint   `mapstructure:"endpoints"`
+	Username             string                   `mapstructure:"username"`
+	Password             string                   `mapstructure:"password"`
+	Database             string                   `mapstructure:"database"`
+	MaxConnections       int32                    `mapstructure:"max-connections"`
+	MinConnections       int32                    `mapstructure:"min-connections"`
+	LoadBalance          bool                     `mapstructure:"load-balance"`
+	Retry                *connection.RetryProfile `mapstructure:"retry"`
+	TLS                  dbconn.DatabaseTLSConfig `mapstructure:"tls"`
+	TablePreSplitTablets int                      `mapstructure:"table-pre-split-tablets"`
 }
 
 // DataSourceName returns the data source name of the database.

--- a/service/vc/create_namespace_tmpl.sql
+++ b/service/vc/create_namespace_tmpl.sql
@@ -19,7 +19,7 @@ CREATE TABLE IF NOT EXISTS ns_${NAMESPACE_ID}
     key     BYTEA                    NOT NULL PRIMARY KEY,
     value   BYTEA  DEFAULT NULL,
     version BIGINT DEFAULT 0::BIGINT NOT NULL CHECK (version >= 0)
-);
+)${SPLIT_INTO_TABLETS};
 
 CREATE OR REPLACE FUNCTION insert_ns_${NAMESPACE_ID}(
     IN _keys BYTEA[],

--- a/service/vc/dbinit_test.go
+++ b/service/vc/dbinit_test.go
@@ -43,6 +43,38 @@ func TestDBInit(t *testing.T) {
 	}
 }
 
+func TestFmtSplitIntoTablets(t *testing.T) {
+	t.Parallel()
+
+	t.Run("init_database_tmpl with tablets", func(t *testing.T) {
+		t.Parallel()
+		result := fmtSplitIntoTablets(dbInitSQLStmt, 4)
+		require.Contains(t, result, "SPLIT INTO 4 TABLETS")
+		require.NotContains(t, result, splitIntoTabletsPlaceholder)
+	})
+
+	t.Run("init_database_tmpl without tablets", func(t *testing.T) {
+		t.Parallel()
+		result := fmtSplitIntoTablets(dbInitSQLStmt, 0)
+		require.NotContains(t, result, "SPLIT INTO")
+		require.NotContains(t, result, splitIntoTabletsPlaceholder)
+	})
+
+	t.Run("create_namespace_tmpl with tablets", func(t *testing.T) {
+		t.Parallel()
+		result := fmtSplitIntoTablets(createNamespaceSQLStmt, 3)
+		require.Contains(t, result, "SPLIT INTO 3 TABLETS")
+		require.NotContains(t, result, splitIntoTabletsPlaceholder)
+	})
+
+	t.Run("create_namespace_tmpl without tablets", func(t *testing.T) {
+		t.Parallel()
+		result := fmtSplitIntoTablets(createNamespaceSQLStmt, 0)
+		require.NotContains(t, result, "SPLIT INTO")
+		require.NotContains(t, result, splitIntoTabletsPlaceholder)
+	})
+}
+
 func TestRetry(t *testing.T) {
 	t.Parallel()
 	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Minute)

--- a/service/vc/init_database_tmpl.sql
+++ b/service/vc/init_database_tmpl.sql
@@ -10,7 +10,7 @@ CREATE TABLE IF NOT EXISTS metadata
 (
     key   BYTEA NOT NULL PRIMARY KEY,
     value BYTEA
-);
+)${SPLIT_INTO_TABLETS};
 
 INSERT INTO metadata
 VALUES ('last committed block number', NULL)
@@ -21,7 +21,7 @@ CREATE TABLE IF NOT EXISTS tx_status
     tx_id  BYTEA NOT NULL PRIMARY KEY,
     status INTEGER,
     height BYTEA NOT NULL
-);
+)${SPLIT_INTO_TABLETS};
 
 CREATE OR REPLACE FUNCTION insert_tx_status(
     IN _tx_ids BYTEA[],


### PR DESCRIPTION
#### Type of change

- Improvement (improvement to code, performance, etc)
 
#### Description

When a new table is created, YugabyteDB starts with a single tablet that handles all initial writes. Auto-splitting only kicks in after the tablet reaches a size threshold (~1 GB by default), meaning the first N transactions all funnel through one tablet on one tserver — creating a severe bottleneck during the critical warm-up phase.

By pre-splitting tables at CREATE TABLE time (e.g., SPLIT INTO 3 TABLETS for a 3-node cluster), data is hash-distributed across all tservers from the very first write. This converts cold-start throughput from single-tserver-bound to cluster-wide from block 1.

This applies to all three table types: metadata, tx_status, and per-namespace state tables (ns_*). The setting auto-detects the DB backend and is silently ignored on PostgreSQL, which has no tablet concept.

By default, we are not enabling the table pre-split in config so that the test can run without stress. 

#### Related issues

  - resolves #308 #61 