### PR TITLE
Improve test coverage of API and workload

### DIFF
--- a/api/servicepb/height_test.go
+++ b/api/servicepb/height_test.go
@@ -33,3 +33,79 @@ func TestVersionExtraBytes(t *testing.T) {
 	require.Len(t, h1.ToBytes(), n)
 	require.Equal(t, extraBytes, b1[n:])
 }
+
+func TestNewHeightFromBytes_ErrorCases(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name        string
+		input       []byte
+		expectedErr string
+	}{
+		{
+			name:        "empty bytes",
+			input:       []byte{},
+			expectedErr: "failed to decode block number from bytes",
+		},
+		{
+			name:        "invalid block number encoding",
+			input:       []byte{0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF},
+			expectedErr: "failed to decode block number from bytes",
+		},
+		{
+			name:        "missing tx number",
+			input:       []byte{0x01, 0x05}, // valid block number (size=1, value=5) but no tx number
+			expectedErr: "failed to decode tx number from bytes",
+		},
+		{
+			name:        "invalid tx number encoding",
+			input:       append([]byte{0x01}, []byte{0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}...),
+			expectedErr: "failed to decode tx number from bytes",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			h, n, err := NewHeightFromBytes(tc.input)
+			require.ErrorContains(t, err, tc.expectedErr)
+			require.Nil(t, h)
+			require.Equal(t, -1, n)
+		})
+	}
+}
+
+func TestHeight_String(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name     string
+		height   *Height
+		expected string
+	}{
+		{
+			name:     "normal height",
+			height:   NewHeight(10, 100),
+			expected: "{BlockNum: 10, TxNum: 100}",
+		},
+		{
+			name:     "zero values",
+			height:   NewHeight(0, 0),
+			expected: "{BlockNum: 0, TxNum: 0}",
+		},
+		{
+			name:     "large values",
+			height:   NewHeight(18446744073709551615, 4294967295),
+			expected: "{BlockNum: 18446744073709551615, TxNum: 4294967295}",
+		},
+		{
+			name:     "nil height",
+			height:   nil,
+			expected: "<nil>",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			result := tc.height.String()
+			require.Equal(t, tc.expected, result)
+		})
+	}
+}

--- a/integration/runner/runtime.go
+++ b/integration/runner/runtime.go
@@ -408,7 +408,7 @@ func (c *CommitterRuntime) CreateNamespacesAndCommit(t *testing.T, namespaces ..
 	}
 
 	t.Logf("Creating namespaces: %v", namespaces)
