### PR TITLE
[test] Add parent stack track in test.RunGrpcServerForTest()

### DIFF
--- a/utils/test/secure_connection.go
+++ b/utils/test/secure_connection.go
@@ -191,7 +191,7 @@ func CreateServerAndClientTLSConfig(t *testing.T, tlsMode string) (
 ) {
 	t.Helper()
 	credsFactory := NewCredentialsFactory(t)
-	clientTLSConfig, _ = credsFactory.CreateServerCredentials(t, tlsMode, defaultHostName)
-	serverTLSConfig, _ = credsFactory.CreateClientCredentials(t, tlsMode)
-	return clientTLSConfig, serverTLSConfig
+	serverTLSConfig, _ = credsFactory.CreateServerCredentials(t, tlsMode, defaultHostName)
+	clientTLSConfig, _ = credsFactory.CreateClientCredentials(t, tlsMode)
+	return serverTLSConfig, clientTLSConfig
 }

--- a/utils/test/utils.go
+++ b/utils/test/utils.go
@@ -112,9 +112,16 @@ func RunGrpcServerForTest(
 	var wg sync.WaitGroup
 	tb.Cleanup(wg.Wait)
 	tb.Cleanup(server.Stop)
+
+	// The parent error capture the caller stack trace,
+	// which helps track the server origin when debugging test failures.
+	parentErr := errors.New("parent stack context")
 	wg.Go(func() {
 		// We use assert to prevent panicking for cleanup errors.
-		assert.NoError(tb, server.Serve(listener))
+		serveErr := server.Serve(listener)
+		if serveErr != nil && !errors.Is(serveErr, grpc.ErrServerStopped) {
+			assert.NoError(tb, errors.WithSecondaryError(serveErr, parentErr))
+		}
 	})
 
 	_ = context.AfterFunc(ctx, func() {


### PR DESCRIPTION
#### Type of change

- Test update
 
#### Description

- Fix variables mix up in `test.CreateServerAndClientTLSConfig()`
- Add parent stack trace in `test.RunGrpcServerForTest()`.
