### PR TITLE
[sidecar] add limits

### DIFF
--- a/cmd/config/app_config_test.go
+++ b/cmd/config/app_config_test.go
@@ -78,7 +78,9 @@ func TestReadConfigSidecar(t *testing.T) {
 				Path: "./ledger/",
 			},
 			Notification: sidecar.NotificationServiceConfig{
-				MaxTimeout: time.Minute,
+				MaxTimeout:         time.Minute,
+				MaxActiveTxIDs:     100_000,
+				MaxTxIDsPerRequest: 1000,
 			},
 			LastCommittedBlockSetInterval: 3 * time.Second,
 			WaitingTxsLimit:               100_000,
@@ -128,7 +130,9 @@ func TestReadConfigSidecar(t *testing.T) {
 				SyncInterval: 100,
 			},
 			Notification: sidecar.NotificationServiceConfig{
-				MaxTimeout: 10 * time.Minute,
+				MaxTimeout:         10 * time.Minute,
+				MaxActiveTxIDs:     100_000,
+				MaxTxIDsPerRequest: 1000,
 			},
 			LastCommittedBlockSetInterval: 5 * time.Second,
 			WaitingTxsLimit:               20_000_000,

--- a/cmd/config/samples/sidecar.yaml
+++ b/cmd/config/samples/sidecar.yaml
@@ -88,6 +88,8 @@ ledger:
   sync-interval: 100
 notification:
   max-timeout: 10m
+  max-active-tx-ids: 100_000
+  max-tx-ids-per-request: 1000
 
 bootstrap:
   genesis-block-file-path: /root/artifacts/config-block.pb.bin

--- a/cmd/config/viper.go
+++ b/cmd/config/viper.go
@@ -30,6 +30,8 @@ func NewViperWithSidecarDefaults() *viper.Viper {
 	v.SetDefault("committer.endpoint", "localhost:9001")
 	v.SetDefault("ledger.path", "./ledger/")
 	v.SetDefault("notification.max-timeout", "1m")
+	v.SetDefault("notification.max-active-tx-ids", 100_000)
+	v.SetDefault("notification.max-tx-ids-per-request", 1000)
 	v.SetDefault("last-committed-block-set-interval", "3s")
 	v.SetDefault("waiting-txs-limit", 100_000)
 	v.SetDefault("channel-buffer-size", 100)

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.4
 	github.com/hyperledger/fabric-lib-go v1.1.3-0.20240523144151-25edd1eaf5f5
 	github.com/hyperledger/fabric-protos-go-apiv2 v0.3.7
-	github.com/hyperledger/fabric-x-common v0.1.1-0.20260303132028-7df0f34a545b
+	github.com/hyperledger/fabric-x-common v0.1.1-0.20260309100324-897c999bab17
 	github.com/jackc/puddle/v2 v2.2.2
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/onsi/gomega v1.38.2

--- a/go.sum
+++ b/go.sum
@@ -1116,8 +1116,8 @@ github.com/hyperledger/fabric-lib-go v1.1.3-0.20240523144151-25edd1eaf5f5 h1:RPW
 github.com/hyperledger/fabric-lib-go v1.1.3-0.20240523144151-25edd1eaf5f5/go.mod h1:SHNCq8AB0VpHAmvJEtdbzabv6NNV1F48JdmDihasBjc=
 github.com/hyperledger/fabric-protos-go-apiv2 v0.3.7 h1:sQ5qv8vQQfwewa1JlCiSCC8dLElmaU2/frLolpgibEY=
 github.com/hyperledger/fabric-protos-go-apiv2 v0.3.7/go.mod h1:bJnwzfv03oZQeCc863pdGTDgf5nmCy6Za3RAE7d2XsQ=
-github.com/hyperledger/fabric-x-common v0.1.1-0.20260303132028-7df0f34a545b h1:d+Y5V77Ot/lfkJkANZd+3vyo80zmpsx7bB1tsIialgU=
-github.com/hyperledger/fabric-x-common v0.1.1-0.20260303132028-7df0f34a545b/go.mod h1:+VPYRRCGAZo7+rlT55yK3aRmUbRJwQGlWg7lz0SLdMY=
+github.com/hyperledger/fabric-x-common v0.1.1-0.20260309100324-897c999bab17 h1:I8kskJY5l0Lg7nhGQXdEhQnzrGQRC98jeS+u1WuesLc=
+github.com/hyperledger/fabric-x-common v0.1.1-0.20260309100324-897c999bab17/go.mod h1:+VPYRRCGAZo7+rlT55yK3aRmUbRJwQGlWg7lz0SLdMY=
 github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=

--- a/service/sidecar/config.go
+++ b/service/sidecar/config.go
@@ -52,10 +52,16 @@ type (
 		// MaxTimeout is an upper limit on the request's timeout to prevent resource exhaustion.
 		// If a request doesn't specify a timeout, this value will be used.
 		MaxTimeout time.Duration `mapstructure:"max-timeout"`
+		// MaxActiveTxIDs is the global limit on total active txID subscriptions across all streams.
+		MaxActiveTxIDs int `mapstructure:"max-active-tx-ids"`
+		// MaxTxIDsPerRequest is the maximum number of txIDs allowed in a single notification request.
+		MaxTxIDsPerRequest int `mapstructure:"max-tx-ids-per-request"`
 	}
 )
 
 const (
 	defaultNotificationMaxTimeout = time.Minute
 	defaultBufferSize             = 100
+	defaultMaxActiveTxIDs         = 100_000
+	defaultMaxTxIDsPerRequest     = 1000
 )

