### PR TITLE
[integration-test] sidecar block query rate limit

### DIFF
--- a/cmd/config/templates/sidecar.yaml
+++ b/cmd/config/templates/sidecar.yaml
@@ -19,6 +19,17 @@ server:
     enforcement-policy:
       min-time: 60s
       permit-without-stream: false
+  {{- if .RateLimit }}
+  # Rate limiting configuration for unary gRPC endpoints.
+  # Uses a token bucket algorithm to limit the number of requests per second.
+  rate-limit:
+    # Maximum number of requests per second allowed.
+    # Set to 0 to disable rate limiting.
+    requests-per-second: {{ .RateLimit.RequestsPerSecond }}
+    # Maximum number of requests allowed in a single burst.
+    # Must be greater than 0 and less than or equal to requests-per-second.
+    burst: {{ .RateLimit.Burst }}
+  {{- end }}
 monitoring:
   endpoint: {{ .ThisService.MetricsEndpoint | default "localhost:0" }}
   tls:


### PR DESCRIPTION
#### Type of change

- Test update
 
#### Description

Test the rate limiting for block query apis

#### Related issues

  - partially handles #370  