### PR TITLE
[testcrypto] PrepareBlockHeaderAndMetadata returns a copy of the block to prevent race condition

### DIFF
--- a/mock/orderer.go
+++ b/mock/orderer.go
@@ -237,8 +237,7 @@ func (o *Orderer) Deliver(stream ab.AtomicBroadcast_DeliverServer) error {
 		}
 		if b == nil {
 			logger.Warnf("Lost block. Sending an empty block for the sake of the delivery progress.")
-			b = &common.Block{Data: &common.BlockData{}}
-			testcrypto.PrepareBlockHeaderAndMetadata(b, p)
+			b = testcrypto.PrepareBlockHeaderAndMetadata(&common.Block{Data: &common.BlockData{}}, p)
 		}
 		msg := state.prepareResponse(ctx, b)
 		if msg == nil {
@@ -361,7 +360,7 @@ func (o *Orderer) Run(ctx context.Context) error {
 		if b == nil {
 			return
 		}
-		testcrypto.PrepareBlockHeaderAndMetadata(b, blockParams)
+		b = testcrypto.PrepareBlockHeaderAndMetadata(b, blockParams)
 		o.cache.addBlock(ctx, b)
 		blockParams.PrevBlock = b
 

--- a/mock/orderer_test.go
+++ b/mock/orderer_test.go
@@ -245,7 +245,7 @@ func TestOrderer(t *testing.T) {
 	require.NoError(t, err)
 
 	block, _ = f.requireGetBlock(ctx, t, o, 1)
-	test.RequireProtoEqual(t, newConfigBlock, block)
+	test.RequireProtoEqual(t, newConfigBlock.Data, block.Data)
 
 	t.Log("Submit block with new config and verify it is verified with the new config")
 	f.verifier = getVerifier(t, newConfigBlock)
@@ -253,7 +253,7 @@ func TestOrderer(t *testing.T) {
 	block, _ = f.requireGetBlock(ctx, t, o, 1)
 	lastConfigIndex, err := protoutil.GetLastConfigIndexFromBlock(block)
 	require.NoError(t, err)
-	require.Equal(t, newConfigBlock.Header.Number, lastConfigIndex)
+	require.EqualValues(t, 8, lastConfigIndex)
 }
 
 func (f *blockFetcher) requireGetBlock(

--- a/utils/testcrypto/block.go
+++ b/utils/testcrypto/block.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hyperledger/fabric-protos-go-apiv2/common"
 	"github.com/hyperledger/fabric-x-common/msp"
 	"github.com/hyperledger/fabric-x-common/protoutil"
+	"google.golang.org/protobuf/proto"
 )
 
 var logger = flogging.MustGetLogger("testcrypto")
@@ -28,7 +29,8 @@ type BlockPrepareParameters struct {
 }
 
 // PrepareBlockHeaderAndMetadata adds a valid header and metadata to the block.
-func PrepareBlockHeaderAndMetadata(block *common.Block, p BlockPrepareParameters) {
+func PrepareBlockHeaderAndMetadata(block *common.Block, p BlockPrepareParameters) *common.Block {
+	block = proto.CloneOf(block)
 	var blockNumber uint64
 	var previousHash []byte
 	if p.PrevBlock != nil {
@@ -98,4 +100,5 @@ func PrepareBlockHeaderAndMetadata(block *common.Block, p BlockPrepareParameters
 		Value:      ordererMetadataBytes,
 		Signatures: sigs,
 	})
+	return block
 }


### PR DESCRIPTION
#### Type of change

- Bug fix
- Test update

#### Description

- PrepareBlockHeaderAndMetadata returns a copy of the block to prevent race condition

#### Related issues

- discovered by #442 
