### PR TITLE
fix flaky TestWaitingTxsCount

### DIFF
--- a/service/coordinator/coordinator_test.go
+++ b/service/coordinator/coordinator_test.go
@@ -917,11 +917,12 @@ func TestChunkSizeSentForDepGraph(t *testing.T) {
 
 	// Wait for all transactions to be committed before checking the metric
 	// This handles the race condition where restarted verifier may not have processed all txs yet
-	require.Eventually(t, func() bool {
-		return test.GetIntMetricValue(t, env.coordinator.metrics.transactionCommittedTotal.WithLabelValues(
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		actual := test.GetIntMetricValue(t, env.coordinator.metrics.transactionCommittedTotal.WithLabelValues(
 			committerpb.Status_COMMITTED.String(),
-		)) == txPerBlock
-	}, 4*time.Second, 100*time.Millisecond, "expected %d committed transactions", txPerBlock)
+		))
+		assert.Equal(c, txPerBlock, actual, "committed transactions count")
+	}, 4*time.Second, 100*time.Millisecond)
 }
 
 func TestWaitingTxsCount(t *testing.T) {


### PR DESCRIPTION
#### Type of change

- Bug fix
 
#### Description

root cause: The test was experiencing a race condition after restarting the verifier service. When the verifier service is stopped and restarted, there's a brief window where the new service instance may not have processed all pending transactions yet. The immediate RequireIntMetricValue check at line 965 would sometimes execute before all 10 transactions were committed, seeing only 8 committed transactions.

This commit adds a retry to the check.

#### Related issues

  - resolves #409 