### PR TITLE
[sidecar] input validation for block query APIs

### DIFF
--- a/service/sidecar/block_query.go
+++ b/service/sidecar/block_query.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"strings"
 
+	"github.com/cockroachdb/errors"
 	"github.com/hyperledger/fabric-protos-go-apiv2/common"
 	"github.com/hyperledger/fabric-x-common/api/committerpb"
 	"github.com/hyperledger/fabric-x-common/common/ledger/blkstorage"
@@ -17,6 +18,9 @@ import (
 
 	"github.com/hyperledger/fabric-x-committer/utils/grpcerror"
 )
+
+// ErrEmptyTxID is returned when a transaction ID query is called with an empty tx_id.
+var ErrEmptyTxID = errors.New("tx_id must not be empty")
 
 // blockQuery implements committerpb.BlockQueryServiceServer by delegating
 // read-only queries directly to the underlying block store.
@@ -50,6 +54,9 @@ func (s *blockQuery) GetBlockByNumber(_ context.Context, req *committerpb.BlockN
 
 // GetBlockByTxID retrieves the block that contains the specified transaction.
 func (s *blockQuery) GetBlockByTxID(_ context.Context, req *committerpb.TxID) (*common.Block, error) {
+	if req.GetTxId() == "" {
+		return nil, grpcerror.WrapInvalidArgument(ErrEmptyTxID)
+	}
 	block, err := s.store.RetrieveBlockByTxID(req.GetTxId())
 	if err != nil {
 		return nil, wrapQueryError(err)
@@ -59,6 +66,9 @@ func (s *blockQuery) GetBlockByTxID(_ context.Context, req *committerpb.TxID) (*
 
 // GetTxByID retrieves the transaction envelope for the specified transaction ID.
 func (s *blockQuery) GetTxByID(_ context.Context, req *committerpb.TxID) (*common.Envelope, error) {
+	if req.GetTxId() == "" {
+		return nil, grpcerror.WrapInvalidArgument(ErrEmptyTxID)
+	}
 	envelope, err := s.store.RetrieveTxByID(req.GetTxId())
 	if err != nil {
 		return nil, wrapQueryError(err)

--- a/service/sidecar/block_query_test.go
+++ b/service/sidecar/block_query_test.go
@@ -64,6 +64,13 @@ func TestBlockQuery(t *testing.T) {
 		require.Equal(t, uint64(1), block.GetHeader().GetNumber())
 	})
 
+	t.Run("GetBlockByTxID_EmptyTxID", func(t *testing.T) {
+		t.Parallel()
+		_, err := client.GetBlockByTxID(t.Context(), &committerpb.TxID{TxId: ""})
+		require.ErrorContains(t, err, "tx_id must not be empty")
+		require.Equal(t, codes.InvalidArgument, status.Code(err))
+	})
+
 	t.Run("GetBlockByTxID_NotFound", func(t *testing.T) {
 		t.Parallel()
 		_, err := client.GetBlockByTxID(t.Context(), &committerpb.TxID{TxId: "nonexistent"})
@@ -76,6 +83,13 @@ func TestBlockQuery(t *testing.T) {
 		envelope, err := client.GetTxByID(t.Context(), &committerpb.TxID{TxId: txIDs[0][0]})
 		require.NoError(t, err)
 		require.NotNil(t, envelope)
+	})
+
+	t.Run("GetTxByID_EmptyTxID", func(t *testing.T) {
+		t.Parallel()
+		_, err := client.GetTxByID(t.Context(), &committerpb.TxID{TxId: ""})
+		require.ErrorContains(t, err, "tx_id must not be empty")
+		require.Equal(t, codes.InvalidArgument, status.Code(err))
 	})
 
 	t.Run("GetTxByID_NotFound", func(t *testing.T) {


### PR DESCRIPTION
#### Type of change

- Improvement (improvement to code, performance, etc)
 
#### Description

When txID is empty, this commit returns an appropriate gRPC error codes. 

#### Related issues

  - resolves #368 