--- a/service/sidecar/notify.go
+++ b/service/sidecar/notify.go
@@ -8,6 +8,7 @@ package sidecar
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/cockroachdb/errors"
@@ -22,14 +23,16 @@ import (
 type (
 	// notifier uses a single go-routine for processing.
 	// Each stream has its own notificationQueue (stream-level).
-	// All requests flow into the global requestQueue and are accumulated in subscriptionMap (txID -> requests).
+	// All requests flow into the global requestQueue and are accumulated in subscriptions (txID -> requests).
 	// Status updates from statusQueue are dispatched by grouping responses per stream and
 	// writing to each stream's notificationQueue.
 	// Deadlock is prevented by buffered channels and single-threaded processing in run().
 	notifier struct {
 		committerpb.UnimplementedNotifierServer
-		bufferSize int
-		maxTimeout time.Duration
+		bufferSize         int
+		maxTimeout         time.Duration
+		maxActiveTxIDs     int
+		maxTxIDsPerRequest int
 		// requestQueue receives requests from users.
 		requestQueue chan *notificationRequest
 	}
@@ -44,33 +47,78 @@ type (
 		pending int
 	}
 
-	// subscriptionMap maps from TX ID to a set of notificationRequest objects.
-	subscriptionMap map[string]map[*notificationRequest]any
+	// subscriptions maps from TX ID to a set of notificationRequest objects
+	// and tracks available slots for new subscriptions.
+	subscriptions struct {
+		txIDToRequests map[string]map[*notificationRequest]any
+		availableSlots int
+	}
 )
 
 func newNotifier(bufferSize int, conf *NotificationServiceConfig) *notifier {
+	// TODO: Define all defaults in cmd/config so Viper handles them directly.
+	//	     Otherwise, we are unnecessarily maintaining defaults in two locations.
+	//       Removing local defaults might require tests to pass explicit configurations,
+	//       which helps prevent default divergence. To ensure consistency, we could
+	//       export default values from here for cmd/config to use, or only set them
+	//       here if a "second line of defense" is strictly necessary.
 	maxTimeout := conf.MaxTimeout
 	if maxTimeout <= 0 {
 		maxTimeout = defaultNotificationMaxTimeout
 	}
+	maxActiveTxIDs := conf.MaxActiveTxIDs
+	if maxActiveTxIDs <= 0 {
+		maxActiveTxIDs = defaultMaxActiveTxIDs
+	}
+	maxTxIDsPerRequest := conf.MaxTxIDsPerRequest
+	if maxTxIDsPerRequest <= 0 {
+		maxTxIDsPerRequest = defaultMaxTxIDsPerRequest
+	}
 	return &notifier{
-		bufferSize:   bufferSize,
-		maxTimeout:   maxTimeout,
-		requestQueue: make(chan *notificationRequest, bufferSize),
+		bufferSize:         bufferSize,
+		maxTimeout:         maxTimeout,
+		maxActiveTxIDs:     maxActiveTxIDs,
+		maxTxIDsPerRequest: maxTxIDsPerRequest,
+		requestQueue:       make(chan *notificationRequest, bufferSize),
 	}
 }
 
 func (n *notifier) run(ctx context.Context, statusQueue chan []*committerpb.TxStatus) error {
-	notifyMap := subscriptionMap(make(map[string]map[*notificationRequest]any))
+	notifyMap := subscriptions{
+		txIDToRequests: make(map[string]map[*notificationRequest]any),
+		availableSlots: n.maxActiveTxIDs,
+	}
 	timeoutQueue := make(chan *notificationRequest, cap(n.requestQueue))
 	timeoutQueueCtx := channel.NewWriter(ctx, timeoutQueue)
+
+	reject := func(req *notificationRequest, txIDs []string, reason string) {
+		req.streamEventQueue.Write(&committerpb.NotificationResponse{
+			RejectedTxIds: &committerpb.RejectedTxIds{
+				TxIds:  txIDs,
+				Reason: reason,
+			},
+		})
+	}
 
 	for {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
 		case req := <-n.requestQueue:
-			notifyMap.addRequest(req)
+			txIDs := req.request.TxStatusRequest.GetTxIds()
+			// Per-request limit: reject the entire request, similar to query service limits
+			// (e.g., max keys per query). The client controls request size and should respect it.
+			if len(txIDs) > n.maxTxIDsPerRequest {
+				reject(req, txIDs, fmt.Sprintf(
+					"request contains %d tx IDs, max allowed is %d", len(txIDs), n.maxTxIDsPerRequest))
+				continue
+			}
+			// Global active limit: accept what fits, reject the rest. Unlike the per-request limit,
+			// the global limit depends on factors outside the client's control (other streams,
+			// pending subscriptions), so partial acceptance is more appropriate.
+			if rejected := notifyMap.addRequest(req); len(rejected) > 0 {
+				reject(req, rejected, "active tx IDs limit reached")
+			}
 			if req.pending > 0 {
 				req.timer = time.AfterFunc(req.request.Timeout.AsDuration(), func() {
 					timeoutQueueCtx.Write(req)
@@ -138,33 +186,44 @@ func fixTimeout(request *committerpb.NotificationRequest, maxTimeout time.Durati
 	request.Timeout = durationpb.New(timeout)
 }
 
-// addRequest adds a requests to the map and updates the number of pending TX IDs for this request.
-func (m subscriptionMap) addRequest(req *notificationRequest) {
-	for _, id := range req.request.TxStatusRequest.TxIds {
-		requests, ok := m[id]
+// addRequest adds tx IDs from the request to the subscriptions up to available slots.
+// It returns any tx IDs that were rejected due to the limit being reached.
+func (m *subscriptions) addRequest(req *notificationRequest) []string {
+	txIDs := req.request.TxStatusRequest.GetTxIds()
+	for i, id := range txIDs {
+		requests, ok := m.txIDToRequests[id]
+		if ok {
+			if _, alreadyAssigned := requests[req]; alreadyAssigned {
+				continue
+			}
+		}
+		if m.availableSlots <= 0 {
+			return txIDs[i:]
+		}
 		if !ok {
 			requests = make(map[*notificationRequest]any)
-			m[id] = requests
+			m.txIDToRequests[id] = requests
 		}
-		if _, alreadyAssigned := requests[req]; !alreadyAssigned {
-			requests[req] = nil
-			req.pending++
-		}
+		requests[req] = nil
+		req.pending++
+		m.availableSlots--
 	}
+	return nil
 }
 
-// removeAndEnqueueStatusEvents removes TXs from the map and reports the responses to the subscribers.
-func (m subscriptionMap) removeAndEnqueueStatusEvents(status []*committerpb.TxStatus) {
+// removeAndEnqueueStatusEvents removes TXs from the subscriptions and reports the responses to the subscribers.
+func (m *subscriptions) removeAndEnqueueStatusEvents(status []*committerpb.TxStatus) {
 	respMap := make(map[channel.Writer[*committerpb.NotificationResponse]][]*committerpb.TxStatus)
 	for _, response := range status {
-		reqList, ok := m[response.Ref.TxId]
+		reqList, ok := m.txIDToRequests[response.Ref.TxId]
 		if !ok {
 			continue
 		}
-		delete(m, response.Ref.TxId)
+		delete(m.txIDToRequests, response.Ref.TxId)
 		for req := range reqList {
 			respMap[req.streamEventQueue] = append(respMap[req.streamEventQueue], response)
 			req.pending--
+			m.availableSlots++
 			if req.pending == 0 {
 				req.timer.Stop()
 			}
@@ -177,11 +236,12 @@ func (m subscriptionMap) removeAndEnqueueStatusEvents(status []*committerpb.TxSt
 	}
 }
 
-// removeAndEnqueueTimeoutEvents removes a request from the map, and reports the remaining TX IDs for this request.
-func (m subscriptionMap) removeAndEnqueueTimeoutEvents(req *notificationRequest) {
+// removeAndEnqueueTimeoutEvents removes a request from the subscriptions, and
+// reports the timed out TX IDs for this request.
+func (m *subscriptions) removeAndEnqueueTimeoutEvents(req *notificationRequest) {
 	txIDs := make([]string, 0, len(req.request.TxStatusRequest.TxIds))
 	for _, id := range req.request.TxStatusRequest.TxIds {
-		requests, ok := m[id]
+		requests, ok := m.txIDToRequests[id]
 		if !ok {
 			continue
 		}
@@ -189,8 +249,9 @@ func (m subscriptionMap) removeAndEnqueueTimeoutEvents(req *notificationRequest)
 		if _, ok = requests[req]; !ok {
 			continue
 		}
+		m.availableSlots++
 		if len(requests) == 1 {
-			delete(m, id)
+			delete(m.txIDToRequests, id)
 		} else {
 			delete(requests, req)
 		}

--- a/service/sidecar/notify_test.go
+++ b/service/sidecar/notify_test.go
@@ -217,6 +217,31 @@ func TestNotifierDirect(t *testing.T) {
 		require.Empty(t, res.TimeoutTxIds)
 		test.RequireProtoElementsMatch(t, expected[:1], res.TxStatusEvents)
 	}
+
+	t.Log("Submitting request exceeding per-request limit - expecting rejection")
+	perRequestLimit := env.n.maxTxIDsPerRequest
+	overLimitTxIDs := make([]string, perRequestLimit+1)
+	for i := range overLimitTxIDs {
+		overLimitTxIDs[i] = fmt.Sprintf("over-%d", i)
+	}
+	for _, q := range env.notificationQueues {
+		env.requestQueue.Write(&notificationRequest{
+			request: &committerpb.NotificationRequest{
+				TxStatusRequest: &committerpb.TxIDsBatch{
+					TxIds: overLimitTxIDs,
+				},
+				Timeout: durationpb.New(5 * time.Minute),
+			},
+			streamEventQueue: q,
+		})
+	}
+	for _, q := range env.notificationQueues {
+		res, ok := q.ReadWithTimeout(10 * time.Second)
+		require.True(t, ok)
+		require.NotNil(t, res.RejectedTxIds)
+		require.ElementsMatch(t, overLimitTxIDs, res.RejectedTxIds.TxIds)
+		require.Contains(t, res.RejectedTxIds.Reason, fmt.Sprintf("max allowed is %d", perRequestLimit))
+	}
 }
 
 func TestNotifierStream(t *testing.T) {
@@ -317,7 +342,85 @@ func TestNotifierStream(t *testing.T) {
 	test.RequireProtoElementsMatch(t, expected[:1], res.TxStatusEvents)
 }
 
+func TestNotifierGlobalLimit(t *testing.T) {
+	t.Parallel()
+
+	env := newNotifierTestEnvWithConfig(t, &NotificationServiceConfig{
+		MaxActiveTxIDs:     5,
+		MaxTxIDsPerRequest: 10,
+	})
+	q := env.notificationQueues[0]
+
+	submitRequest := func(timeout time.Duration, txIDs ...string) {
+		env.requestQueue.Write(&notificationRequest{
+			request: &committerpb.NotificationRequest{
+				TxStatusRequest: &committerpb.TxIDsBatch{TxIds: txIDs},
+				Timeout:         durationpb.New(timeout),
+			},
+			streamEventQueue: q,
+		})
+	}
+
+	requireRejected := func(expectedTxIDs []string) {
+		t.Helper()
+		res, ok := q.ReadWithTimeout(10 * time.Second)
+		require.True(t, ok)
+		require.NotNil(t, res.RejectedTxIds)
+		require.ElementsMatch(t, expectedTxIDs, res.RejectedTxIds.TxIds)
+		require.Contains(t, res.RejectedTxIds.Reason, "active tx IDs limit reached")
+	}
+
+	// First request: 3 txIDs, fits within limit.
+	submitRequest(5*time.Minute, "1", "2", "3")
+
+	// Second request: 4 unique txIDs (with duplicates), only 2 slots remain.
+	// Duplicates are skipped before checking slots, so "4" and "5" are accepted, "6" and "7" rejected.
+	// FIFO processing of the request queue guarantees the first request is handled before this one.
+	submitRequest(5*time.Minute, "4", "4", "5", "5", "6", "7")
+	requireRejected([]string{"6", "7"})
+
+	// Third request: all slots still full, fully rejected.
+	submitRequest(5*time.Minute, "6", "7")
+	requireRejected([]string{"6", "7"})
+
+	// Fulfil the 2 accepted txIDs from the second request.
+	env.statusQueue.Write([]*committerpb.TxStatus{
+		{Ref: committerpb.NewTxRef("4", 1, 0)},
+		{Ref: committerpb.NewTxRef("5", 1, 1)},
+	})
+
+	res, ok := q.ReadWithTimeout(10 * time.Second)
+	require.True(t, ok)
+	require.Nil(t, res.RejectedTxIds)
+	require.Len(t, res.TxStatusEvents, 2)
+
+	// Timeout frees slots: fill remaining slots with a short timeout request.
+	submitRequest(1*time.Millisecond, "t1", "t2")
+
+	// Wait for timeout notification — this confirms the slots have been freed.
+	res, ok = q.ReadWithTimeout(10 * time.Second)
+	require.True(t, ok)
+	require.ElementsMatch(t, []string{"t1", "t2"}, res.TimeoutTxIds)
+
+	// Now 2 slots freed by timeout + 2 freed by status = 4 free (1 still held by "1","2","3" minus fulfilled).
+	// "1","2","3" are still active from the first request. So 2 slots are available.
+	// New request with 2 txIDs should be fully accepted (no rejection).
+	submitRequest(5*time.Minute, "6", "7")
+
+	// Fulfil to confirm they were accepted.
+	env.statusQueue.Write([]*committerpb.TxStatus{
+		{Ref: committerpb.NewTxRef("6", 2, 0)},
+		{Ref: committerpb.NewTxRef("7", 2, 1)},
+	})
+
+	res, ok = q.ReadWithTimeout(10 * time.Second)
+	require.True(t, ok)
+	require.Nil(t, res.RejectedTxIds)
+	require.Len(t, res.TxStatusEvents, 2)
+}
+
 func newNotifierTestEnv(tb testing.TB) *notifierTestEnv {
+	tb.Helper()
 	return newNotifierTestEnvWithConfig(tb, &NotificationServiceConfig{})
 }
 

--- a/service/sidecar/sidecar_test.go
+++ b/service/sidecar/sidecar_test.go
@@ -157,6 +157,9 @@ func newSidecarTestEnvWithTLS(
 		Ledger: LedgerConfig{
 			Path: t.TempDir(),
 		},
+		Notification: NotificationServiceConfig{
+			MaxTxIDsPerRequest: blockSize * 2,
+		},
 		LastCommittedBlockSetInterval: 100 * time.Millisecond,
 		WaitingTxsLimit:               1000,
 		Monitoring:                    connection.NewLocalHostServer(conf.ServerTLS),


### PR DESCRIPTION
#### Type of change

- New feature
 
#### Description

Reject notification requests that exceed MaxTxIDsPerRequest with a RejectedTxIds response containing the offending txIDs and a reason.

Track active subscription count. When a new request would exceed maxActiveTxIDs, reject full/partial with a rejection response.

#### Related issues

 - resolves #405 