### PR TITLE
[sidecar] newBlockDelivery and newBlockQuery accept blockStore

### DIFF
--- a/service/sidecar/block_delivery.go
+++ b/service/sidecar/block_delivery.go
@@ -26,7 +26,6 @@ import (
 // blockDelivery implements peer.DeliverServer by streaming blocks from a blockStore.
 type blockDelivery struct {
 	blockStore *blockStore
-	channelID  string
 }
 
 var blockReadyRetryProfile = connection.RetryProfile{
@@ -35,8 +34,8 @@ var blockReadyRetryProfile = connection.RetryProfile{
 	MaxInterval:     3 * time.Second,
 }
 
-func newBlockDelivery(bs *blockStore, channelID string) *blockDelivery {
-	return &blockDelivery{blockStore: bs, channelID: channelID}
+func newBlockDelivery(bs *blockStore) *blockDelivery {
+	return &blockDelivery{blockStore: bs}
 }
 
 // Deliver delivers the requested blocks.
@@ -94,7 +93,7 @@ func (s *blockDelivery) deliverBlocks( //nolint:gocognit
 		return common.Status_BAD_REQUEST, errors.Wrap(err, "error parsing envelope")
 	}
 
-	if chdr.ChannelId != s.channelID {
+	if chdr.ChannelId != s.blockStore.channelID {
 		// Note, we log this at DEBUG because SDKs will poll waiting for channels to be created
 		// So we would expect our log to be somewhat flooded with these
 		return common.Status_NOT_FOUND, errors.New("channel not found")

--- a/service/sidecar/block_delivery_test.go
+++ b/service/sidecar/block_delivery_test.go
@@ -32,7 +32,7 @@ func TestBlockDelivery(t *testing.T) {
 	config := connection.NewLocalHostServer(test.InsecureTLSConfig)
 	test.RunGrpcServerForTest(t.Context(), t, config,
 		func(server *grpc.Server) {
-			peer.RegisterDeliverServer(server, newBlockDelivery(bs, channelID))
+			peer.RegisterDeliverServer(server, newBlockDelivery(bs))
 		})
 	conn := test.NewInsecureConnection(t, &config.Endpoint)
 	deliverClient := peer.NewDeliverClient(conn)

--- a/service/sidecar/block_query.go
+++ b/service/sidecar/block_query.go
@@ -13,7 +13,6 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/hyperledger/fabric-protos-go-apiv2/common"
 	"github.com/hyperledger/fabric-x-common/api/committerpb"
-	"github.com/hyperledger/fabric-x-common/common/ledger/blkstorage"
 	"google.golang.org/protobuf/types/known/emptypb"
 
 	"github.com/hyperledger/fabric-x-committer/utils/grpcerror"
@@ -26,16 +25,16 @@ var ErrEmptyTxID = errors.New("tx_id must not be empty")
 // read-only queries directly to the underlying block store.
 type blockQuery struct {
 	committerpb.UnimplementedBlockQueryServiceServer
-	store *blkstorage.BlockStore
+	blockStore *blockStore
 }
 
-func newBlockQuery(store *blkstorage.BlockStore) *blockQuery {
-	return &blockQuery{store: store}
+func newBlockQuery(bs *blockStore) *blockQuery {
+	return &blockQuery{blockStore: bs}
 }
 
 // GetBlockchainInfo returns the current blockchain height and hash metadata.
 func (s *blockQuery) GetBlockchainInfo(_ context.Context, _ *emptypb.Empty) (*common.BlockchainInfo, error) {
-	info, err := s.store.GetBlockchainInfo()
+	info, err := s.blockStore.store.GetBlockchainInfo()
 	if err != nil {
 		logger.Errorf("GetBlockchainInfo failed: %v", err)
 		return nil, grpcerror.WrapInternalError(err)
@@ -45,7 +44,7 @@ func (s *blockQuery) GetBlockchainInfo(_ context.Context, _ *emptypb.Empty) (*co
 
 // GetBlockByNumber retrieves a block by its sequence number.
 func (s *blockQuery) GetBlockByNumber(_ context.Context, req *committerpb.BlockNumber) (*common.Block, error) {
-	block, err := s.store.RetrieveBlockByNumber(req.GetNumber())
+	block, err := s.blockStore.store.RetrieveBlockByNumber(req.GetNumber())
 	if err != nil {
 		return nil, wrapQueryError(err)
 	}
@@ -57,7 +56,7 @@ func (s *blockQuery) GetBlockByTxID(_ context.Context, req *committerpb.TxID) (*
 	if req.GetTxId() == "" {
 		return nil, grpcerror.WrapInvalidArgument(ErrEmptyTxID)
 	}
-	block, err := s.store.RetrieveBlockByTxID(req.GetTxId())
+	block, err := s.blockStore.store.RetrieveBlockByTxID(req.GetTxId())
 	if err != nil {
 		return nil, wrapQueryError(err)
 	}
@@ -69,7 +68,7 @@ func (s *blockQuery) GetTxByID(_ context.Context, req *committerpb.TxID) (*commo
 	if req.GetTxId() == "" {
 		return nil, grpcerror.WrapInvalidArgument(ErrEmptyTxID)
 	}
-	envelope, err := s.store.RetrieveTxByID(req.GetTxId())
+	envelope, err := s.blockStore.store.RetrieveTxByID(req.GetTxId())
 	if err != nil {
 		return nil, wrapQueryError(err)
 	}

--- a/service/sidecar/block_query_test.go
+++ b/service/sidecar/block_query_test.go
@@ -26,7 +26,7 @@ func TestBlockQuery(t *testing.T) {
 	bs, txIDs := newBlockStoreWithBlocks(t, "ch1", 2)
 
 	// Create the query service and register on a gRPC server.
-	queryService := newBlockQuery(bs.store)
+	queryService := newBlockQuery(bs)
 
 	config := connection.NewLocalHostServer(test.InsecureTLSConfig)
 	test.RunGrpcServerForTest(t.Context(), t, config, func(server *grpc.Server) {

--- a/service/sidecar/block_store_test.go
+++ b/service/sidecar/block_store_test.go
@@ -27,14 +27,13 @@ import (
 func TestBlockStoreAndDelivery(t *testing.T) {
 	t.Parallel()
 	ledgerPath := t.TempDir()
-	channelID := "ch1"
 
 	metrics := newPerformanceMetrics()
-	bs, err := newBlockStore(channelID, ledgerPath, 0, metrics)
+	bs, err := newBlockStore("ch1", ledgerPath, 0, metrics)
 	require.NoError(t, err)
 	t.Cleanup(bs.close)
 
-	bd := newBlockDelivery(bs, channelID)
+	bd := newBlockDelivery(bs)
 
 	config := connection.NewLocalHostServer(test.InsecureTLSConfig)
 	inputBlock := make(chan *common.Block, 10)
@@ -64,7 +63,7 @@ func TestBlockStoreAndDelivery(t *testing.T) {
 	require.Greater(t, test.GetMetricValue(t, metrics.appendBlockToLedgerSeconds), float64(0))
 
 	receivedBlocksFromLedgerService := sidecarclient.StartSidecarClient(t.Context(), t, &sidecarclient.Parameters{
-		ChannelID: channelID,
+		ChannelID: bs.channelID,
 		Client:    test.NewInsecureClientConfig(&config.Endpoint),
 	}, 0)
 

--- a/service/sidecar/sidecar.go
+++ b/service/sidecar/sidecar.go
@@ -85,7 +85,7 @@ func New(c *Config) (*Service, error) {
 
 	// 3. Deliver the block with status to client.
 	logger.Infof("Create block store for channel %s", c.Orderer.ChannelID)
-	blockStore, err := newBlockStore(c.Orderer.ChannelID, c.Ledger.Path, c.Ledger.SyncInterval, metrics)
+	blockStoreInstance, err := newBlockStore(c.Orderer.ChannelID, c.Ledger.Path, c.Ledger.SyncInterval, metrics)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create block store: %w", err)
 	}
@@ -97,9 +97,9 @@ func New(c *Config) (*Service, error) {
 		ordererClient:  ordererClient,
 		relay:          relayService,
 		notifier:       newNotifier(c.ChannelBufferSize, &c.Notification),
-		blockStore:     blockStore,
-		blockDelivery:  newBlockDelivery(blockStore, c.Orderer.ChannelID),
-		blockQuery:     newBlockQuery(blockStore.store),
+		blockStore:     blockStoreInstance,
+		blockDelivery:  newBlockDelivery(blockStoreInstance),
+		blockQuery:     newBlockQuery(blockStoreInstance),
 		healthcheck:    connection.DefaultHealthCheckService(),
 		config:         c,
 		metrics:        metrics,

--- a/service/sidecar/sidecar_test.go
+++ b/service/sidecar/sidecar_test.go
@@ -439,8 +439,8 @@ func TestSidecarRecovery(t *testing.T) {
 		newPerformanceMetrics(),
 	)
 	require.NoError(t, err)
-	env.sidecar.blockDelivery = newBlockDelivery(env.sidecar.blockStore, env.config.Orderer.ChannelID)
-	env.sidecar.blockQuery = newBlockQuery(env.sidecar.blockStore.store)
+	env.sidecar.blockDelivery = newBlockDelivery(env.sidecar.blockStore)
+	env.sidecar.blockQuery = newBlockQuery(env.sidecar.blockStore)
 	ensureAtLeastHeight(t, env.sidecar.blockStore, 1) // back to block 0
 
 	t.Log("4. Make coordinator not idle to ensure sidecar is waiting")


### PR DESCRIPTION
#### Type of change

- Improvement (improvement to code, performance, etc)
 
#### Description

- Align `newBlockDelivery()` and `newBlockQuery()` to accept only `blockStore`. There is no need for `channelID` as it is included in `blockStore`.
