### PR TITLE
[connection] Improve endpoint parsing test coverage

### DIFF
--- a/cmd/config/cobra_test_exports.go
+++ b/cmd/config/cobra_test_exports.go
@@ -49,7 +49,7 @@ func StartDefaultSystem(t *testing.T) SystemConfig {
 	_, vc := mock.StartMockVCService(t, serverParams)
 	_, orderer := mock.StartMockOrderingServices(t, &mock.OrdererConfig{TestServerParameters: serverParams})
 	_, coordinator := mock.StartMockCoordinatorService(t, serverParams)
-	server := connection.NewLocalHostServer(test.InsecureTLSConfig)
+	server := test.NewLocalHostServer(test.InsecureTLSConfig)
 	listen, err := server.Listener(t.Context())
 	require.NoError(t, err)
 	connection.CloseConnectionsLog(listen)
@@ -176,7 +176,7 @@ func defaultTestDBConfig() DatabaseConfig {
 	return DatabaseConfig{
 		Name:        "dummy_test_db",
 		Username:    username,
-		Endpoints:   []*connection.Endpoint{connection.CreateEndpointHP("localhost", "5433")},
+		Endpoints:   []*connection.Endpoint{{Host: "localhost", Port: 5433}},
 		LoadBalance: false,
 	}
 }

--- a/cmd/config/config_decoder.go
+++ b/cmd/config/config_decoder.go
@@ -7,7 +7,11 @@ SPDX-License-Identifier: Apache-2.0
 package config
 
 import (
+	"math"
+	"net"
 	"reflect"
+	"regexp"
+	"strconv"
 	"time"
 
 	"github.com/cockroachdb/errors"
@@ -16,6 +20,21 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/hyperledger/fabric-x-committer/utils/connection"
+)
+
+// RFC 1123 hostname validation regex:
+// - Labels (hostname components) can contain letters, digits, and hyphens.
+// - Labels must start and end with alphanumeric.
+// - Labels can be up to 63 characters.
+var hostNameRegex = regexp.MustCompile(
+	`(?i)^([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\.)*[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$`,
+)
+
+const (
+	// Total hostname can be up to 253 characters (RFC 1123).
+	hostNameMaxLength = 253
+	// Maximal valid port number.
+	maxPort = math.MaxUint16
 )
 
 // decoderHook contains custom unmarshalling for types not supported by default by mapstructure.
@@ -40,7 +59,7 @@ func endpointDecoder(dataType, targetType reflect.Type, rawData any) (result any
 	if !ok || targetType != reflect.TypeFor[connection.Endpoint]() {
 		return rawData, nil
 	}
-	endpoint, err := connection.NewEndpoint(stringData)
+	endpoint, err := parseEndpoint(stringData)
 	return endpoint, errors.Wrap(err, "failed to parse endpoint")
 }
 
@@ -49,10 +68,56 @@ func serverDecoder(dataType, targetType reflect.Type, rawData any) (result any, 
 	if !ok || targetType != reflect.TypeFor[connection.ServerConfig]() {
 		return rawData, nil
 	}
-	endpoint, err := connection.NewEndpoint(stringData)
+	endpoint, err := parseEndpoint(stringData)
 	var ret connection.ServerConfig
 	if endpoint != nil {
 		ret = connection.ServerConfig{Endpoint: *endpoint}
 	}
 	return ret, err
+}
+
+// parseEndpoint parses an endpoint from an address string.
+func parseEndpoint(hostPort string) (*connection.Endpoint, error) {
+	if len(hostPort) == 0 {
+		return &connection.Endpoint{}, nil
+	}
+	hostName, portStr, err := net.SplitHostPort(hostPort)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not split host and port")
+	}
+	err = validateHostName(hostName)
+	if err != nil {
+		return nil, err
+	}
+	portInt, err := strconv.Atoi(portStr)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not convert port to integer")
+	}
+	if portInt < 0 || portInt > maxPort {
+		return nil, errors.Newf("port must be between 0 and %d, got %d", maxPort, portInt)
+	}
+	return &connection.Endpoint{
+		Host: hostName,
+		Port: portInt,
+	}, nil
+}
+
+func validateHostName(hostName string) error {
+	// An empty hostname is valid (e.g., :8080).
+	if len(hostName) == 0 {
+		return nil
+	}
+	// Check if it's an IPv6 address (IPv6 already extracted from brackets by SplitHostPort).
+	if net.ParseIP(hostName) != nil {
+		return nil
+	}
+	// Not an IP, validate as hostname.
+	if len(hostName) > hostNameMaxLength {
+		return errors.Newf("hostname exceeds maximum length of 253 characters")
+	}
+	// RFC 1123 hostname validation.
+	if !hostNameRegex.MatchString(hostName) {
+		return errors.Newf("invalid hostname: %s", hostName)
+	}
+	return nil
 }

