### PR TITLE
[channel] Fix race condition on channel.Ready.Reset()

### DIFF
--- a/utils/channel/channel.go
+++ b/utils/channel/channel.go
@@ -9,6 +9,7 @@ package channel
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -46,10 +47,16 @@ type (
 
 	// Ready supports waiting for readiness and notifying of readiness.
 	// It also supports closing to release waiters.
+	// Ready uses atomic pointer indirection to allow safe Reset() while other
+	// goroutines may be waiting on the channels. This prevents race conditions
+	// when the internal state is replaced.
 	Ready struct {
+		ready atomic.Pointer[ready]
+	}
+	ready struct {
 		ready  chan any
 		closed chan any
-		once   *sync.Once
+		once   sync.Once
 	}
 
 	//nolint:containedctx // holding the context is required.
@@ -150,30 +157,42 @@ func (c *channel[T]) Write(value T) bool {
 
 // NewReady instantiate a new Ready.
 func NewReady() *Ready {
-	return &Ready{
+	r := &Ready{}
+	r.ready.Store(newReady())
+	return r
+}
+
+func newReady() *ready {
+	return &ready{
 		ready:  make(chan any),
 		closed: make(chan any),
-		once:   &sync.Once{},
 	}
 }
 
 // Reset resets the object to be reused.
 func (r *Ready) Reset() {
-	r.Close()
-	*r = *NewReady()
+	rr := r.ready.Load()
+	rr.once.Do(func() {
+		close(rr.closed)
+	})
+	// We only set a new internal ready to replace the one we closed.
+	// If another process already replaced it, we can continue.
+	r.ready.CompareAndSwap(rr, newReady())
 }
 
 // SignalReady signals readiness.
 func (r *Ready) SignalReady() {
-	r.once.Do(func() {
-		close(r.ready)
+	rr := r.ready.Load()
+	rr.once.Do(func() {
+		close(rr.ready)
 	})
 }
 
 // Close notifies of closing.
 func (r *Ready) Close() {
-	r.once.Do(func() {
-		close(r.closed)
+	rr := r.ready.Load()
+	rr.once.Do(func() {
+		close(rr.closed)
 	})
 }
 
@@ -187,12 +206,13 @@ func (r *Ready) WaitForReady(ctx context.Context) bool {
 // or false if one of them is closed or the context ended before that.
 func WaitForAllReady(ctx context.Context, ready ...*Ready) bool {
 	for _, r := range ready {
+		rr := r.ready.Load()
 		select {
 		case <-ctx.Done():
 			return false
-		case <-r.closed:
+		case <-rr.closed:
 			return false
-		case <-r.ready:
+		case <-rr.ready:
 		}
 	}
 	return true

--- a/utils/channel/channel_test.go
+++ b/utils/channel/channel_test.go
@@ -4,16 +4,19 @@ Copyright IBM Corp. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 
-package channel
+package channel_test
 
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger/fabric-x-committer/utils/channel"
 )
 
 type data struct {
@@ -34,7 +37,7 @@ func TestChannel(t *testing.T) {
 		t.Cleanup(cancel)
 
 		chan1 := make(chan *data, 10)
-		c := NewReader(ctx, chan1)
+		c := channel.NewReader(ctx, chan1)
 		require.Equal(t, ctx, c.Context())
 
 		chan1 <- d
@@ -61,7 +64,7 @@ func TestChannel(t *testing.T) {
 		t.Cleanup(cancel)
 
 		chan1 := make(chan *data, 1)
-		c := NewWriter(ctx, chan1)
+		c := channel.NewWriter(ctx, chan1)
 		require.Equal(t, ctx, c.Context())
 		require.True(t, c.Write(d))
 
@@ -85,7 +88,7 @@ func TestChannel(t *testing.T) {
 		t.Cleanup(cancel)
 
 		chan1 := make(chan *data)
-		c := NewReaderWriter(ctx, chan1)
+		c := channel.NewReaderWriter(ctx, chan1)
 		require.Equal(t, ctx, c.Context())
 
 		go func() {
@@ -117,7 +120,7 @@ func TestChannel(t *testing.T) {
 		t.Cleanup(cancel)
 
 		chan1 := make(chan *data, 10)
-		c := NewReaderWriter(ctx, chan1)
+		c := channel.NewReaderWriter(ctx, chan1)
 		require.Equal(t, ctx, c.Context())
 
 		require.True(t, c.Write(d))
@@ -163,7 +166,7 @@ func TestWaitForReady(t *testing.T) {
 
 	t.Run("ready", func(t *testing.T) {
 		t.Parallel()
-		r := NewReady()
+		r := channel.NewReady()
 		go func() {
 			assert.True(t, r.WaitForReady(testContext))
 		}()
@@ -173,7 +176,7 @@ func TestWaitForReady(t *testing.T) {
 
 	t.Run("not ready", func(t *testing.T) {
 		t.Parallel()
-		r := NewReady()
+		r := channel.NewReady()
 		timeoutCtx, timeoutCancel := context.WithTimeout(testContext, 3*time.Second)
 		t.Cleanup(timeoutCancel)
 		require.False(t, r.WaitForReady(timeoutCtx))
@@ -181,7 +184,7 @@ func TestWaitForReady(t *testing.T) {
 
 	t.Run("closed", func(t *testing.T) {
 		t.Parallel()
-		r := NewReady()
+		r := channel.NewReady()
 		go func() {
 			assert.False(t, r.WaitForReady(testContext))
 		}()
@@ -191,7 +194,7 @@ func TestWaitForReady(t *testing.T) {
 
 	t.Run("reset", func(t *testing.T) {
 		t.Parallel()
-		r := NewReady()
+		r := channel.NewReady()
 		go func() {
 			assert.False(t, r.WaitForReady(testContext))
 		}()
@@ -206,12 +209,12 @@ func TestWaitForReady(t *testing.T) {
 
 	t.Run("all ready", func(t *testing.T) {
 		t.Parallel()
-		r := make([]*Ready, 3)
+		r := make([]*channel.Ready, 3)
 		for i := range r {
-			r[i] = NewReady()
+			r[i] = channel.NewReady()
 		}
 		go func() {
-			assert.True(t, WaitForAllReady(testContext, r...))
+			assert.True(t, channel.WaitForAllReady(testContext, r...))
 		}()
 		time.Sleep(time.Second)
 		for _, ready := range r {
@@ -221,31 +224,61 @@ func TestWaitForReady(t *testing.T) {
 
 	t.Run("not all ready", func(t *testing.T) {
 		t.Parallel()
-		r := make([]*Ready, 3)
+		r := make([]*channel.Ready, 3)
 		for i := range r {
-			r[i] = NewReady()
+			r[i] = channel.NewReady()
 		}
 		for _, ready := range r[1:] {
 			ready.SignalReady()
 		}
 		timeoutCtx, timeoutCancel := context.WithTimeout(testContext, 3*time.Second)
 		t.Cleanup(timeoutCancel)
-		require.False(t, WaitForAllReady(timeoutCtx, r...))
+		require.False(t, channel.WaitForAllReady(timeoutCtx, r...))
 	})
 
 	t.Run("some closed", func(t *testing.T) {
 		t.Parallel()
-		r := make([]*Ready, 3)
+		r := make([]*channel.Ready, 3)
 		for i := range r {
-			r[i] = NewReady()
+			r[i] = channel.NewReady()
 		}
 		for _, ready := range r[2:] {
 			ready.SignalReady()
 		}
 		go func() {
-			assert.False(t, WaitForAllReady(testContext, r...))
+			assert.False(t, channel.WaitForAllReady(testContext, r...))
 		}()
 		time.Sleep(time.Second)
 		r[0].Close()
 	})
+}
+
+// TestReadyConcurrentResetAndSignal should be run with the race detector enabled: go test -race.
+func TestReadyConcurrentResetAndSignal(t *testing.T) {
+	t.Parallel()
+	testContext, testCancel := context.WithTimeout(t.Context(), time.Minute)
+	t.Cleanup(testCancel)
+
+	r := channel.NewReady()
+	var wg sync.WaitGroup
+	var successCount atomic.Uint64
+
+	// Launch multiple goroutines that reset, signal, and wait concurrently.
+	for range 1_000 {
+		wg.Go(func() {
+			r.Reset()
+		})
+		wg.Go(func() {
+			r.SignalReady()
+		})
+		wg.Go(func() {
+			if r.WaitForReady(testContext) {
+				successCount.Add(1)
+			}
+		})
+	}
+	wg.Wait()
+
+	// At least one waiter should have succeeded since we're signaling ready multiple times.
+	require.Positive(t, successCount.Load(), "expected at least one successful wait")
 }


### PR DESCRIPTION
#### Type of change

- Bug fix

#### Description

**Root cause:** The `Ready.Reset()` method was experiencing a race condition due to non-atomic struct field replacement. The original implementation used `*r = *NewReady()` to reset the struct, which performs a multi-step memory copy operation that replaces all fields (channels `ready`, `closed`, and `once`). This struct copy is not atomic.

Concurrently, other goroutines calling `WaitForReady()` or `WaitForAllReady()` would read from the same channel fields (`r.ready` and `r.closed`) via select statements. This created a classic data race where one goroutine was writing to struct fields while others were simultaneously reading from them.

**Race scenario:**
1. Goroutine A calls `Reset()` and begins copying new struct fields (non-atomic multi-step operation)
2. Goroutine B calls `WaitForReady()` and attempts to read `r.ready` or `r.closed` channels
3. Data race occurs: Goroutine A writes to memory while Goroutine B reads from the same memory locations

**The fix:** Uses atomic pointer indirection by moving channels into an inner `ready` struct and storing only an `atomic.Pointer[ready]` in the outer `Ready` struct. This enables atomic swapping of the entire internal state via `CompareAndSwap()`, eliminating the race condition while maintaining the same external API. 

#### Related issues

- discovered by #442
