### PR TITLE
Refactor DB container lifecycle to use shared TestMain container

### DIFF
--- a/cmd/config/cobra_test_exports.go
+++ b/cmd/config/cobra_test_exports.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/hyperledger/fabric-x-committer/loadgen/workload"
 	"github.com/hyperledger/fabric-x-committer/mock"
-	"github.com/hyperledger/fabric-x-committer/service/vc/dbtest"
 	"github.com/hyperledger/fabric-x-committer/utils/connection"
 	"github.com/hyperledger/fabric-x-committer/utils/logging"
 	"github.com/hyperledger/fabric-x-committer/utils/test"
@@ -50,11 +49,11 @@ func StartDefaultSystem(t *testing.T) SystemConfig {
 	_, vc := mock.StartMockVCService(t, serverParams)
 	_, orderer := mock.StartMockOrderingServices(t, &mock.OrdererConfig{TestServerParameters: serverParams})
 	_, coordinator := mock.StartMockCoordinatorService(t, serverParams)
-	conn := dbtest.PrepareTestEnv(t)
 	server := connection.NewLocalHostServer(test.InsecureTLSConfig)
 	listen, err := server.Listener(t.Context())
 	require.NoError(t, err)
 	connection.CloseConnectionsLog(listen)
+
 	return SystemConfig{
 		ThisService: ServiceConfig{
 			GrpcEndpoint: &server.Endpoint,
@@ -66,8 +65,8 @@ func StartDefaultSystem(t *testing.T) SystemConfig {
 			Coordinator: ServiceConfig{GrpcEndpoint: &coordinator.Configs[0].Endpoint},
 		},
 		DB: DatabaseConfig{
-			Name:        conn.Database,
-			Endpoints:   conn.Endpoints,
+			Name:        "dummy_test_db",
+			Endpoints:   []*connection.Endpoint{connection.CreateEndpointHP("localhost", "5433")},
 			LoadBalance: false,
 		},
 		Policy: &workload.PolicyProfile{

--- a/integration/test/main_test.go
+++ b/integration/test/main_test.go
@@ -18,6 +18,7 @@ import (
 	"google.golang.org/grpc/grpclog"
 
 	"github.com/hyperledger/fabric-x-committer/integration/runner"
+	"github.com/hyperledger/fabric-x-committer/service/vc/dbtest"
 )
 
 func TestMain(m *testing.M) {
@@ -43,5 +44,6 @@ func TestMain(m *testing.M) {
 
 	// Waiting a seconds solves a bug where the binaries are not yet accessible by the filesystem.
 	time.Sleep(time.Second)
-	os.Exit(m.Run())
+
+	dbtest.RunTestMain(m)
 }

--- a/loadgen/main_test.go
+++ b/loadgen/main_test.go
@@ -1,0 +1,17 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package loadgen
+
+import (
+	"testing"
+
+	"github.com/hyperledger/fabric-x-committer/service/vc/dbtest"
+)
+
+func TestMain(m *testing.M) {
+	dbtest.RunTestMain(m)
+}

--- a/service/coordinator/main_test.go
+++ b/service/coordinator/main_test.go
@@ -1,0 +1,17 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package coordinator
+
+import (
+	"testing"
+
+	"github.com/hyperledger/fabric-x-committer/service/vc/dbtest"
+)
+
+func TestMain(m *testing.M) {
+	dbtest.RunTestMain(m)
+}

--- a/service/query/main_test.go
+++ b/service/query/main_test.go
@@ -1,0 +1,17 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package query
+
+import (
+	"testing"
+
+	"github.com/hyperledger/fabric-x-committer/service/vc/dbtest"
+)
+
+func TestMain(m *testing.M) {
+	dbtest.RunTestMain(m)
+}

--- a/service/vc/dbtest/database_setup.go
+++ b/service/vc/dbtest/database_setup.go
@@ -12,12 +12,15 @@ import (
 	"crypto/sha256"
 	"encoding/base32"
 	"fmt"
+	"log"
 	"os"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/cockroachdb/errors"
+	docker "github.com/fsouza/go-dockerclient"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
 	"github.com/hyperledger/fabric-x-committer/utils"
@@ -44,6 +47,18 @@ const (
 	deploymentTypeEnv = "DB_DEPLOYMENT"
 	databaseTypeEnv   = "DB_TYPE"
 )
+
+// sharedContainer holds the container created by SetupSharedContainer for use
+// by all tests.
+//
+// Write: SetupSharedContainer (called once from TestMain, before m.Run())
+// Read:  StartAndConnect (called from individual tests, during m.Run())
+// Write: CleanupSharedContainer (called once from TestMain, after m.Run())
+//
+// This is safe without synchronization because Go's test runner guarantees
+// that TestMain completes SetupSharedContainer before any test goroutine
+// starts, and CleanupSharedContainer runs after all test goroutines finish.
+var sharedContainer *DatabaseContainer
 
 // randDbName generates random DB name.
 // It digests the current time, the test name, and a random string to a base32 string.
@@ -83,7 +98,7 @@ func PrepareTestEnv(t *testing.T) *Connection {
 	t.Helper()
 	ctx, cancel := context.WithTimeout(t.Context(), defaultStartTimeout)
 	t.Cleanup(cancel)
-	return PrepareTestEnvWithConnection(t, StartAndConnect(ctx, t))
+	return PrepareTestEnvWithConnection(t, startAndConnect(ctx, t))
 }
 
 // PrepareTestEnvWithConnection initializes a test environment given a db connection.
@@ -110,19 +125,51 @@ func PrepareTestEnvWithConnection(t *testing.T, conn *Connection) *Connection {
 	return conn
 }
 
-// StartAndConnect connects to an existing Yugabyte instance or creates a containerized new one.
-func StartAndConnect(ctx context.Context, t *testing.T) *Connection {
+// SetupSharedContainer creates a fresh test container for the current test.
+// Call this from TestMain before m.Run(). The container uses a unique
+// name to avoid interfering with developer containers or other test runs.
+// For DB_DEPLOYMENT=local, this is a no-op (returns nil).
+//
+// Design decisions:
+//   - Unique name (UUID suffix): never touches existing containers. A developer
+//     may have a YugabyteDB container running for other purposes — we must not
+//     stop, remove, or reuse it.
+//   - Auto-assigned host port: avoids port conflicts with any other service on
+//     the host, including other test runs.
+//   - CleanupSharedContainer (called after m.Run) guarantees removal. In the
+//     rare case of SIGKILL, `make kill-test-docker` cleans up all containers
+//     matching the "sc_test" prefix.
+func SetupSharedContainer() error {
+	if getDBDeploymentFromEnv() != deploymentContainer {
+		return nil
+	}
+
+	dc := &DatabaseContainer{
+		DatabaseType: getDBTypeFromEnv(),
+		Name:         fmt.Sprintf(defaultDBDeploymentTemplateName, getDBTypeFromEnv()) + "_" + uuid.NewString()[:8],
+	}
+
+	if err := dc.start(context.Background()); err != nil {
+		return err
+	}
+
+	log.Printf("Started test container %s (image: %s)", dc.Name, dc.Image)
+	sharedContainer = dc
+	return nil
+}
+
+// startAndConnect returns a connection to the shared test container or a local
+// DB instance. The shared container must have been created by
+// SetupSharedContainer in TestMain before any test calls this function.
+func startAndConnect(ctx context.Context, t *testing.T) *Connection {
 	t.Helper()
 	dbDeployment := getDBDeploymentFromEnv()
 
 	var connOptions *Connection
 	switch dbDeployment {
 	case deploymentContainer:
-		container := DatabaseContainer{
-			DatabaseType: getDBTypeFromEnv(),
-		}
-		container.StartContainer(ctx, t)
-		connOptions = container.GetConnectionOptions(ctx, t)
+		require.NotNil(t, sharedContainer)
+		connOptions = sharedContainer.GetConnectionOptions(ctx, t)
 	case deploymentLocal:
 		connOptions = NewConnection(connection.CreateEndpointHP("localhost", defaultLocalDBPort))
 	default:
@@ -131,4 +178,38 @@ func StartAndConnect(ctx context.Context, t *testing.T) *Connection {
 	}
 	t.Logf("connection endpoints: %+v", connOptions.Endpoints)
 	return connOptions
+}
+
+// CleanupSharedContainer stops and removes the shared test container.
+// Call this from TestMain after m.Run(). It is safe to call even when no
+// container was created (e.g. DB_DEPLOYMENT=local).
+func CleanupSharedContainer() {
+	dc := sharedContainer
+	if dc == nil {
+		return
+	}
+
+	log.Printf("Stopping and removing test container %s", dc.Name)
+	if err := dc.client.StopContainer(dc.ContainerID(), 10); err != nil {
+		log.Printf("Warning: failed to stop container %s: %v", dc.Name, err)
+	}
+
+	if err := dc.client.RemoveContainer(docker.RemoveContainerOptions{
+		ID:    dc.ContainerID(),
+		Force: true,
+	}); err != nil {
+		log.Printf("Warning: failed to remove container %s: %v", dc.Name, err)
+	}
+}
+
+// RunTestMain is a convenience wrapper for TestMain functions that only need
+// the shared container lifecycle. It sets up the container, runs all tests,
+// and cleans up. For TestMain functions with additional setup (e.g. building
+// binaries), call SetupSharedContainer/CleanupSharedContainer directly.
+func RunTestMain(m *testing.M) {
+	if err := SetupSharedContainer(); err != nil {
+		log.Printf("Failed to start shared container: %v", err)
+	}
+	defer CleanupSharedContainer()
+	m.Run()
 }

--- a/service/vc/main_test.go
+++ b/service/vc/main_test.go
@@ -1,0 +1,17 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package vc
+
+import (
+	"testing"
+
+	"github.com/hyperledger/fabric-x-committer/service/vc/dbtest"
+)
+
+func TestMain(m *testing.M) {
+	dbtest.RunTestMain(m)
+}


### PR DESCRIPTION
#### Type of change

- Improvement (improvement to code, performance, etc)
 
#### Description

  - Refactor container methods to return errors instead of calling t.Fatal()
  - Add SetupSharedContainer()/CleanupSharedContainer() for TestMain
  - Use UUID-suffixed container names and auto-assigned host ports
  - Remove findContainer() — always create fresh containers
  - Move real DB setup out of StartDefaultSystem() into tests that need it

#### Related issues

  - resolves #312 