### PR TITLE
[sidecar/verifier] reject transactions with empty endorsements

### DIFF
--- a/service/sidecar/sidecar_test.go
+++ b/service/sidecar/sidecar_test.go
@@ -750,6 +750,7 @@ func makeValidTx(t *testing.T, chanID string) *servicepb.LoadGenTx {
 			NsVersion:   0,
 			BlindWrites: []*applicationpb.Write{{Key: utils.MustRead(rand.Reader, 32)}},
 		}},
+		Endorsements: dummyEndorsements(1),
 	})
 }
 

--- a/utils/signature/verify.go
+++ b/utils/signature/verify.go
@@ -132,6 +132,9 @@ func (*keyVerifier) UpdateIdentities(msp.IdentityDeserializer) error {
 
 // Verify evaluates the endorsements against the data for keyVerifier.
 func (v *keyVerifier) Verify(data []byte, endorsements []*applicationpb.EndorsementWithIdentity) error {
+	if len(endorsements) == 0 {
+		return errors.New("no endorsements provided for key-based verification")
+	}
 	digest := sha256.Sum256(data)
 	return v.verifyDigest(digest[:], endorsements[0].Endorsement)
 }
@@ -166,8 +169,14 @@ func (v *channelPolicyVerifier) Verify(data []byte, endorsements []*applicationp
 
 // evaluateEndorsements constructs SignedData from endorsements and evaluates them against a policy.
 func evaluateEndorsements(p policies.Policy, data []byte, endorsements []*applicationpb.EndorsementWithIdentity) error {
+	if len(endorsements) == 0 {
+		return errors.New("no endorsements provided for MSP-based verification")
+	}
 	signedData := make([]*protoutil.SignedData, len(endorsements))
 	for i, s := range endorsements {
+		if s.Identity == nil {
+			return errors.New("endorsement has nil identity")
+		}
 		signedData[i] = &protoutil.SignedData{
 			Data:      data,
 			Identity:  s.Identity,


### PR DESCRIPTION
#### Type of change

- Bug fix
 
#### Description

The keyVerifier.Verify method panicked when processing a namespace transaction with a key-based policy but no endorsements, due to an unguarded endorsements[0] access on an empty slice.

- Sidecar: verifyTxForm now validates that each namespace has at least one endorsement, rejecting as MALFORMED_MISSING_SIGNATURE
- Verifier: keyVerifier.Verify returns a descriptive error instead of panicking on empty endorsements and empty identities.

#### Related issues

  - resolves #343 