### PR TITLE
[flaky-test] increase timing tolerance

### DIFF
--- a/loadgen/workload/limiter_test.go
+++ b/loadgen/workload/limiter_test.go
@@ -82,7 +82,7 @@ func TestLimiterMaxWait(t *testing.T) {
 		taken := l.Consume(ctx, p)
 		duration := time.Since(start)
 		assert.NotNil(t, taken)
-		assert.Lessf(t, duration, p.SoftTimeout+200*time.Millisecond, "Iteration: %d", i)
+		assert.Lessf(t, duration, p.SoftTimeout+500*time.Millisecond, "Iteration: %d", i)
 		assert.GreaterOrEqualf(t, len(taken), 80, "Iteration: %d", i)
 	}
 }
@@ -103,7 +103,7 @@ func TestLimiterMinBatch(t *testing.T) {
 		duration := time.Since(start)
 		assert.NotNil(t, taken)
 		assert.Len(t, taken, int(p.MinItems), "Iteration: %d", i) //nolint:gosec // uint64 -> int.
-		assert.Less(t, duration, time.Second+200*time.Millisecond, "Iteration: %d", i)
+		assert.Less(t, duration, time.Second+500*time.Millisecond, "Iteration: %d", i)
 	}
 }
 


### PR DESCRIPTION
#### Type of change

- Test update
 
#### Description

TestLimiterMaxWait has a tight timing tolerance (200ms) that's insufficient for CI environments. The actual duration was 1.33s vs the 1.2s limit — a CI scheduling delay issue. This commit increases the tolerance too 500 msecs.

#### Related issues

  - resolves #413 