### PR TITLE
fix TestCommitterReleaseImagesWithTLS

### DIFF
--- a/service/vc/dbtest/container.go
+++ b/service/vc/dbtest/container.go
@@ -315,7 +315,7 @@ func (dc *DatabaseContainer) ExposePort(port string) {
 	if dc.PortBinds == nil {
 		dc.PortBinds = make(map[docker.Port][]docker.PortBinding)
 	}
-	dc.PortBinds[p] = []docker.PortBinding{{HostIP: "0.0.0.0", HostPort: ""}}
+	dc.PortBinds[p] = []docker.PortBinding{{HostIP: "0.0.0.0", HostPort: "0"}}
 }
 
 // GetHostMappedEndpoint inspects the container and returns a host-accessible endpoint


### PR DESCRIPTION
#### Type of change

- Bug fix
 
#### Description

Root cause: ExposePort() used HostPort: "" with go-dockerclient's PortBinding, which has json:"HostPort,omitempty". The omitempty tag drops the empty string during JSON serialization, so Docker never receives a HostPort field and defaults to binding the container's own port number (5433) on the host. When parallel subtests each try to bind host port 5433, only the first wins.

Fix: HostPort: "" → HostPort: "0". The string "0" explicitly tells Docker to auto-assign an ephemeral port, and being non-empty, it survives omitempty serialization.

#### Related issues

  - resolves #375 