### PR TITLE
add connection-reset to streamEnd filter

### DIFF
--- a/utils/connection/client_util.go
+++ b/utils/connection/client_util.go
@@ -56,7 +56,9 @@ type (
 
 var logger = flogging.MustGetLogger("grpc-connection")
 
-var knownConnectionIssues = regexp.MustCompile(`(?i)EOF|connection\s+refused|closed\s+network\s+connection`)
+var knownConnectionIssues = regexp.MustCompile(
+	`(?i)EOF|connection\s+refused|closed\s+network\s+connection|connection\s+reset`,
+)
 
 // NewLoadBalancedConnection creates a connection with load balancing between the endpoints
 // in the given config.

--- a/utils/connection/client_util_test.go
+++ b/utils/connection/client_util_test.go
@@ -304,6 +304,16 @@ func TestFilterStreamRPCError(t *testing.T) {
 		// This returns either codes.Canceled or codes.Unavailable (EOF).
 		requireNoWrappedError(t, err)
 	})
+
+	t.Run("connection reset by peer", func(t *testing.T) {
+		t.Parallel()
+		// Synthetic error matching the exact gRPC message observed when a server
+		// sends a TCP RST before the client-side context cancellation propagates.
+		err := status.Error(codes.Unavailable,
+			"error reading from server: read tcp 127.0.0.1:56918->127.0.0.1:41275: read: connection reset by peer",
+		)
+		requireNoWrappedError(t, err)
+	})
 }
 
 func requireNoWrappedError(t *testing.T, err error) {


### PR DESCRIPTION
#### Type of change

- Bug fix
 
#### Description

When a server sends a TCP RST before the client-side context cancellation propagates, the IsStreamEnd function treats this as an internal error instead of a stream ending error. This has resulted in flakiness in several loadgen tests.


#### Related issues

  - resolves #373 