### PR TITLE
[grpc logger] reduce GRPC log level by default for tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ permissions:
 env:
   DB_DEPLOYMENT: local
   DB_TYPE: postgres
+  FABRIC_LOGGING_SPEC: info:grpc=error
 
 jobs:
   gate:

--- a/cmd/config/app_config.go
+++ b/cmd/config/app_config.go
@@ -16,7 +16,6 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/hyperledger/fabric-lib-go/common/flogging"
 	"github.com/spf13/viper"
-	"google.golang.org/grpc/grpclog"
 
 	"github.com/hyperledger/fabric-x-committer/loadgen"
 	"github.com/hyperledger/fabric-x-committer/mock"
@@ -92,7 +91,6 @@ func ReadYamlAndSetupLogging(v *viper.Viper, configPath, servicePrefix string, c
 	if err = unmarshal(v, &loggingWrapper); err != nil {
 		return err
 	}
-	grpclog.SetLoggerV2(grpclog.NewLoggerV2(io.Discard, io.Discard, os.Stderr))
 	flogging.Init(*loggingWrapper.Logging)
 	return unmarshal(v, c)
 }

--- a/cmd/config/cobra_test_exports.go
+++ b/cmd/config/cobra_test_exports.go
@@ -100,11 +100,12 @@ func UnitTestRunner(
 		os.Stderr = origStderr
 		_ = logFile.Close()
 	})
