### PR TITLE
[test] Fix race condition when accessing command buffer output

### DIFF
--- a/cmd/config/cobra_test_exports.go
+++ b/cmd/config/cobra_test_exports.go
@@ -7,7 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 package config
 
 import (
-	"bytes"
 	"context"
 	"os"
 	"path"
@@ -85,7 +84,7 @@ func StartDefaultSystem(t *testing.T) SystemConfig {
 func UnitTestRunner(
 	t *testing.T,
 	cmd *cobra.Command,
-	test CommandTest,
+	cmdTest CommandTest,
 ) {
 	t.Helper()
 	// Redirect os.Stderr to a file so we can capture log output for assertions.
@@ -105,18 +104,18 @@ func UnitTestRunner(
 		LogSpec: "debug",
 	}
 	flogging.Init(*logConfig)
-	test.System.Logging = logConfig
+	cmdTest.System.Logging = logConfig
 
-	args := test.Args
-	if test.UseConfigTemplate != "" {
-		configPath := CreateTempConfigFromTemplate(t, test.UseConfigTemplate, &test.System)
+	args := cmdTest.Args
+	if cmdTest.UseConfigTemplate != "" {
+		configPath := CreateTempConfigFromTemplate(t, cmdTest.UseConfigTemplate, &cmdTest.System)
 		args = append(args, "--config", configPath)
 	}
 	cmd.SetArgs(args)
 
 	// Creating new buffers for the cmd stdout and stderr and redirect the CMD output.
-	var cmdStdOut bytes.Buffer
-	var cmdStdErr bytes.Buffer
+	var cmdStdOut test.SafeBuffer
+	var cmdStdErr test.SafeBuffer
 	cmd.SetOut(&cmdStdOut)
 	cmd.SetErr(&cmdStdErr)
 
@@ -137,15 +136,15 @@ func UnitTestRunner(
 		defer wg.Done()
 		_, err := cmd.ExecuteContextC(ctx)
 		err = connection.FilterStreamRPCError(err)
-		if test.Err == nil {
+		if cmdTest.Err == nil {
 			assert.NoError(t, err)
 		} else if assert.Error(t, err) {
-			assert.Equal(t, test.Err.Error(), err.Error())
+			assert.Equal(t, cmdTest.Err.Error(), err.Error())
 		}
 	}()
 
 	assert.Eventually(t, func() bool {
-		return len(getMissing(test, &cmdStdOut, loggerPath)) == 0
+		return len(getMissing(cmdTest, cmdStdOut.String(), loggerPath)) == 0
 	}, 10*time.Minute, 500*time.Millisecond)
 
 	t.Log("Stopping command, and waiting for finish")
@@ -162,7 +161,7 @@ func UnitTestRunner(
 	if err == nil {
 		t.Log("LOG:\n", string(logOut))
 	}
-	for _, m := range getMissing(test, &cmdStdOut, loggerPath) {
+	for _, m := range getMissing(cmdTest, cmdStdOut.String(), loggerPath) {
 		t.Logf("Missing: %s", m)
 	}
 }
@@ -182,18 +181,18 @@ func defaultTestDBConfig() DatabaseConfig {
 	}
 }
 
-func getMissing(test CommandTest, cmdStdOut *bytes.Buffer, loggerPath string) (missing []string) {
-	if test.CmdStdOutput != "" && !strings.Contains(cmdStdOut.String(), test.CmdStdOutput) {
-		missing = append(missing, test.CmdStdOutput)
+func getMissing(cmdTest CommandTest, cmdStdOut, loggerPath string) (missing []string) {
+	if cmdTest.CmdStdOutput != "" && !strings.Contains(cmdStdOut, cmdTest.CmdStdOutput) {
+		missing = append(missing, cmdTest.CmdStdOutput)
 	}
-	if len(test.CmdLoggerOutputs) == 0 {
+	if len(cmdTest.CmdLoggerOutputs) == 0 {
 		return missing
 	}
 	logOut, err := os.ReadFile(loggerPath)
 	if err != nil {
 		return append(missing, loggerPath)
 	}
-	for _, loggerLine := range test.CmdLoggerOutputs {
+	for _, loggerLine := range cmdTest.CmdLoggerOutputs {
 		if !strings.Contains(string(logOut), loggerLine) {
 			missing = append(missing, loggerLine)
 		}

--- a/utils/test/buffer.go
+++ b/utils/test/buffer.go
@@ -1,0 +1,66 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package test
+
+import (
+	"bytes"
+	"sync"
+)
+
+// SafeBuffer is a thread-safe wrapper around bytes.Buffer.
+// It protects concurrent access to the underlying buffer using a mutex,
+// preventing race conditions when multiple goroutines read from or write to
+// the same buffer simultaneously.
+//
+// This is particularly useful in testing scenarios where command output
+// is being written by one goroutine while another goroutine is reading
+// or checking the buffer contents.
+type SafeBuffer struct {
+	b bytes.Buffer
+	m sync.Mutex
+}
+
+// Write appends the contents of p to the buffer in a thread-safe manner.
+// It implements the io.Writer interface.
+// Returns the number of bytes written and any error encountered.
+func (sb *SafeBuffer) Write(p []byte) (n int, err error) {
+	sb.m.Lock()
+	defer sb.m.Unlock()
+	return sb.b.Write(p)
+}
+
+// Read reads the next len(p) bytes from the buffer in a thread-safe manner.
+// It implements the io.Reader interface.
+// Returns the number of bytes read and any error encountered.
+func (sb *SafeBuffer) Read(p []byte) (n int, err error) {
+	sb.m.Lock()
+	defer sb.m.Unlock()
+	return sb.b.Read(p)
+}
+
+// String returns the contents of the buffer as a string in a thread-safe manner.
+// This is safe to call concurrently with Write operations.
+func (sb *SafeBuffer) String() string {
+	sb.m.Lock()
+	defer sb.m.Unlock()
+	return sb.b.String()
+}
+
+// Reset resets the buffer to be empty in a thread-safe manner.
+// This is useful for reusing the same SafeBuffer across multiple test cases.
+func (sb *SafeBuffer) Reset() {
+	sb.m.Lock()
+	defer sb.m.Unlock()
+	sb.b.Reset()
+}
+
+// Len returns the number of bytes in the buffer in a thread-safe manner.
+func (sb *SafeBuffer) Len() int {
+	sb.m.Lock()
+	defer sb.m.Unlock()
+	return sb.b.Len()
+}

--- a/utils/test/buffer_test.go
+++ b/utils/test/buffer_test.go
@@ -1,0 +1,175 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package test
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSafeBuffer_BasicOperations(t *testing.T) {
+	t.Parallel()
+
+	var sb SafeBuffer
+	data := "test data"
+
+	// Test initial state
+	require.Empty(t, sb.String())
+	require.Equal(t, 0, sb.Len())
+
+	// Test Write
+	n, err := sb.Write([]byte(data))
+	require.NoError(t, err)
+	require.Equal(t, len(data), n)
+	require.Equal(t, data, sb.String())
+	require.Equal(t, 9, sb.Len())
+
+	// Test Read
+	buf := make([]byte, 4)
+	n, err = sb.Read(buf)
+	require.NoError(t, err)
+	require.Equal(t, 4, n)
+	require.Equal(t, data[:4], string(buf))
+
+	// Test Reset
+	sb.Reset()
+	require.Empty(t, sb.String())
+	require.Equal(t, 0, sb.Len())
+
+	// Test multiple writes
+	_, err = sb.Write([]byte(data[:4]))
+	require.NoError(t, err)
+	require.Equal(t, data[:4], sb.String())
+	require.Equal(t, 4, sb.Len())
+
+	_, err = sb.Write([]byte(data[4:]))
+	require.NoError(t, err)
+	require.Equal(t, data, sb.String())
+	require.Equal(t, 9, sb.Len())
+}
+
+// TestSafeBuffer_ConcurrentAccess verifies that SafeBuffer is safe for concurrent use.
+// This test should be run with the race detector enabled: go test -race.
+func TestSafeBuffer_ConcurrentAccess(t *testing.T) {
+	t.Parallel()
+
+	var sb SafeBuffer
+	const numGoroutines = 100
+	const writesPerGoroutine = 100
+	const initialSize = 1000
+
+	expectedLines := make([]string, 0, numGoroutines*writesPerGoroutine+initialSize)
+
+	// Pre-populate buffer.
+	for i := range initialSize {
+		line := fmt.Sprintf("initial-%d", i)
+		expectedLines = append(expectedLines, line)
+		_, err := sb.Write([]byte(line + "\n"))
+		require.NoError(t, err)
+	}
+
+	// Concurrent writers and readers.
+	var wg sync.WaitGroup
+	for i := range numGoroutines {
+		workerLines := make([]string, 0, writesPerGoroutine)
+		for j := range writesPerGoroutine {
+			workerLines = append(workerLines, fmt.Sprintf("writer-%d-%d", i, j))
+		}
+		expectedLines = append(expectedLines, workerLines...)
+		wg.Go(func() {
+			for _, line := range workerLines {
+				_, _ = sb.Write([]byte(line + "\n"))
+			}
+		})
+		wg.Go(func() {
+			for range writesPerGoroutine {
+				_ = sb.String() // Should not race.
+				_ = sb.Len()    // Should not race.
+				time.Sleep(time.Microsecond)
+			}
+		})
+	}
+
+	wg.Wait()
+
+	// Verify we got the writes.
+	lines := strings.Split(strings.Trim(sb.String(), "\n"), "\n")
+	require.ElementsMatch(t, expectedLines, lines)
+}
+
+// TestSafeBuffer_ConcurrentWriteAndReset tests concurrent writes and resets.
+// This test should be run with the race detector enabled: go test -race.
+func TestSafeBuffer_ConcurrentWriteAndReset(t *testing.T) {
+	t.Parallel()
+
+	var sb SafeBuffer
+	const numGoroutines = 50
+	const operations = 100
+
+	// Concurrent writers and re-setters.
+	var wg sync.WaitGroup
+	for i := range numGoroutines {
+		wg.Go(func() {
+			for j := range operations {
+				_, _ = sb.Write([]byte(fmt.Sprintf("data-%d-%d\n", i, j)))
+			}
+		})
+		wg.Go(func() {
+			for range operations {
+				sb.Reset()
+				time.Sleep(time.Microsecond)
+			}
+		})
+	}
+
+	wg.Wait()
+	// No assertion on final state since resets are happening concurrently.
+	// The test passes if no race conditions are detected.
+}
+
+// TestSafeBuffer_ConcurrentReadWrite tests concurrent reads and writes.
+// This test should be run with the race detector enabled: go test -race.
+func TestSafeBuffer_ConcurrentReadWrite(t *testing.T) {
+	t.Parallel()
+
+	var sb SafeBuffer
+	const numGoroutines = 50
+	const operations = 100
+
+	// Pre-populate buffer
+	for i := range 1000 {
+		_, err := sb.Write([]byte(fmt.Sprintf("initial-%d\n", i)))
+		require.NoError(t, err)
+	}
+
+	// Concurrent writers and readers.
+	var wg sync.WaitGroup
+	for i := range numGoroutines {
+		wg.Go(func() {
+			for j := range operations {
+				_, _ = sb.Write([]byte(fmt.Sprintf("writer-%d-%d\n", i, j)))
+			}
+		})
+
+		wg.Go(func() {
+			buf := make([]byte, 10)
+			for range operations {
+				_, _ = sb.Read(buf) // Ignore EOF errors
+				time.Sleep(time.Microsecond)
+			}
+		})
+	}
+
+	wg.Wait()
+	// No assertion on final state since reads are happening concurrently.
+	// The test passes if no race conditions are detected.
+}


### PR DESCRIPTION
#### Type of change

- Bug fix
- Test update

#### Description

Root cause: The test was experiencing a race condition when accessing command output buffers. In `UnitTestRunner`, the command execution runs in a goroutine that continuously writes output to `bytes.Buffer` instances (cmdStdOut and cmdStdErr), while simultaneously another goroutine in `assert.Eventually` reads from these buffers via `cmdStdOut.String()` to check for expected output. Since `bytes.Buffer` is not thread-safe for concurrent read/write operations, this caused data races detected by the race detector when multiple goroutines accessed the buffer simultaneously.

#### Related issues

- discovered by #442
