### PR TITLE
[deliver] Remove non-production parameters

### DIFF
--- a/integration/runner/runtime.go
+++ b/integration/runner/runtime.go
@@ -33,7 +33,6 @@ import (
 	"github.com/hyperledger/fabric-x-committer/service/vc/dbtest"
 	"github.com/hyperledger/fabric-x-committer/utils/apptest"
 	"github.com/hyperledger/fabric-x-committer/utils/connection"
-	"github.com/hyperledger/fabric-x-committer/utils/deliver"
 	"github.com/hyperledger/fabric-x-committer/utils/ordererconn"
 	"github.com/hyperledger/fabric-x-committer/utils/serialization"
 	"github.com/hyperledger/fabric-x-committer/utils/signature"
@@ -384,7 +383,6 @@ func (c *CommitterRuntime) startBlockDelivery(t *testing.T) {
 	t.Log("Running delivery client")
 	test.RunServiceForTest(t.Context(), t, func(ctx context.Context) error {
 		return connection.FilterStreamRPCError(c.SidecarClient.Deliver(ctx, &sidecarclient.DeliverParameters{
-			EndBlkNum:   deliver.MaxBlockNum,
 			OutputBlock: c.CommittedBlock,
 		}))
 	}, func(ctx context.Context) bool {

--- a/loadgen/adapters/sidecar_receiver.go
+++ b/loadgen/adapters/sidecar_receiver.go
@@ -46,7 +46,6 @@ func runSidecarReceiver(ctx context.Context, params *sidecarReceiverParameters) 
 	}
 	return runDeliveryReceiver(ctx, params.Res, func(gCtx context.Context, committedBlock chan *common.Block) error {
 		return ledgerReceiver.Deliver(gCtx, &sidecarclient.DeliverParameters{
-			EndBlkNum:   deliver.MaxBlockNum,
 			OutputBlock: committedBlock,
 		})
 	})
@@ -56,7 +55,6 @@ func runSidecarReceiver(ctx context.Context, params *sidecarReceiverParameters) 
 func runOrdererReceiver(ctx context.Context, res *ClientResources, client *deliver.Client) error {
 	return runDeliveryReceiver(ctx, res, func(gCtx context.Context, committedBlock chan *common.Block) error {
 		return client.Deliver(gCtx, &deliver.Parameters{
-			EndBlkNum:   deliver.MaxBlockNum,
 			OutputBlock: committedBlock,
 		})
 	})

--- a/service/sidecar/sidecar_test.go
+++ b/service/sidecar/sidecar_test.go
@@ -185,7 +185,7 @@ func newSidecarTestEnvWithTLS(
 func (env *sidecarTestEnv) startSidecarServiceAndClientAndNotificationStream(
 	ctx context.Context,
 	t *testing.T,
-	startBlkNum int64,
+	startBlkNum uint64,
 	sidecarClientCreds connection.TLSConfig,
 ) {
 	t.Helper()
@@ -202,7 +202,7 @@ func (env *sidecarTestEnv) startSidecarService(ctx context.Context, t *testing.T
 func (env *sidecarTestEnv) startSidecarClient(
 	ctx context.Context,
 	t *testing.T,
-	startBlkNum int64,
+	startBlkNum uint64,
 	sidecarClientCreds connection.TLSConfig,
 ) {
 	t.Helper()

--- a/service/sidecar/sidecarclient/client.go
+++ b/service/sidecar/sidecarclient/client.go
@@ -35,9 +35,8 @@ type (
 	// DeliverParameters needed for deliver to run.
 	// This is copy of deliver.Parameters to allow easy divergence in the future.
 	DeliverParameters struct {
-		StartBlkNum int64
-		EndBlkNum   uint64
-		OutputBlock chan<- *common.Block
+		NextBlockNum uint64
+		OutputBlock  chan<- *common.Block
 	}
 
 	// ledgerDeliverStream implements deliver.Stream.
@@ -91,9 +90,8 @@ func (c *Client) CloseConnections() {
 // This is a wrapper for CftClient.Deliver to allow easy divergence in the future.
 func (c *Client) Deliver(ctx context.Context, config *DeliverParameters) error {
 	return c.CftClient.Deliver(ctx, &deliver.Parameters{
-		StartBlkNum: config.StartBlkNum,
-		EndBlkNum:   config.EndBlkNum,
-		OutputBlock: config.OutputBlock,
+		NextBlockNum: config.NextBlockNum,
+		OutputBlock:  config.OutputBlock,
 	})
 }
 

--- a/service/sidecar/sidecarclient/test_exports.go
+++ b/service/sidecar/sidecarclient/test_exports.go
@@ -14,7 +14,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/hyperledger/fabric-x-committer/utils/connection"
-	"github.com/hyperledger/fabric-x-committer/utils/deliver"
 	"github.com/hyperledger/fabric-x-committer/utils/test"
 )
 
@@ -23,7 +22,7 @@ func StartSidecarClient(
 	ctx context.Context,
 	t *testing.T,
 	config *Parameters,
-	startBlkNum int64,
+	startBlkNum uint64,
 ) chan *common.Block {
 	t.Helper()
 	receivedBlocksFromLedgerService := make(chan *common.Block, 10)
@@ -32,9 +31,8 @@ func StartSidecarClient(
 	test.RunServiceForTest(ctx, t, func(ctx context.Context) error {
 		return connection.FilterStreamRPCError(deliverClient.Deliver(ctx,
 			&DeliverParameters{
-				StartBlkNum: startBlkNum,
-				EndBlkNum:   deliver.MaxBlockNum,
-				OutputBlock: receivedBlocksFromLedgerService,
+				NextBlockNum: startBlkNum,
+				OutputBlock:  receivedBlocksFromLedgerService,
 			},
 		))
 	}, nil)

--- a/utils/deliver/client_test.go
+++ b/utils/deliver/client_test.go
@@ -68,9 +68,8 @@ func TestBroadcastDeliver(t *testing.T) {
 			outputBlocksChan := make(chan *common.Block, 100)
 			go func() {
 				err = client.Deliver(ctx, &deliver.Parameters{
-					StartBlkNum: 0,
-					EndBlkNum:   deliver.MaxBlockNum,
-					OutputBlock: outputBlocksChan,
+					NextBlockNum: 0,
+					OutputBlock:  outputBlocksChan,
 				})
 				assert.ErrorIs(t, err, context.Canceled)
 			}()


### PR DESCRIPTION
#### Type of change

- Improvement (improvement to code, performance, etc)
 
#### Description

- Verify block order in delivery client
- Remove end block number
- Rename start block number to next block number and change to `uint64`
- Modify the sidecar to avoid the need for "end block number", by moving the ledger recovery to the relay 

#### Related issues

- resolves #360 
- resolves #362
