### PR TITLE
[metrics] Use atomic pointer to URL to prevent race condition

### DIFF
--- a/utils/monitoring/provider.go
+++ b/utils/monitoring/provider.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"net/http/pprof"
 	"net/url"
+	"sync/atomic"
 	"time"
 
 	"github.com/cockroachdb/errors"
@@ -34,7 +35,7 @@ const (
 // Provider is a prometheus metrics provider.
 type Provider struct {
 	registry *prometheus.Registry
-	url      string
+	url      atomic.Pointer[string]
 }
 
 var logger = flogging.MustGetLogger("monitoring")
@@ -100,14 +101,15 @@ func (p *Provider) StartPrometheusServer(
 		l = tls.NewListener(l, serverTLSConfig)
 	}
 
-	p.url, err = MakeMetricsURL(l.Addr().String(), serverTLSConfig)
+	metricsURL, err := MakeMetricsURL(l.Addr().String(), serverTLSConfig)
 	if err != nil {
 		return err
 	}
+	p.url.Store(&metricsURL)
 
 	g, gCtx := errgroup.WithContext(ctx)
 	g.Go(func() error {
-		logger.Infof("Prometheus serving on URL: %s", p.url)
+		logger.Infof("Prometheus serving on URL: %s", metricsURL)
 		defer logger.Info("Prometheus stopped serving")
 		return server.Serve(l)
 	})
@@ -139,7 +141,11 @@ func (p *Provider) StartPrometheusServer(
 
 // URL returns the prometheus server URL.
 func (p *Provider) URL() string {
-	return p.url
+	metricsURL := p.url.Load()
+	if metricsURL != nil {
+		return *metricsURL
+	}
+	return ""
 }
 
 // NewCounter creates a new prometheus counter.

--- a/utils/monitoring/provider_test.go
+++ b/utils/monitoring/provider_test.go
@@ -197,7 +197,8 @@ func TestPprofEndpoints(t *testing.T) {
 	defer client.CloseIdleConnections()
 
 	// Extract base URL from metrics URL (remove /metrics path)
-	baseURL := env.provider.url[:len(env.provider.url)-len(metricsSubPath)]
+	metricsURL := env.provider.URL()
+	baseURL := metricsURL[:len(metricsURL)-len(metricsSubPath)]
 
 	tests := []struct {
 		name string


### PR DESCRIPTION
#### Type of change

- Bug fix
- Test update
 
#### Description

- The metrics unit test had apparent race condition when accessing the URL
- This PR fix this by using atomic pointer
- This is an intermediate solution until we address #441 

#### Related issues

- discovered by #442 