--- a/cmd/config/config_decoder_test.go
+++ b/cmd/config/config_decoder_test.go
@@ -8,6 +8,7 @@ package config
 
 import (
 	"bytes"
+	"strings"
 	"testing"
 
 	commontypes "github.com/hyperledger/fabric-x-common/api/types"
@@ -40,7 +41,7 @@ yaml-orderer-endpoint:
     port: 5050
 `
 
-func TestEndpoints(t *testing.T) {
+func TestParseEndpoint(t *testing.T) {
 	t.Parallel()
 	v := viper.New()
 	require.NoError(t, readYamlConfigsFromIO(v, bytes.NewBufferString(config)))
@@ -70,4 +71,178 @@ func TestEndpoints(t *testing.T) {
 	require.Equal(t, expected, conf.JSONOrdererEndpoint)
 	require.Equal(t, expected, conf.MultilineJSONOrdererEndpoint)
 	require.Equal(t, expected, conf.YamlJSONOrdererEndpoint)
+}
+
+func TestParseEndpointEdgeCases(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name     string
+		input    string
+		expected *connection.Endpoint
+	}{
+		{
+			name:     "empty string returns empty endpoint",
+			input:    "",
+			expected: &connection.Endpoint{},
+		},
+		{
+			name:  "valid hostname and port",
+			input: "localhost:8080",
+			expected: &connection.Endpoint{
+				Host: "localhost",
+				Port: 8080,
+			},
+		},
+		{
+			name:  "valid IP address and port",
+			input: "192.168.1.1:9090",
+			expected: &connection.Endpoint{
+				Host: "192.168.1.1",
+				Port: 9090,
+			},
+		},
+		{
+			name:  "IPv6 address with brackets",
+			input: "[::1]:8080",
+			expected: &connection.Endpoint{
+				Host: "::1",
+				Port: 8080,
+			},
+		},
+		{
+			name:  "IPv6 full address with brackets",
+			input: "[2001:db8::1]:443",
+			expected: &connection.Endpoint{
+				Host: "2001:db8::1",
+				Port: 443,
+			},
+		},
+		{
+			name:  "hostname with hyphen",
+			input: "my-service:3000",
+			expected: &connection.Endpoint{
+				Host: "my-service",
+				Port: 3000,
+			},
+		},
+		{
+			name:  "FQDN with port",
+			input: "service.example.com:443",
+			expected: &connection.Endpoint{
+				Host: "service.example.com",
+				Port: 443,
+			},
+		},
+		{
+			name:  "empty host with port",
+			input: ":8080",
+			expected: &connection.Endpoint{
+				Host: "",
+				Port: 8080,
+			},
+		},
+		{
+			name:  "port at upper boundary",
+			input: "localhost:65535",
+			expected: &connection.Endpoint{
+				Host: "localhost",
+				Port: 65535,
+			},
+		},
+		{
+			name:  "port at lower boundary",
+			input: "localhost:0",
+			expected: &connection.Endpoint{
+				Host: "localhost",
+				Port: 0,
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			result, err := parseEndpoint(tc.input)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, result)
+		})
+	}
+
+	for _, tc := range []struct {
+		name     string
+		input    string
+		errorMsg string
+	}{
+		{
+			name:     "missing port",
+			input:    "localhost",
+			errorMsg: "could not split host and port",
+		},
+		{
+			name:     "invalid port - non-numeric",
+			input:    "localhost:abc",
+			errorMsg: "could not convert port to integer",
+		},
+		{
+			name:     "invalid port - empty",
+			input:    "localhost:",
+			errorMsg: "could not convert port to integer",
+		},
+		{
+			name:     "invalid port - space",
+			input:    "localhost: 1234",
+			errorMsg: "could not convert port to integer",
+		},
+		{
+			name:     "multiple colons without brackets",
+			input:    "::1:8080",
+			errorMsg: "could not split host and port",
+		},
+		{
+			name:     "negative port",
+			input:    "localhost:-1",
+			errorMsg: "port must be between 0 and 65535",
+		},
+		{
+			name:     "port too large",
+			input:    "localhost:65536",
+			errorMsg: "port must be between 0 and 65535",
+		},
+		{
+			name:     "port way too large",
+			input:    "localhost:99999",
+			errorMsg: "port must be between 0 and 65535",
+		},
+		{
+			name:     "invalid hostname - starts with hyphen",
+			input:    "-invalid:8080",
+			errorMsg: "invalid hostname",
+		},
+		{
+			name:     "invalid hostname - ends with hyphen",
+			input:    "invalid-:8080",
+			errorMsg: "invalid hostname",
+		},
+		{
+			name:     "invalid hostname - special characters",
+			input:    "host_name:8080",
+			errorMsg: "invalid hostname",
+		},
+		{
+			name:     "invalid hostname - spaces",
+			input:    "host name:8080",
+			errorMsg: "invalid hostname",
+		},
+		{
+			name:     "hostname too long",
+			input:    strings.Repeat("a", 254) + ":8080",
+			errorMsg: "hostname exceeds maximum length",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			result, err := parseEndpoint(tc.input)
+			require.ErrorContains(t, err, tc.errorMsg)
+			require.Nil(t, result)
+		})
+	}
 }

--- a/docker/test/container_test.go
+++ b/docker/test/container_test.go
@@ -11,7 +11,6 @@ import (
 	_ "embed"
 	"fmt"
 	"math/rand"
-	"net"
 	"path/filepath"
 	"testing"
 	"time"
@@ -200,10 +199,7 @@ func TestStartTestNode(t *testing.T) {
 	})
 
 	t.Log("Try to fetch the first block")
-	sidecarEndpoint, err := connection.NewEndpoint(
-		net.JoinHostPort(localhost, getContainerMappedHostPort(ctx, t, containerName, sidecarPort)),
-	)
-	require.NoError(t, err)
+	sidecarEndpoint := mustGetEndpoint(ctx, t, containerName, sidecarPort)
 	committerClient := test.NewInsecureClientConfig(sidecarEndpoint)
 	committedBlock := delivercommitter.Start(ctx, t, committerClient, 0)
 	b, ok := channel.NewReader(ctx, committedBlock).Read()
@@ -287,11 +283,7 @@ func startCommitter(ctx context.Context, t *testing.T, params startNodeParameter
 
 func mustGetEndpoint(ctx context.Context, t *testing.T, containerName, servicePort string) *connection.Endpoint {
 	t.Helper()
-	ep, err := connection.NewEndpoint(
-		net.JoinHostPort(localhost, getContainerMappedHostPort(ctx, t, containerName, servicePort)),
-	)
-	require.NoError(t, err)
-	return ep
+	return test.NewEndpoint(t, localhost, getContainerMappedHostPort(ctx, t, containerName, servicePort))
 }
 
 // requireQueryResults checks that the QueryService returned the expected rows.

--- a/integration/runner/ports.go
+++ b/integration/runner/ports.go
@@ -57,7 +57,7 @@ func (p *serviceAllocator) allocateService(t *testing.T, count int) []config.Ser
 
 func (p *serviceAllocator) allocateEndpoint(t *testing.T) *connection.Endpoint {
 	t.Helper()
-	s := connection.NewLocalHostServer(test.InsecureTLSConfig)
+	s := test.NewLocalHostServer(test.InsecureTLSConfig)
 	listener, err := s.Listener(t.Context())
 	require.NoError(t, err)
 	p.listeners = append(p.listeners, listener)

--- a/loadgen/client_test.go
+++ b/loadgen/client_test.go
@@ -130,8 +130,8 @@ func startVerifiers(t *testing.T, serverTLS, clientTLS connection.TLSConfig) *co
 	endpoints := make([]*connection.Endpoint, 2)
 	for i := range endpoints {
 		sConf := &verifier.Config{
-			Server:     connection.NewLocalHostServer(serverTLS),
-			Monitoring: connection.NewLocalHostServer(serverTLS),
+			Server:     test.NewLocalHostServer(serverTLS),
+			Monitoring: test.NewLocalHostServer(serverTLS),
 			ParallelExecutor: verifier.ExecutorConfig{
 				BatchSizeCutoff:   50,
 				BatchTimeCutoff:   10 * time.Millisecond,
@@ -168,8 +168,8 @@ func TestLoadGenForCoordinator(t *testing.T) {
 			_, vcServer := mock.StartMockVCService(t, mockSettings)
 
 			cConf := &coordinator.Config{
-				Server:             connection.NewLocalHostServer(serverTLSConfig),
-				Monitoring:         connection.NewLocalHostServer(serverTLSConfig),
+				Server:             test.NewLocalHostServer(serverTLSConfig),
+				Monitoring:         test.NewLocalHostServer(serverTLSConfig),
 				Verifier:           *test.ServerToMultiClientConfig(clientTLSConfig, sigVerServer.Configs...),
 				ValidatorCommitter: *test.ServerToMultiClientConfig(clientTLSConfig, vcServer.Configs...),
 				DependencyGraph: &coordinator.DependencyGraphConfig{
@@ -226,7 +226,7 @@ func TestLoadGenForSidecar(t *testing.T) {
 					clientTLSConfig,
 					&coordinatorServer.Configs[0].Endpoint,
 				),
-				Monitoring: connection.NewLocalHostServer(serverTLSConfig),
+				Monitoring: test.NewLocalHostServer(serverTLSConfig),
 				Ledger: sidecar.LedgerConfig{
 					Path: t.TempDir(),
 				},
@@ -279,14 +279,14 @@ func TestLoadGenForOrderer(t *testing.T) {
 
 			endpoints := test.NewOrdererEndpoints(0, ordererServer.Configs...)
 			sidecarConf := &sidecar.Config{
-				Server:                        connection.NewLocalHostServer(serverTLSConfig),
+				Server:                        test.NewLocalHostServer(serverTLSConfig),
 				LastCommittedBlockSetInterval: 100 * time.Millisecond,
 				WaitingTxsLimit:               5000,
 				Committer: test.NewTLSClientConfig(
 					clientTLSConfig,
 					&coordinatorServer.Configs[0].Endpoint,
 				),
-				Monitoring: connection.NewLocalHostServer(serverTLSConfig),
+				Monitoring: test.NewLocalHostServer(serverTLSConfig),
 				Ledger: sidecar.LedgerConfig{
 					Path: t.TempDir(),
 				},
@@ -379,7 +379,7 @@ func TestLoadGenForOnlyOrderer(t *testing.T) {
 
 func preAllocatePorts(t *testing.T, tlsConfig connection.TLSConfig) *connection.ServerConfig {
 	t.Helper()
-	server := connection.NewLocalHostServer(tlsConfig)
+	server := test.NewLocalHostServer(tlsConfig)
 	listener, err := server.PreAllocateListener()
 	require.NoError(t, err)
 	t.Cleanup(func() {
@@ -463,7 +463,7 @@ func TestLoadGenRateLimiterServer(t *testing.T) {
 	clientConf.LoadProfile.Block.PreferredRate = 10 * time.Millisecond
 	clientConf.LoadProfile.Block.MaxSize = 100
 	clientConf.LoadProfile.Block.MinSize = 1
-	clientConf.HTTPServer = connection.NewLocalHostServer(test.InsecureTLSConfig)
+	clientConf.HTTPServer = test.NewLocalHostServer(test.InsecureTLSConfig)
 	client, err := NewLoadGenClient(clientConf)
 	require.NoError(t, err)
 

--- a/loadgen/client_test_utils.go
+++ b/loadgen/client_test_utils.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hyperledger/fabric-x-committer/loadgen/metrics"
 	"github.com/hyperledger/fabric-x-committer/loadgen/workload"
 	"github.com/hyperledger/fabric-x-committer/utils/connection"
+	"github.com/hyperledger/fabric-x-committer/utils/test"
 )
 
 const defaultBlockSize = 500
@@ -37,9 +38,9 @@ func eventuallyMetrics(
 func DefaultClientConf(t *testing.T, serverTLS connection.TLSConfig) *ClientConfig {
 	t.Helper()
 	return &ClientConfig{
-		Server: connection.NewLocalHostServer(serverTLS),
+		Server: test.NewLocalHostServer(serverTLS),
 		Monitoring: metrics.Config{
-			ServerConfig: *connection.NewLocalHostServer(serverTLS),
+			ServerConfig: *test.NewLocalHostServer(serverTLS),
 		},
 		LoadProfile: &workload.Profile{
 			Key:   workload.KeyProfile{Size: 32},

--- a/service/coordinator/coordinator_test.go
+++ b/service/coordinator/coordinator_test.go
@@ -123,7 +123,7 @@ func newCoordinatorTestEnv(t *testing.T, tConfig *testConfig) *coordinatorTestEn
 			WaitingTxsLimit:           10,
 		},
 		ChannelBufferSizePerGoroutine: 2000,
-		Monitoring:                    connection.NewLocalHostServer(test.InsecureTLSConfig),
+		Monitoring:                    test.NewLocalHostServer(test.InsecureTLSConfig),
 	}
 
 	return &coordinatorTestEnv{
@@ -157,7 +157,7 @@ func (e *coordinatorTestEnv) startService(
 ) {
 	t.Helper()
 	cs := e.coordinator
-	e.coordinator.config.Server = connection.NewLocalHostServer(e.serverTLS)
+	e.coordinator.config.Server = test.NewLocalHostServer(e.serverTLS)
 
 	test.RunServiceAndGrpcForTest(ctx, t, cs, e.coordinator.config.Server)
 }
@@ -890,7 +890,14 @@ func (e *coordinatorTestEnv) receiveStatus(t *testing.T, count int) []*committer
 
 func TestConnectionReadyWithTimeout(t *testing.T) {
 	t.Parallel()
-	c := NewCoordinatorService(fakeConfigForTest(t))
+	randomEndpoint := &connection.Endpoint{Host: "random", Port: 1234}
+	c := NewCoordinatorService(&Config{
+		Server:             test.NewLocalHostServer(test.InsecureTLSConfig),
+		Verifier:           *test.NewTLSMultiClientConfig(test.InsecureTLSConfig, randomEndpoint),
+		ValidatorCommitter: *test.NewTLSMultiClientConfig(test.InsecureTLSConfig, randomEndpoint),
+		DependencyGraph:    &DependencyGraphConfig{},
+		Monitoring:         test.NewLocalHostServer(test.InsecureTLSConfig),
+	})
 	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	t.Cleanup(cancel)
 	require.False(t, c.WaitForReady(ctx))
@@ -989,19 +996,6 @@ func TestWaitingTxsCount(t *testing.T) {
 		}
 		return wTxs.GetCount() == 0
 	}, 2*time.Second, 100*time.Millisecond)
-}
-
-func fakeConfigForTest(t *testing.T) *Config {
-	t.Helper()
-	randomEndpoint, err := connection.NewEndpoint("random:1234")
-	require.NoError(t, err)
-	return &Config{
-		Server:             connection.NewLocalHostServer(test.InsecureTLSConfig),
-		Verifier:           *test.NewTLSMultiClientConfig(test.InsecureTLSConfig, randomEndpoint),
-		ValidatorCommitter: *test.NewTLSMultiClientConfig(test.InsecureTLSConfig, randomEndpoint),
-		DependencyGraph:    &DependencyGraphConfig{},
-		Monitoring:         connection.NewLocalHostServer(test.InsecureTLSConfig),
-	}
 }
 
 func readTxStatus(t *testing.T, stream servicepb.Coordinator_BlockProcessingClient, count int) []*committerpb.TxStatus {

--- a/service/query/query_service_test.go
+++ b/service/query/query_service_test.go
@@ -531,10 +531,10 @@ func newQueryServiceTestEnv(t *testing.T, opts *queryServiceTestOpts) *queryServ
 		MaxViewTimeout:        time.Minute,
 		MaxAggregatedViews:    5,
 		MaxActiveViews:        opts.maxActiveViews,
-		Server:                connection.NewLocalHostServer(opts.serverTLS),
+		Server:                test.NewLocalHostServer(opts.serverTLS),
 		MaxRequestKeys:        opts.maxRequestKeys,
 		Database:              dbConf,
-		Monitoring:            connection.NewLocalHostServer(test.InsecureTLSConfig),
+		Monitoring:            test.NewLocalHostServer(test.InsecureTLSConfig),
 	}
 
 	qs := NewQueryService(config)

--- a/service/sidecar/block_delivery_test.go
+++ b/service/sidecar/block_delivery_test.go
@@ -19,7 +19,6 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	"github.com/hyperledger/fabric-x-committer/utils/connection"
 	"github.com/hyperledger/fabric-x-committer/utils/test"
 )
 
@@ -29,7 +28,7 @@ func TestBlockDelivery(t *testing.T) {
 	bs, _ := newBlockStoreWithBlocks(t, 3)
 
 	// Register block delivery on a gRPC server.
-	config := connection.NewLocalHostServer(test.InsecureTLSConfig)
+	config := test.NewLocalHostServer(test.InsecureTLSConfig)
 	test.RunGrpcServerForTest(t.Context(), t, config,
 		func(server *grpc.Server) {
 			peer.RegisterDeliverServer(server, newBlockDelivery(bs))

--- a/service/sidecar/block_query_test.go
+++ b/service/sidecar/block_query_test.go
@@ -16,7 +16,6 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/emptypb"
 
-	"github.com/hyperledger/fabric-x-committer/utils/connection"
 	"github.com/hyperledger/fabric-x-committer/utils/test"
 )
 
@@ -28,7 +27,7 @@ func TestBlockQuery(t *testing.T) {
 	// Create the query service and register on a gRPC server.
 	queryService := newBlockQuery(bs)
 
-	config := connection.NewLocalHostServer(test.InsecureTLSConfig)
+	config := test.NewLocalHostServer(test.InsecureTLSConfig)
 	test.RunGrpcServerForTest(t.Context(), t, config, func(server *grpc.Server) {
 		committerpb.RegisterBlockQueryServiceServer(server, queryService)
 	})

--- a/service/sidecar/block_store_test.go
+++ b/service/sidecar/block_store_test.go
@@ -35,7 +35,7 @@ func TestBlockStoreAndDelivery(t *testing.T) {
 
 	bd := newBlockDelivery(bs)
 
-	config := connection.NewLocalHostServer(test.InsecureTLSConfig)
+	config := test.NewLocalHostServer(test.InsecureTLSConfig)
 	inputBlock := make(chan *common.Block, 10)
 	test.RunServiceForTest(t.Context(), t, func(ctx context.Context) error {
 		return connection.FilterStreamRPCError(bs.run(ctx, &blockStoreRunConfig{

--- a/service/sidecar/notify_test.go
+++ b/service/sidecar/notify_test.go
@@ -247,7 +247,7 @@ func TestNotifierDirect(t *testing.T) {
 func TestNotifierStream(t *testing.T) {
 	t.Parallel()
 	env := newNotifierTestEnv(t)
-	config := connection.NewLocalHostServer(test.InsecureTLSConfig)
+	config := test.NewLocalHostServer(test.InsecureTLSConfig)
 	test.RunGrpcServerForTest(t.Context(), t, config, func(server *grpc.Server) {
 		committerpb.RegisterNotifierServer(server, env.n)
 	})

--- a/service/sidecar/sidecar_test.go
+++ b/service/sidecar/sidecar_test.go
@@ -152,7 +152,7 @@ func newSidecarTestEnvWithTLS(
 		initOrdererOrganizations = nil
 	}
 	sidecarConf := &Config{
-		Server:    connection.NewLocalHostServer(conf.ServerTLS),
+		Server:    test.NewLocalHostServer(conf.ServerTLS),
 		Committer: test.NewTLSClientConfig(conf.ClientTLS, &coordinatorServer.Configs[0].Endpoint),
 		Ledger: LedgerConfig{
 			Path: t.TempDir(),
@@ -162,7 +162,7 @@ func newSidecarTestEnvWithTLS(
 		},
 		LastCommittedBlockSetInterval: 100 * time.Millisecond,
 		WaitingTxsLimit:               1000,
-		Monitoring:                    connection.NewLocalHostServer(conf.ServerTLS),
+		Monitoring:                    test.NewLocalHostServer(conf.ServerTLS),
 		Bootstrap: Bootstrap{
 			GenesisBlockFilePath: genesisBlockFilePath,
 		},

--- a/service/vc/config_test.go
+++ b/service/vc/config_test.go
@@ -12,15 +12,12 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/hyperledger/fabric-x-committer/utils/connection"
-	"github.com/hyperledger/fabric-x-committer/utils/test"
 )
 
 func TestDatasourceName(t *testing.T) {
 	t.Parallel()
 	c1 := &DatabaseConfig{
-		Endpoints: []*connection.Endpoint{
-			test.MustCreateEndpoint("localhost:5433"),
-		},
+		Endpoints:   []*connection.Endpoint{{Host: "localhost", Port: 5433}},
 		Username:    "yugabyte_user",
 		Password:    "yugabyte_pass",
 		Database:    "yugabyte_db",
@@ -34,8 +31,8 @@ func TestDatasourceName(t *testing.T) {
 
 	c2 := &DatabaseConfig{
 		Endpoints: []*connection.Endpoint{
-			test.MustCreateEndpoint("host1:1111"),
-			test.MustCreateEndpoint("host2:2222"),
+			{Host: "host1", Port: 1111},
+			{Host: "host2", Port: 2222},
 		},
 		Username:    "yugabyte",
 		Password:    "yugabyte",

--- a/service/vc/dbinit_test.go
+++ b/service/vc/dbinit_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/hyperledger/fabric-x-committer/utils/connection"
-	"github.com/hyperledger/fabric-x-committer/utils/test"
 )
 
 func TestDBInit(t *testing.T) {
@@ -82,9 +81,7 @@ func TestRetry(t *testing.T) {
 	pool, err := NewDatabasePool(
 		ctx,
 		&DatabaseConfig{
-			Endpoints: []*connection.Endpoint{
-				test.MustCreateEndpoint(":1234"),
-			},
+			Endpoints:      []*connection.Endpoint{{Port: 1234}},
 			Username:       "name",
 			Password:       "pwd",
 			MaxConnections: 5,

--- a/service/vc/test_exports.go
+++ b/service/vc/test_exports.go
@@ -80,10 +80,10 @@ func NewValidatorAndCommitServiceTestEnv(t *testing.T, opts *TestEnvOpts) *Valid
 
 	for i := range vcservices {
 		config := &Config{
-			Server:         connection.NewLocalHostServer(opts.ServerCreds),
+			Server:         test.NewLocalHostServer(opts.ServerCreds),
 			Database:       opts.DBEnv.DBConf,
 			ResourceLimits: opts.ResourceLimits,
-			Monitoring:     connection.NewLocalHostServer(test.InsecureTLSConfig),
+			Monitoring:     test.NewLocalHostServer(test.InsecureTLSConfig),
 		}
 		vcs, err := NewValidatorCommitterService(initCtx, config)
 		require.NoError(t, err)

--- a/service/verifier/verifier_server_test.go
+++ b/service/verifier/verifier_server_test.go
@@ -552,14 +552,14 @@ func defaultCryptoParameters(t *testing.T) cryptoParameters {
 
 func defaultConfigWithTLS(tlsConfig connection.TLSConfig) *Config {
 	return &Config{
-		Server: connection.NewLocalHostServer(tlsConfig),
+		Server: test.NewLocalHostServer(tlsConfig),
 		ParallelExecutor: ExecutorConfig{
 			BatchSizeCutoff:   3,
 			BatchTimeCutoff:   1 * time.Hour,
 			Parallelism:       3,
 			ChannelBufferSize: 1,
 		},
-		Monitoring: connection.NewLocalHostServer(test.InsecureTLSConfig),
+		Monitoring: test.NewLocalHostServer(test.InsecureTLSConfig),
 	}
 }
 

--- a/utils/connection/client_util_test.go
+++ b/utils/connection/client_util_test.go
@@ -39,7 +39,7 @@ func TestGRPCRetry(t *testing.T) {
 	})
 
 	t.Log("Starting service")
-	serverConfig := connection.NewLocalHostServer(test.InsecureTLSConfig)
+	serverConfig := test.NewLocalHostServer(test.InsecureTLSConfig)
 
 	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Minute)
 	t.Cleanup(cancel)
@@ -108,7 +108,7 @@ func TestGRPCRetryMultiEndpoints(t *testing.T) {
 	})
 
 	t.Log("Starting service")
-	serverConfig := connection.NewLocalHostServer(test.InsecureTLSConfig)
+	serverConfig := test.NewLocalHostServer(test.InsecureTLSConfig)
 
 	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Minute)
 	t.Cleanup(cancel)
@@ -123,7 +123,7 @@ func TestGRPCRetryMultiEndpoints(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Log("Creating fake service address")
-	fakeServerConfig := connection.NewLocalHostServer(test.InsecureTLSConfig)
+	fakeServerConfig := test.NewLocalHostServer(test.InsecureTLSConfig)
 	l, err := fakeServerConfig.Listener(t.Context())
 	require.NoError(t, err)
 	t.Cleanup(func() {

--- a/utils/connection/endpoint.go
+++ b/utils/connection/endpoint.go
@@ -9,8 +9,6 @@ package connection
 import (
 	"net"
 	"strconv"
-
-	"github.com/cockroachdb/errors"
 )
 
 // Endpoint describes a remote endpoint.
@@ -32,41 +30,4 @@ func (e *Endpoint) Address() string {
 // String returns a string representation of the endpoint.
 func (e *Endpoint) String() string {
 	return e.Address()
-}
-
-// GetHost returns the host of the endpoint.
-func (e *Endpoint) GetHost() string { return e.Host }
-
-// CreateEndpointHP parses an endpoint from give host and port.
-// It panics if it fails to parse.
-func CreateEndpointHP(host, port string) *Endpoint {
-	convertedPort, err := strconv.Atoi(port)
-	if err != nil {
-		panic(errors.New("could not convert port to integer"))
-	}
-	return &Endpoint{
-		Host: host,
-		Port: convertedPort,
-	}
-}
-
-// NewEndpoint parses an endpoint from an address string.
-func NewEndpoint(hostPort string) (*Endpoint, error) {
-	if len(hostPort) == 0 {
-		return &Endpoint{}, nil
-	}
-	host, port, err := net.SplitHostPort(hostPort)
-	if err != nil {
-		return nil, errors.Wrap(err, "could not split host and port")
-	}
-	portInt, err := strconv.Atoi(port)
-	if err != nil {
-		return nil, errors.Wrap(err, "could not convert port to integer")
-	}
-	return &Endpoint{Host: host, Port: portInt}, nil
-}
-
-// NewLocalHost returns a default endpoint "localhost:0".
-func NewLocalHost() *Endpoint {
-	return &Endpoint{Host: "127.0.0.1"}
 }

--- a/utils/connection/server_util.go
+++ b/utils/connection/server_util.go
@@ -40,14 +40,6 @@ var listenRetry = RetryProfile{
 	MaxElapsedTime:  2 * time.Minute,
 }
 
-// NewLocalHostServer returns a default server config with endpoint "localhost:0" given server credentials.
-func NewLocalHostServer(creds TLSConfig) *ServerConfig {
-	return &ServerConfig{
-		Endpoint: *NewLocalHost(),
-		TLS:      creds,
-	}
-}
-
 // GrpcServer instantiate a [grpc.Server].
 func (c *ServerConfig) GrpcServer() (*grpc.Server, error) {
 	opts := []grpc.ServerOption{grpc.MaxRecvMsgSize(maxMsgSize), grpc.MaxSendMsgSize(maxMsgSize)}

--- a/utils/monitoring/provider_test.go
+++ b/utils/monitoring/provider_test.go
@@ -234,7 +234,7 @@ func newMetricsProviderTestEnv(t *testing.T, serverTLS, clientTLS connection.TLS
 	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Minute)
 	t.Cleanup(cancel)
 
-	c := connection.NewLocalHostServer(serverTLS)
+	c := test.NewLocalHostServer(serverTLS)
 	go func() {
 		assert.NoError(t, p.StartPrometheusServer(ctx, c))
 	}()

--- a/utils/test/utils.go
+++ b/utils/test/utils.go
@@ -19,6 +19,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -150,7 +151,7 @@ func StartGrpcServersForTest(
 	t.Helper()
 	sc := make([]*connection.ServerConfig, p.NumService)
 	for i := range sc {
-		sc[i] = connection.NewLocalHostServer(p.TLSConfig)
+		sc[i] = NewLocalHostServer(p.TLSConfig)
 	}
 	return StartGrpcServersWithConfigForTest(ctx, t, register, sc...)
 }
@@ -449,16 +450,6 @@ func flattenEndpoint(in map[string]any) *connection.Endpoint {
 	return &connection.Endpoint{Host: hostStr, Port: int(portFloat)}
 }
 
-// MustCreateEndpoint parses an endpoint from an address string.
-// It panics if it fails to parse.
-func MustCreateEndpoint(value string) *connection.Endpoint {
-	endpoint, err := connection.NewEndpoint(value)
-	if err != nil {
-		panic(errors.Wrap(err, "could not create endpoint"))
-	}
-	return endpoint
-}
-
 const (
 	// CreatorCertificate denotes Creator field in protoblocktx.Identity to contain x509 certificate.
 	CreatorCertificate = 0
@@ -543,5 +534,21 @@ func NewServiceTLSConfig(artifactsPath, serviceName, mode string) connection.TLS
 		CACertPaths: []string{
 			filepath.Join(artifactsPath, OrgRootCA),
 		},
+	}
+}
+
+// NewEndpoint creates an endpoint from give host and port (as string).
+func NewEndpoint(t *testing.T, host, port string) *connection.Endpoint {
+	t.Helper()
+	convertedPort, err := strconv.Atoi(port)
+	require.NoError(t, err, "could not convert port to integer")
+	return &connection.Endpoint{Host: host, Port: convertedPort}
+}
+
+// NewLocalHostServer returns a default server config with endpoint "localhost:0" given server credentials.
+func NewLocalHostServer(creds connection.TLSConfig) *connection.ServerConfig {
+	return &connection.ServerConfig{
+		Endpoint: connection.Endpoint{Host: "127.0.0.1"},
+		TLS:      creds,
 	}
 }

--- a/utils/testdb/container.go
+++ b/utils/testdb/container.go
@@ -302,13 +302,11 @@ func (dc *DatabaseContainer) GetConnectionOptions(ctx context.Context, t *testin
 	})
 	require.NoError(t, err)
 
-	endpoints := []*connection.Endpoint{
-		dc.GetContainerConnectionDetails(t),
-	}
+	endpoints := make([]*connection.Endpoint, 0, len(container.NetworkSettings.Ports)+1)
+	endpoints = append(endpoints, dc.GetContainerConnectionDetails(t))
 	for _, p := range container.NetworkSettings.Ports[dc.DbPort] {
-		endpoints = append(endpoints, connection.CreateEndpointHP(p.HostIP, p.HostPort))
+		endpoints = append(endpoints, test.NewEndpoint(t, p.HostIP, p.HostPort))
 	}
-
 	return NewConnection(dc.DatabaseType, endpoints...)
 }
 
@@ -326,11 +324,11 @@ func (dc *DatabaseContainer) GetContainerConnectionDetails(
 	ipAddress := container.NetworkSettings.IPAddress
 	require.NotNil(t, ipAddress)
 	if dc.Network != "" {
-		net, ok := container.NetworkSettings.Networks[dc.Network]
+		containerNet, ok := container.NetworkSettings.Networks[dc.Network]
 		require.True(t, ok)
-		ipAddress = net.IPAddress
+		ipAddress = containerNet.IPAddress
 	}
-	return connection.CreateEndpointHP(ipAddress, dc.DbPort.Port())
+	return test.NewEndpoint(t, ipAddress, dc.DbPort.Port())
 }
 
 // ExposePort adds a host port mapping for the given container port (e.g. "5433")
@@ -376,7 +374,7 @@ func (dc *DatabaseContainer) GetHostMappedEndpoint(t *testing.T) *connection.End
 	if hostIP == "0.0.0.0" {
 		hostIP = "127.0.0.1"
 	}
-	return connection.CreateEndpointHP(hostIP, bindings[0].HostPort)
+	return test.NewEndpoint(t, hostIP, bindings[0].HostPort)
 }
 
 // streamLogs streams the container output to stdout/stderr.

--- a/utils/testdb/database_setup.go
+++ b/utils/testdb/database_setup.go
@@ -24,7 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/hyperledger/fabric-x-committer/utils"
-	"github.com/hyperledger/fabric-x-committer/utils/connection"
+	"github.com/hyperledger/fabric-x-committer/utils/test"
 )
 
 const (
@@ -173,7 +173,7 @@ func startAndConnect(ctx context.Context, t *testing.T) *Connection {
 		require.NotNil(t, sharedContainer)
 		connOptions = sharedContainer.GetConnectionOptions(ctx, t)
 	case deploymentLocal:
-		connOptions = NewConnection(getDBTypeFromEnv(), connection.CreateEndpointHP("localhost", defaultLocalDBPort))
+		connOptions = NewConnection(getDBTypeFromEnv(), test.NewEndpoint(t, "localhost", defaultLocalDBPort))
 	default:
 		t.Logf("unknown db deployment type: %s", dbDeployment)
 		return nil


### PR DESCRIPTION
#### Type of change

- Improvement (improvement to code, performance, etc)
- Test update
 
#### Description

- Move endpoint parsing to `cmd/config` and increase test coverage.
- Enhance endpoint parsing by validating the host-name and port. 
- Use explicit endpoint creation in tests when possible.
- Move `CreateEndpointHP()` to `utils/test`.
- Move `NewLocalHostServer()` to `utils/test`.

#### Related issues

- address #430 
