### PR TITLE
[connection] Minor fixes

### DIFF
--- a/service/coordinator/signature_verifier_manager.go
+++ b/service/coordinator/signature_verifier_manager.go
@@ -109,7 +109,8 @@ func (svm *signatureVerifierManager) run(ctx context.Context) error {
 
 		g.Go(func() error {
 			// error should never occur unless there is a bug or malicious activity. Hence, it is fine to crash for now.
-			return connection.Sustain(eCtx, func() error {
+			// TODO: initialize retry from config.
+			return connection.Sustain(eCtx, nil, func() error {
 				defer sv.recoverPendingTransactions(txBatchQueue)
 				return sv.sendTransactionsAndForwardStatus(
 					eCtx,

--- a/service/coordinator/validator_committer_manager.go
+++ b/service/coordinator/validator_committer_manager.go
@@ -119,7 +119,8 @@ func (vcm *validatorCommitterManager) run(ctx context.Context) error {
 		logger.Infof("Client [%d] successfully created and connected to vc at %s", i, label)
 
 		g.Go(func() error {
-			return connection.Sustain(eCtx, func() (err error) {
+			// TODO: initialize retry from config.
+			return connection.Sustain(eCtx, nil, func() (err error) {
 				defer vc.recoverPendingTransactions(txBatchQueue)
 				return vc.sendTransactionsAndForwardStatus(
 					eCtx,

--- a/service/sidecar/sidecar.go
+++ b/service/sidecar/sidecar.go
@@ -150,7 +150,8 @@ func (s *Service) Run(ctx context.Context) error {
 	})
 
 	g.Go(func() error {
-		return connection.Sustain(gCtx, func() error {
+		// TODO: initialize retry from config.
+		return connection.Sustain(gCtx, nil, func() error {
 			defer func() {
 				s.recoverCommittedBlocks(gCtx)
 			}()

--- a/utils/connection/client_util.go
+++ b/utils/connection/client_util.go
@@ -44,12 +44,11 @@ type (
 		Address() string
 	}
 
-	// Parameters contain connection parameters.
-	Parameters struct {
+	// ClientParameters contain connection parameters.
+	ClientParameters struct {
 		Address        string
 		Creds          credentials.TransportCredentials
 		Retry          *RetryProfile
-		Resolver       *manual.Resolver
 		AdditionalOpts []grpc.DialOption
 	}
 )
@@ -86,6 +85,14 @@ func newLoadBalancedConnection(
 	creds credentials.TransportCredentials,
 	retry *RetryProfile,
 ) (*grpc.ClientConn, error) {
+	if len(endpoints) == 1 {
+		return NewConnection(ClientParameters{
+			Address: endpoints[0].Address(),
+			Retry:   retry,
+			Creds:   creds,
+		})
+	}
+
 	resolverEndpoints := make([]resolver.Endpoint, len(endpoints))
 	for i, e := range endpoints {
 		// we're setting ServerName for each address because each service-instance has its own certificates.
@@ -96,11 +103,13 @@ func newLoadBalancedConnection(
 	r := manual.NewBuilderWithScheme(scResolverSchema)
 	r.UpdateState(resolver.State{Endpoints: resolverEndpoints})
 
-	return NewConnection(Parameters{
-		Address:  fmt.Sprintf("%s:///%s", r.Scheme(), "method"),
-		Creds:    creds,
-		Retry:    retry,
-		Resolver: r,
+	// Create a meaningful target string for debugging by joining all endpoint addresses.
+	targetName := AddressString(endpoints...)
+	return NewConnection(ClientParameters{
+		Address:        fmt.Sprintf("%s:///%s", r.Scheme(), targetName),
+		Creds:          creds,
+		Retry:          retry,
+		AdditionalOpts: []grpc.DialOption{grpc.WithResolvers(r)},
 	})
 }
 
@@ -112,7 +121,7 @@ func NewConnectionPerEndpoint(config *MultiClientConfig) ([]*grpc.ClientConn, er
 	}
 	connections := make([]*grpc.ClientConn, len(config.Endpoints))
 	for i, e := range config.Endpoints {
-		connections[i], err = NewConnection(Parameters{
+		connections[i], err = NewConnection(ClientParameters{
 			Address: e.Address(),
 			Creds:   tlsCreds,
 			Retry:   config.Retry,
@@ -131,7 +140,7 @@ func NewSingleConnection(config *ClientConfig) (*grpc.ClientConn, error) {
 	if err != nil {
 		return nil, err
 	}
-	return NewConnection(Parameters{
+	return NewConnection(ClientParameters{
 		Address: config.Endpoint.Address(),
 		Creds:   tlsCreds,
 		Retry:   config.Retry,
@@ -140,8 +149,8 @@ func NewSingleConnection(config *ClientConfig) (*grpc.ClientConn, error) {
 
 // NewConnection creates a connection with the given parameters.
 // It will not attempt to create a connection with the remote.
-func NewConnection(p Parameters) (*grpc.ClientConn, error) {
-	dialOpts := []grpc.DialOption{
+func NewConnection(p ClientParameters) (*grpc.ClientConn, error) {
+	dialOpts := append([]grpc.DialOption{
 		grpc.WithDefaultServiceConfig(p.Retry.MakeGrpcRetryPolicyJSON()),
 		grpc.WithTransportCredentials(p.Creds),
 		grpc.WithDefaultCallOptions(
@@ -149,15 +158,11 @@ func NewConnection(p Parameters) (*grpc.ClientConn, error) {
 			grpc.MaxCallSendMsgSize(maxMsgSize),
 		),
 		grpc.WithMaxCallAttempts(defaultGrpcMaxAttempts),
-	}
-	if p.Resolver != nil {
-		dialOpts = append(dialOpts, grpc.WithResolvers(p.Resolver))
-	}
-	dialOpts = append(dialOpts, p.AdditionalOpts...)
+	}, p.AdditionalOpts...)
 
 	cc, err := grpc.NewClient(p.Address, dialOpts...)
 	if err != nil {
-		logger.Errorf("Error openning connection to %s: %v", p.Address, err)
+		logger.Errorf("Error opening connection to %s: %v", p.Address, err)
 		return nil, errors.Wrap(err, "error connecting to grpc")
 	}
 	return cc, nil

--- a/utils/connection/client_util_test.go
+++ b/utils/connection/client_util_test.go
@@ -138,6 +138,9 @@ func TestGRPCRetryMultiEndpoints(t *testing.T) {
 		&fakeServerConfig.Endpoint,
 		&serverConfig.Endpoint,
 	})
+	require.Contains(t, multiConn.Target(), fakeServerConfig.Endpoint.Address())
+	require.Contains(t, multiConn.Target(), serverConfig.Endpoint.Address())
+
 	multiClient := healthgrpc.NewHealthClient(multiConn)
 	for i := range 100 {
 		t.Logf("Fetch attempt: %d", i)

--- a/utils/connection/lifecycle.go
+++ b/utils/connection/lifecycle.go
@@ -35,9 +35,11 @@ var (
 //   - op returns an error wrapping ErrNonRetryable (permanent failure).
 //   - The context ctx is cancelled.
 //   - The internal backoff strategy times out (via ErrRetryTimeout).
-func Sustain(ctx context.Context, op func() error) error {
-	p := &RetryProfile{} // TODO: initialize retry from config.
-	b := p.NewBackoff()
+func Sustain(ctx context.Context, r *RetryProfile, op func() error) error {
+	if r == nil {
+		r = &RetryProfile{}
+	}
+	b := r.NewBackoff()
 
 	for ctx.Err() == nil {
 		opErr := op()

--- a/utils/test/utils.go
+++ b/utils/test/utils.go
@@ -282,7 +282,7 @@ func NewSecuredConnectionWithRetry(
 	t.Helper()
 	clientCreds, err := tlsConfig.ClientCredentials()
 	require.NoError(t, err)
-	conn, err := connection.NewConnection(connection.Parameters{
+	conn, err := connection.NewConnection(connection.ClientParameters{
 		Address: endpoint.Address(),
 		Creds:   clientCreds,
 		Retry:   &retry,
@@ -305,7 +305,7 @@ func NewInsecureConnectionWithRetry(
 	t *testing.T, endpoint connection.WithAddress, retry connection.RetryProfile,
 ) *grpc.ClientConn {
 	t.Helper()
-	conn, err := connection.NewConnection(connection.Parameters{
+	conn, err := connection.NewConnection(connection.ClientParameters{
 		Address: endpoint.Address(),
 		Creds:   insecure.NewCredentials(),
 		Retry:   &retry,


### PR DESCRIPTION
#### Type of change

- Improvement (improvement to code, performance, etc)

#### Description

This PR introduces minor fixes and improvements to the connection utilities:

- Sustain function signature update: Added a retry configuration parameter to `connection.Sustain()` calls across coordinator and sidecar services. Currently passing `nil` with TODO comments to initialize retry from config in future updates.
- ClientParameters refactoring: Renamed `Parameters` struct to `ClientParameters` for better clarity and removed the unused `Resolver` field from the struct.
- Single endpoint optimization: Added logic in `newLoadBalancedConnection()` to handle single endpoint cases more efficiently by directly calling `NewConnection()` instead of setting up load balancing infrastructure when only one endpoint is provided.
- Load balancer target naming: Replaced "method` with actual target addresses in `newLoadBalancedConnection()` to create a meaningful target string for debugging.

These modifications prepare the codebase for future retry configuration support while improving code clarity and handling edge cases more efficiently.