-	logConfig := &flogging.Config{
-		LogSpec: "debug",
-	}
-	flogging.Init(*logConfig)
-	cmdTest.System.Logging = logConfig
+	testLogSpec := "debug:grpc=error"
+	flogging.ActivateSpec(testLogSpec)
+	t.Cleanup(func() {
+		flogging.ActivateSpec("info:grpc=error")
+	})
+	cmdTest.System.Logging.LogSpec = testLogSpec
 
 	args := cmdTest.Args
 	if cmdTest.UseConfigTemplate != "" {

--- a/cmd/config/create_config_file.go
+++ b/cmd/config/create_config_file.go
@@ -48,7 +48,7 @@ type (
 		LoadGenBlockLimit    uint64                      // loadgen
 		LoadGenTXLimit       uint64                      // loadgen
 		LoadGenWorkers       uint64                      // loadgen
-		Logging              *flogging.Config            // for all
+		Logging              flogging.Config             // for all
 		RateLimit            *connection.RateLimitConfig // query, sidecar
 		MaxRequestKeys       int                         // query
 		MaxConcurrentStreams int                         // sidecar

--- a/cmd/config/samples/coordinator.yaml
+++ b/cmd/config/samples/coordinator.yaml
@@ -87,7 +87,7 @@ logging:
   # Log level specification. Can be a single level (e.g., "info", "debug") or
   # module-specific levels (e.g., "info,coordinator=debug").
   # Valid levels: debug, info, warning, error, panic, fatal.
-  logSpec: "info"
+  logSpec: info:grpc=error
   # Log message format template. Supports color codes, timestamps, module names,
   # function names, and log levels. See fabric-lib-go/common/flogging for details.
   format: >-

--- a/cmd/config/samples/loadgen.yaml
+++ b/cmd/config/samples/loadgen.yaml
@@ -269,7 +269,7 @@ logging:
   # Log level specification. Can be a single level (e.g., "info", "debug") or
   # module-specific levels (e.g., "info,loadgen=debug").
   # Valid levels: debug, info, warning, error, panic, fatal.
-  logSpec: "info"
+  logSpec: info:grpc=error
   # Log message format template. Supports color codes, timestamps, module names,
   # function names, and log levels. See fabric-lib-go/common/flogging for details.
   format: >-

--- a/cmd/config/samples/mock-orderer.yaml
+++ b/cmd/config/samples/mock-orderer.yaml
@@ -55,7 +55,7 @@ logging:
   # Log level specification. Can be a single level (e.g., "info", "debug") or
   # module-specific levels (e.g., "info,mock=debug").
   # Valid levels: debug, info, warning, error, panic, fatal.
-  logSpec: "info"
+  logSpec: info:grpc=error
   # Log message format template. Supports color codes, timestamps, module names,
   # function names, and log levels. See fabric-lib-go/common/flogging for details.
   format: >-

--- a/cmd/config/samples/query.yaml
+++ b/cmd/config/samples/query.yaml
@@ -147,7 +147,7 @@ logging:
   # Log level specification. Can be a single level (e.g., "info", "debug") or
   # module-specific levels (e.g., "info,query=debug").
   # Valid levels: debug, info, warning, error, panic, fatal.
-  logSpec: "info"
+  logSpec: info:grpc=error
   # Log message format template. Supports color codes, timestamps, module names,
   # function names, and log levels. See fabric-lib-go/common/flogging for details.
   format: >-

--- a/cmd/config/samples/sidecar.yaml
+++ b/cmd/config/samples/sidecar.yaml
@@ -151,7 +151,7 @@ logging:
   # Log level specification. Can be a single level (e.g., "info", "debug") or
   # module-specific levels (e.g., "info,sidecar=debug").
   # Valid levels: debug, info, warning, error, panic, fatal.
-  logSpec: "info"
+  logSpec: info:grpc=error
   # Log message format template. Supports color codes, timestamps, module names,
   # function names, and log levels. See fabric-lib-go/common/flogging for details.
   format: >-

--- a/cmd/config/samples/vc.yaml
+++ b/cmd/config/samples/vc.yaml
@@ -145,7 +145,7 @@ logging:
   # Log level specification. Can be a single level (e.g., "info", "debug") or
   # module-specific levels (e.g., "info,vc=debug").
   # Valid levels: debug, info, warning, error, panic, fatal.
-  logSpec: "info"
+  logSpec: info:grpc=error
   # Log message format template. Supports color codes, timestamps, module names,
   # function names, and log levels. See fabric-lib-go/common/flogging for details.
   format: >-

--- a/cmd/config/samples/verifier.yaml
+++ b/cmd/config/samples/verifier.yaml
@@ -63,7 +63,7 @@ logging:
   # Log level specification. Can be a single level (e.g., "info", "debug") or
   # module-specific levels (e.g., "info,verifier=debug").
   # Valid levels: debug, info, warning, error, panic, fatal.
-  logSpec: "info"
+  logSpec: info:grpc=error
   # Log message format template. Supports color codes, timestamps, module names,
   # function names, and log levels. See fabric-lib-go/common/flogging for details.
   format: >-

--- a/docker/test/main_test.go
+++ b/docker/test/main_test.go
@@ -7,18 +7,13 @@ SPDX-License-Identifier: Apache-2.0
 package test
 
 import (
-	"io"
 	"log"
-	"os"
 	"testing"
-
-	"google.golang.org/grpc/grpclog"
 
 	"github.com/hyperledger/fabric-x-committer/utils/test"
 )
 
 func TestMain(m *testing.M) {
-	grpclog.SetLoggerV2(grpclog.NewLoggerV2(io.Discard, io.Discard, os.Stderr))
 	err := test.Make("build-image-test-node", "build-image-release")
 	if err != nil {
 		log.Fatal(err) //nolint:revive,nolintlint // false positive.

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.4
 	github.com/hyperledger/fabric-lib-go v1.1.3-0.20240523144151-25edd1eaf5f5
 	github.com/hyperledger/fabric-protos-go-apiv2 v0.3.7
-	github.com/hyperledger/fabric-x-common v0.1.1-0.20260315102958-7e7de0ec948a
+	github.com/hyperledger/fabric-x-common v0.1.1-0.20260322093042-6a85243b44fa
 	github.com/jackc/puddle/v2 v2.2.2
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/onsi/gomega v1.38.2

--- a/go.sum
+++ b/go.sum
@@ -1116,8 +1116,8 @@ github.com/hyperledger/fabric-lib-go v1.1.3-0.20240523144151-25edd1eaf5f5 h1:RPW
 github.com/hyperledger/fabric-lib-go v1.1.3-0.20240523144151-25edd1eaf5f5/go.mod h1:SHNCq8AB0VpHAmvJEtdbzabv6NNV1F48JdmDihasBjc=
 github.com/hyperledger/fabric-protos-go-apiv2 v0.3.7 h1:sQ5qv8vQQfwewa1JlCiSCC8dLElmaU2/frLolpgibEY=
 github.com/hyperledger/fabric-protos-go-apiv2 v0.3.7/go.mod h1:bJnwzfv03oZQeCc863pdGTDgf5nmCy6Za3RAE7d2XsQ=
-github.com/hyperledger/fabric-x-common v0.1.1-0.20260315102958-7e7de0ec948a h1:0p8emZaf0zXU6IT8guv6s+byEVicSleRGmhB7rnsmhI=
-github.com/hyperledger/fabric-x-common v0.1.1-0.20260315102958-7e7de0ec948a/go.mod h1:+VPYRRCGAZo7+rlT55yK3aRmUbRJwQGlWg7lz0SLdMY=
+github.com/hyperledger/fabric-x-common v0.1.1-0.20260322093042-6a85243b44fa h1:eVa9zJ+ChDc8oGg6pGlXGIZshb0U2H9J5+7QekYW/Cw=
+github.com/hyperledger/fabric-x-common v0.1.1-0.20260322093042-6a85243b44fa/go.mod h1:oj72Z5zaOETJQRYq7D39B/JOO018b01K0w8vbLQB8BM=
 github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=

--- a/integration/runner/runtime.go
+++ b/integration/runner/runtime.go
@@ -167,8 +167,8 @@ func NewRuntime(t *testing.T, conf *Config) *CommitterRuntime {
 				ArtifactsPath:         t.TempDir(),
 				PeerOrganizationCount: 2,
 			},
-			Logging: &flogging.Config{
-				LogSpec: "info",
+			Logging: flogging.Config{
+				LogSpec: "info:grpc=error",
 			},
 			RateLimit:            conf.RateLimit,
 			MaxConcurrentStreams: conf.MaxConcurrentStreams,

--- a/integration/test/main_test.go
+++ b/integration/test/main_test.go
@@ -7,20 +7,15 @@ SPDX-License-Identifier: Apache-2.0
 package test
 
 import (
-	"io"
 	"log"
-	"os"
 	"testing"
 	"time"
-
-	"google.golang.org/grpc/grpclog"
 
 	"github.com/hyperledger/fabric-x-committer/utils/test"
 	"github.com/hyperledger/fabric-x-committer/utils/testdb"
 )
 
 func TestMain(m *testing.M) {
-	grpclog.SetLoggerV2(grpclog.NewLoggerV2(io.Discard, io.Discard, os.Stderr))
 	err := test.Make("build")
 	if err != nil {
 		log.Fatal(err)

--- a/loadgen/workload/config_tx.go
+++ b/loadgen/workload/config_tx.go
@@ -15,7 +15,6 @@ import (
 	"github.com/hyperledger/fabric-x-common/api/applicationpb"
 	"github.com/hyperledger/fabric-x-common/api/committerpb"
 	"github.com/hyperledger/fabric-x-common/protoutil"
-	"github.com/hyperledger/fabric-x-common/tools/configtxgen"
 	"github.com/hyperledger/fabric-x-common/tools/cryptogen"
 
 	"github.com/hyperledger/fabric-x-committer/api/servicepb"
@@ -57,7 +56,7 @@ func CreateOrLoadConfigBlockWithCrypto(policy *PolicyProfile) (*common.Block, er
 	if policy.ArtifactsPath != "" {
 		configBlockPath := path.Join(policy.ArtifactsPath, cryptogen.ConfigBlockFileName)
 		if _, fErr := os.Stat(configBlockPath); fErr == nil {
-			block, err := configtxgen.ReadBlock(configBlockPath)
+			block, err := protoutil.ReadBlockFromFile(configBlockPath)
 			return block, errors.Wrapf(err, "failed reading config block from %s", configBlockPath)
 		}
 	}

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -19,7 +19,7 @@ ALL_YAML=$(git ls-files '*.yml' '*.yaml')
 
 echo "Running goimports..."
 # shellcheck disable=SC2086
-BAD_IMPORTS=$($GO_CMD tool goimports -l $ALL_GO)
+BAD_IMPORTS=$($GO_CMD tool goimports -local "$(${GO_CMD} list -m)" -l $ALL_GO)
 if [[ -n "$BAD_IMPORTS" ]]; then
   echo "goimports check failed:"
   echo "$BAD_IMPORTS"

--- a/service/coordinator/dependencygraph/manager_test.go
+++ b/service/coordinator/dependencygraph/manager_test.go
@@ -31,7 +31,7 @@ type batchWithLatency struct {
 
 //nolint:gocognit // single method for simplicity.
 func BenchmarkDependencyGraph(b *testing.B) {
-	flogging.Init(flogging.Config{LogSpec: "fatal"})
+	flogging.ActivateSpec("fatal")
 
 	// Parameters
 	latency := 10 * time.Second

--- a/service/sidecar/mapping_test.go
+++ b/service/sidecar/mapping_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func BenchmarkMapBlock(b *testing.B) {
-	flogging.Init(flogging.Config{LogSpec: "fatal"})
+	flogging.ActivateSpec("fatal")
 	txs := workload.GenerateTransactions(b, nil, b.N)
 	block := workload.MapToOrdererBlock(1, txs)
 

--- a/service/sidecar/notify_test.go
+++ b/service/sidecar/notify_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func BenchmarkNotifier(b *testing.B) {
-	flogging.Init(flogging.Config{LogSpec: "fatal"})
+	flogging.ActivateSpec("fatal")
 	txIDs := make([]string, b.N)
 	for i := range txIDs {
 		txIDs[i] = fmt.Sprintf("%064d", i)

--- a/service/sidecar/sidecar.go
+++ b/service/sidecar/sidecar.go
@@ -17,7 +17,6 @@ import (
 	"github.com/hyperledger/fabric-protos-go-apiv2/peer"
 	"github.com/hyperledger/fabric-x-common/api/committerpb"
 	"github.com/hyperledger/fabric-x-common/protoutil"
-	"github.com/hyperledger/fabric-x-common/tools/configtxgen"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health"
@@ -65,7 +64,7 @@ func New(c *Config) (*Service, error) {
 	}
 
 	if c.Bootstrap.GenesisBlockFilePath != "" {
-		configBlock, bootErr := configtxgen.ReadBlock(c.Bootstrap.GenesisBlockFilePath)
+		configBlock, bootErr := protoutil.ReadBlockFromFile(c.Bootstrap.GenesisBlockFilePath)
 		if bootErr != nil {
 			return nil, errors.Wrap(bootErr, "read config block")
 		}

--- a/service/vc/preparer_test.go
+++ b/service/vc/preparer_test.go
@@ -683,7 +683,7 @@ func requireEqualMapOfLists[K comparable, V any](t *testing.T, expected, actual 
 
 //nolint:gocognit // single method for simplicity.
 func BenchmarkPrepare(b *testing.B) {
-	flogging.Init(flogging.Config{LogSpec: "fatal"})
+	flogging.ActivateSpec("fatal")
 
 	// Parameters
 	batchSize := 1024

--- a/utils/connection/client_util_test.go
+++ b/utils/connection/client_util_test.go
@@ -11,17 +11,16 @@ import (
 	"fmt"
 	"io"
 	"net"
-	"os"
 	"testing"
 	"time"
 
 	"github.com/cockroachdb/errors"
+	"github.com/hyperledger/fabric-lib-go/common/flogging"
 	"github.com/hyperledger/fabric-protos-go-apiv2/common"
 	"github.com/hyperledger/fabric-protos-go-apiv2/peer"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/grpclog"
 	healthgrpc "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/status"
 
@@ -33,9 +32,9 @@ import (
 func TestGRPCRetry(t *testing.T) {
 	// We start GRPC logging for this test to allow visibility into the retry process.
 	// This change prevents us from running this test in parallel to others.
-	grpclog.SetLoggerV2(grpclog.NewLoggerV2(os.Stderr, io.Discard, os.Stderr))
+	flogging.ActivateSpec("info:grpc=debug")
 	t.Cleanup(func() {
-		grpclog.SetLoggerV2(grpclog.NewLoggerV2(io.Discard, io.Discard, os.Stderr))
+		flogging.ActivateSpec("info:grpc=error")
 	})
 
 	t.Log("Starting service")
@@ -102,9 +101,9 @@ func TestGRPCRetry(t *testing.T) {
 func TestGRPCRetryMultiEndpoints(t *testing.T) {
 	// We start GRPC logging for this test to allow visibility into the retry process.
 	// This change prevents us from running this test in parallel to others.
-	grpclog.SetLoggerV2(grpclog.NewLoggerV2(os.Stderr, io.Discard, os.Stderr))
+	flogging.ActivateSpec("info:grpc=debug")
 	t.Cleanup(func() {
-		grpclog.SetLoggerV2(grpclog.NewLoggerV2(io.Discard, io.Discard, os.Stderr))
+		flogging.ActivateSpec("info:grpc=error")
 	})
 
 	t.Log("Starting service")

--- a/utils/ordererconn/load.go
+++ b/utils/ordererconn/load.go
@@ -13,7 +13,6 @@ import (
 	"github.com/hyperledger/fabric-x-common/common/channelconfig"
 	"github.com/hyperledger/fabric-x-common/common/configtx"
 	"github.com/hyperledger/fabric-x-common/protoutil"
-	"github.com/hyperledger/fabric-x-common/tools/configtxgen"
 )
 
 type (
@@ -31,7 +30,7 @@ var ErrNotConfigBlock = errors.New("the block is not a config block")
 // LoadConfigBlockFromFile loads a config block from a file.
 // If the block is not a config block, ErrNotConfigBlock will be returned.
 func LoadConfigBlockFromFile(blockPath string) (*ConfigBlockMaterial, error) {
-	configBlock, err := configtxgen.ReadBlock(blockPath)
+	configBlock, err := protoutil.ReadBlockFromFile(blockPath)
 	if err != nil {
 		return nil, err
 	}

--- a/utils/serialization/envelope_wrapper_test.go
+++ b/utils/serialization/envelope_wrapper_test.go
@@ -8,10 +8,9 @@ package serialization_test
 import (
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/hyperledger/fabric-protos-go-apiv2/common"
 	"github.com/hyperledger/fabric-x-common/protoutil"
+	"github.com/stretchr/testify/require"
 
 	"github.com/hyperledger/fabric-x-committer/utils/serialization"
 	"github.com/hyperledger/fabric-x-committer/utils/test"

--- a/utils/test/utils.go
+++ b/utils/test/utils.go
@@ -274,9 +274,7 @@ func CheckServerStopped(t *testing.T, addr string) bool {
 
 // SetupDebugging can be added for development to tests that required additional debugging info.
 func SetupDebugging() {
-	flogging.Init(flogging.Config{
-		LogSpec: "debug",
-	})
+	flogging.ActivateSpec("debug:grpc=error")
 }
 
 // NewSecuredConnection creates the default connection with given transport credentials.

--- a/utils/testsig/sign_verify_bench_test.go
+++ b/utils/testsig/sign_verify_bench_test.go
@@ -24,7 +24,7 @@ import (
 var testedSchemes = append(signature.AllRealSchemes, "MSP")
 
 func BenchmarkMarshal(b *testing.B) {
-	flogging.Init(flogging.Config{LogSpec: "fatal"})
+	flogging.ActivateSpec("fatal")
 	txs := workload.GenerateTransactions(b, nil, b.N)
 
 	resBench := make([][]byte, b.N)
@@ -42,7 +42,7 @@ func BenchmarkMarshal(b *testing.B) {
 }
 
 func BenchmarkDigest(b *testing.B) {
-	flogging.Init(flogging.Config{LogSpec: "fatal"})
+	flogging.ActivateSpec("fatal")
 	txs := workload.GenerateTransactions(b, nil, b.N)
 
 	resBench := make([][]byte, b.N)
@@ -62,7 +62,7 @@ func BenchmarkDigest(b *testing.B) {
 }
 
 func BenchmarkSign(b *testing.B) {
-	flogging.Init(flogging.Config{LogSpec: "fatal"})
+	flogging.ActivateSpec("fatal")
 	for _, scheme := range testedSchemes {
 		b.Run(scheme, func(b *testing.B) {
 			policy, _ := makePolicy(b, scheme)
@@ -85,7 +85,7 @@ func BenchmarkSign(b *testing.B) {
 }
 
 func BenchmarkVerify(b *testing.B) {
-	flogging.Init(flogging.Config{LogSpec: "fatal"})
+	flogging.ActivateSpec("fatal")
 	for _, scheme := range testedSchemes {
 		b.Run(scheme, func(b *testing.B) {
 			policy, block := makePolicy(b, scheme)

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -15,10 +15,9 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/errors"
-	"google.golang.org/grpc/peer"
-
 	"github.com/hyperledger/fabric-x-common/api/applicationpb"
 	"github.com/hyperledger/fabric-x-common/api/committerpb"
+	"google.golang.org/grpc/peer"
 )
 
 // ErrActiveStream represents the error when attempting to create a new stream while one is already active.


### PR DESCRIPTION
#### Type of change

- Bug fix

#### Description

- Reduce GRPC log level by default using environment variable instead of manually

#### Related issues

- resolves #448 