-	metaTX, err := workload.CreateNamespacesTX(c.SystemConfig.Policy, 0, namespaces...)
+	metaTX, err := workload.CreateNamespacesTxFromEndorser(c.TxBuilder.TxEndorser, 0, namespaces...)
 	require.NoError(t, err)
 	c.MakeAndSendTransactionsToOrderer(
 		t,

--- a/integration/test/config_update_test.go
+++ b/integration/test/config_update_test.go
@@ -92,7 +92,7 @@ func TestConfigUpdateLifecyclePolicy(t *testing.T) {
 	sendTXs()
 
 	// Meta-namespace uses LifecycleEndorsement (MSP-based) from the config block.
-	metaTx, err := workload.CreateNamespacesTX(c.SystemConfig.Policy, 0, "2", "3")
+	metaTx, err := workload.CreateNamespacesTxFromEndorser(c.TxBuilder.TxEndorser, 0, "2", "3")
 	require.NoError(t, err)
 
 	// TxBuilder adds valid MSP endorsements via TxEndorser.
@@ -145,7 +145,7 @@ func TestConfigUpdateLifecyclePolicy(t *testing.T) {
 	// The endorser satisfies the new 4-org policy, but the stale NsVersion causes
 	// an MVCC conflict against _config (now at version 1).
 	t.Log("Case 1: updated endorser + stale config version → MVCC conflict")
-	staleVersionMetaTx, err := workload.CreateNamespacesTX(c.SystemConfig.Policy, 0, "2", "3")
+	staleVersionMetaTx, err := workload.CreateNamespacesTxFromEndorser(c.TxBuilder.TxEndorser, 0, "2", "3")
 	require.NoError(t, err)
 	setReadWriteVersions(staleVersionMetaTx, 0)
 	staleVersionTx := &applicationpb.Tx{Namespaces: staleVersionMetaTx.Namespaces}
@@ -161,7 +161,7 @@ func TestConfigUpdateLifecyclePolicy(t *testing.T) {
 	// The NsVersion matches _config, but the 2-org endorser no longer satisfies
 	// the updated 4-org LifecycleEndorsement policy → signature invalid.
 	t.Log("Case 2: stale endorser + current config version → signature invalid")
-	staleEndorserMetaTx, err := workload.CreateNamespacesTX(c.SystemConfig.Policy, 1, "2", "3")
+	staleEndorserMetaTx, err := workload.CreateNamespacesTxFromEndorser(c.TxBuilder.TxEndorser, 1, "2", "3")
 	require.NoError(t, err)
 	setReadWriteVersions(staleEndorserMetaTx, 0)
 	staleEndorserTx := &applicationpb.Tx{Namespaces: staleEndorserMetaTx.Namespaces}
@@ -176,7 +176,7 @@ func TestConfigUpdateLifecyclePolicy(t *testing.T) {
 	// Case 3: Updated endorser (4-org) + correct NsVersion (1).
 	// Both the policy and version gates pass → committed.
 	t.Log("Case 3: updated endorser + current config version → committed")
-	freshMetaTx, err := workload.CreateNamespacesTX(c.SystemConfig.Policy, 1, "2", "3")
+	freshMetaTx, err := workload.CreateNamespacesTxFromEndorser(c.TxBuilder.TxEndorser, 1, "2", "3")
 	require.NoError(t, err)
 	setReadWriteVersions(freshMetaTx, 0)
 	freshTx := &applicationpb.Tx{Namespaces: freshMetaTx.Namespaces}

--- a/loadgen/workload/config.go
+++ b/loadgen/workload/config.go
@@ -7,16 +7,12 @@ SPDX-License-Identifier: Apache-2.0
 package workload
 
 import (
-	"fmt"
 	"time"
-
-	"go.yaml.in/yaml/v3"
 
 	"github.com/cockroachdb/errors"
 	"github.com/hyperledger/fabric-x-common/api/committerpb"
 	commontypes "github.com/hyperledger/fabric-x-common/api/types"
 
-	"github.com/hyperledger/fabric-x-committer/utils"
 	"github.com/hyperledger/fabric-x-committer/utils/ordererconn"
 	"github.com/hyperledger/fabric-x-committer/utils/signature"
 )
@@ -181,24 +177,4 @@ type StreamOptions struct {
 	// RateLimit directly impacts the rate by limiting it.
 	// TXs are released at RateLimit (default: unlimited).
 	RateLimit uint64 `mapstructure:"rate-limit" yaml:"rate-limit"`
-}
-
-// Debug outputs the profile to stdout.
-func (p *Profile) Debug() {
-	debug("Profile", p)
-}
-
-// Debug outputs the stream configuration to stdout.
-func (o *StreamOptions) Debug() {
-	debug("Stream Config", o)
-}
-
-func debug(title string, val any) {
-	d, err := yaml.Marshal(val)
-	utils.Must(err)
-	fmt.Println("############################################################")
-	fmt.Printf("# %s\n", title)
-	fmt.Println("############################################################")
-	fmt.Println(string(d))
-	fmt.Println("############################################################")
 }

--- a/loadgen/workload/namespace.go
+++ b/loadgen/workload/namespace.go
@@ -30,14 +30,6 @@ func CreateLoadGenNamespacesTX(policy *PolicyProfile) (*servicepb.LoadGenTx, err
 	return txb.MakeTx(tx), nil
 }
 
-// CreateNamespacesTX creating the transaction containing the requested namespaces into the MetaNamespace.
-func CreateNamespacesTX(
-	policy *PolicyProfile, metaNamespaceVersion uint64, includeNS ...string,
-) (*applicationpb.Tx, error) {
-	endorser := NewTxEndorser(policy)
-	return CreateNamespacesTxFromEndorser(endorser, metaNamespaceVersion, includeNS...)
-}
-
 // CreateNamespacesTxFromEndorser creating the transaction containing the requested namespaces into the MetaNamespace.
 func CreateNamespacesTxFromEndorser(
 	endorser *TxEndorser, metaNamespaceVersion uint64, includeNS ...string,

--- a/loadgen/workload/sign.go
+++ b/loadgen/workload/sign.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/cockroachdb/errors"
 	"github.com/hyperledger/fabric-lib-go/common/flogging"
 	"github.com/hyperledger/fabric-protos-go-apiv2/common"
 	"github.com/hyperledger/fabric-x-common/api/applicationpb"
@@ -145,49 +144,30 @@ func NewPolicyEndorserFromMsp(artifactsPath string) (*testsig.NsEndorser, *appli
 }
 
 func getKeyPair(profile *Policy) (signingKey signature.PrivateKey, verificationKey signature.PublicKey) {
-	var err error
-	if profile.KeyPath != nil {
-		logger.Infof("Attempting to load keys")
-		signingKey, verificationKey, err = loadKeys(*profile.KeyPath)
-		utils.Must(err)
-	} else {
+	if profile.KeyPath == nil {
 		logger.Debugf("Generating new keys")
-		signingKey, verificationKey = testsig.NewKeyPairWithSeed(profile.Scheme, profile.Seed)
+		return testsig.NewKeyPairWithSeed(profile.Scheme, profile.Seed)
 	}
+
+	k := profile.KeyPath
+	var err error
+
+	logger.Infof("Loading signing key from file '%s'.", k.SigningKey)
+	signingKey, err = os.ReadFile(k.SigningKey)
+	utils.Mustf(err, "could not read signing key from %s", k.SigningKey)
+
+	switch {
+	case k.VerificationKey != "" && utils.FileExists(k.VerificationKey):
+		logger.Infof("Loading verification key from file '%s'.", k.VerificationKey)
+		verificationKey, err = os.ReadFile(k.VerificationKey)
+		utils.Mustf(err, "could not read public key from %s", k.VerificationKey)
+	case k.SignCertificate != "" && utils.FileExists(k.SignCertificate):
+		logger.Infof("Loading sign certiticate from file '%s'.", k.SignCertificate)
+		verificationKey, err = testsig.GetSerializedKeyFromCert(k.SignCertificate)
+		utils.Mustf(err, "could not read sign cert from %s", k.SignCertificate)
+	default:
+		panic("could not find verification key or sign certificate")
+	}
+
 	return signingKey, verificationKey
-}
-
-func loadKeys(keyPath KeyPath) (signingKey signature.PrivateKey, verificationKey signature.PublicKey, err error) {
-	signingKey, err = os.ReadFile(keyPath.SigningKey)
-	if err != nil {
-		return nil, nil, errors.Wrapf(err,
-			"could not read private key from %s", keyPath.SigningKey,
-		)
-	}
-
-	if keyPath.VerificationKey != "" && utils.FileExists(keyPath.VerificationKey) {
-		verificationKey, err = os.ReadFile(keyPath.VerificationKey)
-		if err != nil {
-			return nil, nil, errors.Wrapf(err,
-				"could not read public key from %s", keyPath.VerificationKey,
-			)
-		}
-		logger.Infof("Loaded private key and verification key from files %s and %s.",
-			keyPath.SigningKey, keyPath.VerificationKey)
-		return signingKey, verificationKey, nil
-	}
-
-	if keyPath.SignCertificate != "" && utils.FileExists(keyPath.SignCertificate) {
-		verificationKey, err = testsig.GetSerializedKeyFromCert(keyPath.SignCertificate)
-		if err != nil {
-			return nil, nil, errors.Wrapf(err,
-				"could not read sign cert from %s", keyPath.SignCertificate,
-			)
-		}
-		logger.Infof("Sign cert and key found in files %s/%s. Importing...",
-			keyPath.SignCertificate, keyPath.SigningKey)
-		return signingKey, verificationKey, nil
-	}
-
-	return nil, nil, errors.New("could not find verification key or sign certificate")
 }

--- a/loadgen/workload/stream_test.go
+++ b/loadgen/workload/stream_test.go
@@ -10,6 +10,8 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -21,6 +23,7 @@ import (
 	"github.com/hyperledger/fabric-x-committer/api/servicepb"
 	"github.com/hyperledger/fabric-x-committer/utils/signature"
 	"github.com/hyperledger/fabric-x-committer/utils/test"
+	"github.com/hyperledger/fabric-x-committer/utils/testsig"
 )
 
 // result is used to prevent compiler optimizations.
@@ -178,7 +181,8 @@ func testWorkersProfiles() (profiles []*Profile) {
 	return profiles
 }
 
-func testTxProfiles() (profiles []*Profile) {
+func testTxProfiles(t *testing.T) (profiles []*Profile) {
+	t.Helper()
 	for _, onlyReadWrite := range []bool{true, false} {
 		for _, p := range testWorkersProfiles() {
 			if !onlyReadWrite {
@@ -191,7 +195,31 @@ func testTxProfiles() (profiles []*Profile) {
 			profiles = append(profiles, p)
 		}
 	}
-	return profiles
+
+	// Adding test cases with user keys.
+	tmpDir := t.TempDir()
+
+	sigKey, verKey := testsig.NewKeyPair(signature.Ecdsa)
+	sigPath := KeyPath{
+		SigningKey:      filepath.Join(tmpDir, "signing.key"),
+		VerificationKey: filepath.Join(tmpDir, "verification.key"),
+	}
+	require.NoError(t, os.WriteFile(sigPath.SigningKey, sigKey, 0o600))
+	require.NoError(t, os.WriteFile(sigPath.VerificationKey, verKey, 0o600))
+	sigProfile := DefaultProfile(1)
+	sigProfile.Policy.NamespacePolicies[DefaultGeneratedNamespaceID].KeyPath = &sigPath
+
+	sigWithCertKey, cert := testsig.EcdsaNewKeyPairWithCert()
+	sigWithCertPath := KeyPath{
+		SigningKey:      filepath.Join(tmpDir, "signing-with-cert.key"),
+		SignCertificate: filepath.Join(tmpDir, "cert.pem"),
+	}
+	require.NoError(t, os.WriteFile(sigWithCertPath.SigningKey, sigWithCertKey, 0o600))
+	require.NoError(t, os.WriteFile(sigWithCertPath.SignCertificate, cert, 0o600))
+	sigWithCertProfile := DefaultProfile(1)
+	sigWithCertProfile.Policy.NamespacePolicies[DefaultGeneratedNamespaceID].KeyPath = &sigWithCertPath
+
+	return append(profiles, sigProfile, sigWithCertProfile)
 }
 
 func startTxGeneratorUnderTest(
@@ -214,11 +242,8 @@ func startQueryGeneratorUnderTest(
 
 func TestGenValidTx(t *testing.T) {
 	t.Parallel()
-	for _, p := range testTxProfiles() {
-		onlyReadWrite := p.Transaction.ReadOnlyCount == nil
-		t.Run(fmt.Sprintf(
-			"workers:%d-onlyReadWrite:%v", p.Workers, onlyReadWrite,
-		), func(t *testing.T) {
+	for _, p := range testTxProfiles(t) {
+		t.Run(profileTestName(p), func(t *testing.T) {
 			t.Parallel()
 			c := startTxGeneratorUnderTest(t, p, defaultStreamOptions())
 			g := c.MakeGenerator()
@@ -233,11 +258,8 @@ func TestGenValidTx(t *testing.T) {
 
 func TestGenValidBlock(t *testing.T) {
 	t.Parallel()
-	for _, p := range testTxProfiles() {
-		onlyReadWrite := p.Transaction.ReadOnlyCount == nil
-		t.Run(fmt.Sprintf(
-			"workers:%d-onlyReadWrite:%v", p.Workers, onlyReadWrite,
-		), func(t *testing.T) {
+	for _, p := range testTxProfiles(t) {
+		t.Run(profileTestName(p), func(t *testing.T) {
 			t.Parallel()
 			c := startTxGeneratorUnderTest(t, p, defaultStreamOptions())
 			g := c.MakeGenerator()
@@ -251,6 +273,19 @@ func TestGenValidBlock(t *testing.T) {
 			}
 		})
 	}
+}
+
+func profileTestName(p *Profile) string {
+	onlyReadWrite := p.Transaction.ReadOnlyCount == nil
+	key := "no-key"
+	policy := p.Policy.NamespacePolicies[DefaultGeneratedNamespaceID]
+	if policy.KeyPath != nil && policy.KeyPath.VerificationKey != "" {
+		key = "verification-key"
+	}
+	if policy.KeyPath != nil && policy.KeyPath.SignCertificate != "" {
+		key = "signing-certificate"
+	}
+	return fmt.Sprintf("workers:%d-onlyReadWrite:%v-%s", p.Workers, onlyReadWrite, key)
 }
 
 func TestGenInvalidSigTx(t *testing.T) {

--- a/utils/testsig/key_factory.go
+++ b/utils/testsig/key_factory.go
@@ -12,11 +12,15 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/sha3"
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/binary"
+	"encoding/pem"
 	"io"
 	"math/big"
 	pseudorand "math/rand"
 	"strings"
+	"time"
 
 	"github.com/consensys/gnark-crypto/ecc/bn254"
 	"github.com/consensys/gnark-crypto/ecc/bn254/fr"
@@ -138,4 +142,24 @@ func ecdsaNewKeyPairWithSeed(seed int64) (signature.PrivateKey, signature.Public
 	serializedPublicKey, err := SerializeVerificationKey(&pk.PublicKey)
 	utils.Must(err)
 	return serializedPrivateKey, serializedPublicKey
+}
+
+// EcdsaNewKeyPairWithCert generates an ECDSA key with a matching certificate.
+func EcdsaNewKeyPairWithCert() (signature.PrivateKey, []byte) {
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	utils.Must(err)
+	serializedPrivateKey, err := SerializeSigningKey(privateKey)
+	utils.Must(err)
+
+	// Create a self-signed certificate
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject:      pkix.Name{Organization: []string{"Test"}},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(time.Hour * 24),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+	}
+	certBytes, err := x509.CreateCertificate(rand.Reader, template, template, &privateKey.PublicKey, privateKey)
+	utils.Must(err)
+	return serializedPrivateKey, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certBytes})
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -62,6 +62,13 @@ func Must(err error, msg ...string) {
 	}
 }
 
+// Mustf panics given an error.
+func Mustf(err error, format string, args ...any) {
+	if err != nil {
+		panic(errors.Wrapf(err, format, args...))
+	}
+}
+
 // MustRead reads a byte array of the given size from the source.
 // It panics if the read fails, or cannot read the requested size.
 // "crypto/rand" and "math/rand" never fail and always returns the correct length.


### PR DESCRIPTION
#### Type of change

- Test update
 
#### Description

- Add tests to `height.go`
- Remove `workload.CreateNamespacesTX(policy)` and replace calls with `workload.CreateNamespacesTxFromEndorser(c.TxBuilder.TxEndorser, ...)`
- Remove unused debug method for `Profile`
- Add test cases for profiles with user generated keys
- Refactor `workload.getKeyPair()`

#### Related issues

- address #293
- address #429
