### PR TITLE
[deliver] Sign seek info with TLS certificate

### DIFF
--- a/utils/deliver/client.go
+++ b/utils/deliver/client.go
@@ -75,6 +75,7 @@ func (s *Client) Deliver(ctx context.Context, p *Parameters) error {
 			ConnectionManager: s.connectionManager,
 			Signer:            s.signer,
 			ChannelID:         s.config.ChannelID,
+			TLSCertHash:       s.connectionManager.GetTLSCertHash(),
 			StreamCreator: func(ctx context.Context, conn grpc.ClientConnInterface) (Stream, error) {
 				client, err := ab.NewAtomicBroadcastClient(conn).Deliver(ctx)
 				if err != nil {

--- a/utils/deliver/deliver_cft.go
+++ b/utils/deliver/deliver_cft.go
@@ -31,6 +31,7 @@ type (
 		Signer            identity.SignerSerializer
 		ChannelID         string
 		StreamCreator     func(ctx context.Context, conn grpc.ClientConnInterface) (Stream, error)
+		TLSCertHash       []byte
 	}
 
 	// Parameters needed for deliver to run.
@@ -129,7 +130,7 @@ func (c *CftClient) deliverRelay(
 	ctx context.Context, stream Stream, p *Parameters,
 ) (common.Status, error) {
 	logger.Infof("Sending seek request from block %d on channel %s.", p.NextBlockNum, c.ChannelID)
-	seekEnv, seekErr := seekSince(p.NextBlockNum, c.ChannelID, c.Signer)
+	seekEnv, seekErr := seekSince(p.NextBlockNum, c.ChannelID, c.Signer, c.TLSCertHash)
 	if seekErr != nil {
 		return 0, errors.Wrap(seekErr, "failed to create seek request")
 	}
@@ -172,13 +173,14 @@ func seekSince(
 	startBlockNumber uint64,
 	channelID string,
 	signer identity.SignerSerializer,
+	tlsCertHash []byte,
 ) (*common.Envelope, error) {
-	return protoutil.CreateSignedEnvelope(
+	return protoutil.CreateSignedEnvelopeWithTLSBinding(
 		common.HeaderType_DELIVER_SEEK_INFO, channelID, signer, &orderer.SeekInfo{
 			Start:    seekPosition(startBlockNumber),
 			Stop:     seekPosition(MaxBlockNum),
 			Behavior: orderer.SeekInfo_BLOCK_UNTIL_READY,
-		}, 0, 0,
+		}, 0, 0, tlsCertHash,
 	)
 }
 

--- a/utils/ordererconn/conn_manager.go
+++ b/utils/ordererconn/conn_manager.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package ordererconn
 
 import (
+	"crypto/sha256"
 	"fmt"
 	"maps"
 	"math"
@@ -142,6 +143,17 @@ func (cm *ConnectionManager) Update(orgsMat []*OrganizationMaterial) error { //n
 	cm.connections = connections
 	cm.endpoints = allOrgsEndpoints
 	return nil
+}
+
+// GetTLSCertHash returns the hash of the TLS certificate used by the connection manager.
+func (cm *ConnectionManager) GetTLSCertHash() []byte {
+	cm.lock.Lock()
+	defer cm.lock.Unlock()
+	if cm.tls == nil || len(cm.tls.Cert) == 0 {
+		return nil
+	}
+	sum := sha256.Sum256(cm.tls.Cert)
+	return sum[:]
 }
 
 // GetConnection returns a connection given filters.


### PR DESCRIPTION
#### Type of change

- New feature
 
#### Description

- The delivery client signs the seek request to the Orderer with the TLS certificate hash embedded to the envelope

#### Related issues

- resolves #271 
