### PR TITLE
[sidecar] Fix monitor race condition

### DIFF
--- a/service/sidecar/sidecar.go
+++ b/service/sidecar/sidecar.go
@@ -9,6 +9,7 @@ package sidecar
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
 	"time"
 
 	"github.com/cockroachdb/errors"
@@ -46,7 +47,7 @@ type Service struct {
 	blockDelivery      *blockDelivery
 	blockQuery         *blockQuery
 	coordConn          *grpc.ClientConn
-	blockToBeCommitted chan *common.Block
+	blockToBeCommitted atomic.Pointer[chan *common.Block]
 	committedBlock     chan *common.Block
 	statusQueue        chan []*committerpb.TxStatus
 	config             *Config
@@ -185,14 +186,14 @@ func (s *Service) sendBlocksAndReceiveStatus(
 	g, gCtx := errgroup.WithContext(ctx)
 
 	// We drop all enqueued block if any before starting a new session.
-	s.blockToBeCommitted = make(chan *common.Block, s.config.ChannelBufferSize)
+	s.blockToBeCommitted.Store(new(make(chan *common.Block, s.config.ChannelBufferSize)))
 
 	// NOTE: ordererClient.Deliver and relay.Run must always return an error on exist.
 	g.Go(func() error {
 		logger.Info("Fetch blocks from the ordering service and write them on s.blockToBeCommitted.")
 		deliverErr := s.ordererClient.Deliver(gCtx, &deliver.Parameters{
 			NextBlockNum: nextBlockNum,
-			OutputBlock:  s.blockToBeCommitted,
+			OutputBlock:  *s.blockToBeCommitted.Load(),
 		})
 		if errors.Is(deliverErr, context.Canceled) {
 			// A context may be cancelled due to a relay error, thus it is not critical error.
@@ -207,7 +208,7 @@ func (s *Service) sendBlocksAndReceiveStatus(
 			coordClient:                    coordClient,
 			nextExpectedBlockByCoordinator: nextBlockNum,
 			configUpdater:                  s.configUpdater,
-			incomingBlockToBeCommitted:     s.blockToBeCommitted,
+			incomingBlockToBeCommitted:     *s.blockToBeCommitted.Load(),
 			outgoingCommittedBlock:         s.committedBlock,
 			outgoingStatusUpdates:          s.statusQueue,
 			waitingTxsLimit:                s.config.WaitingTxsLimit,
@@ -405,7 +406,10 @@ func (s *Service) monitorQueues(ctx context.Context) {
 		case <-ticker.C:
 		}
 
-		promutil.SetGauge(m.yetToBeCommittedBlocksQueueSize, len(s.blockToBeCommitted))
+		blockToBeCommittedChan := s.blockToBeCommitted.Load()
+		if blockToBeCommittedChan != nil {
+			promutil.SetGauge(m.yetToBeCommittedBlocksQueueSize, len(*blockToBeCommittedChan))
+		}
 		promutil.SetGauge(m.committedBlocksQueueSize, len(s.committedBlock))
 	}
 }


### PR DESCRIPTION
#### Type of change

- Bug fix
 
#### Description

- Use atomic pointer to store channel to prevent race condition in monitoring loop

#### Related issues

- resolves #449 
