### PR TITLE
[ci] Retrieve latest packages lists for apt-get

### DIFF
--- a/scripts/install-dev-dependencies.sh
+++ b/scripts/install-dev-dependencies.sh
@@ -45,8 +45,9 @@ echo
 echo "Installing platform-specific packages"
 case "$(uname -s)" in
 Linux*)
-  if which apt >/dev/null 2>&1; then
-    sudo apt install -y libprotobuf-dev yamllint
+  if which apt-get >/dev/null 2>&1; then
+    sudo apt-get update
+    sudo apt-get install -y libprotobuf-dev yamllint
   else
     ${PYTHON_CMD:-python3} -m pip install yamllint
   fi


### PR DESCRIPTION
#### Type of change

- Test update
 
#### Description

- Using `apt-get` instead of `apt`. `apt-get` should be used for scripts. `apt` should be used for CLI.
- Retrieve latest packages lists for `apt-get`
