### PR TITLE
[verifier-test] Remove gomega fail handler

### DIFF
--- a/service/verifier/verifier_server_test.go
+++ b/service/verifier/verifier_server_test.go
@@ -74,7 +74,6 @@ func TestNoVerificationKeySet(t *testing.T) {
 
 func TestNoInput(t *testing.T) {
 	t.Parallel()
-	test.FailHandler(t)
 	c := newTestState(t, defaultConfigWithTLS(test.InsecureTLSConfig))
 
 	stream, _ := c.Client.StartStream(t.Context())
@@ -89,7 +88,6 @@ func TestNoInput(t *testing.T) {
 
 func TestMinimalInput(t *testing.T) {
 	t.Parallel()
-	test.FailHandler(t)
 	c := newTestState(t, defaultConfigWithTLS(test.InsecureTLSConfig))
 
 	stream, _ := c.Client.StartStream(t.Context())
@@ -263,7 +261,6 @@ func TestBadSignature(t *testing.T) {
 
 func TestUpdatePolicies(t *testing.T) {
 	t.Parallel()
-	test.FailHandler(t)
 	c := newTestState(t, defaultConfigQuickCutoff())
 
 	ns1 := "ns1"
@@ -351,7 +348,6 @@ func TestUpdatePolicies(t *testing.T) {
 
 func TestMultipleUpdatePolicies(t *testing.T) {
 	t.Parallel()
-	test.FailHandler(t)
 	c := newTestState(t, defaultConfigQuickCutoff())
 
 	ns := make([]string, 101)

--- a/utils/test/utils.go
+++ b/utils/test/utils.go
@@ -29,7 +29,6 @@ import (
 	"github.com/hyperledger/fabric-lib-go/common/flogging"
 	"github.com/hyperledger/fabric-x-common/api/types"
 	"github.com/hyperledger/fabric-x-common/tools/cryptogen"
-	"github.com/onsi/gomega"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tedsuo/ifrit"
@@ -74,16 +73,6 @@ type (
 		NumService int
 	}
 )
-
-// FailHandler registers a [gomega] fail handler.
-func FailHandler(t *testing.T) {
-	t.Helper()
-	gomega.RegisterFailHandler(func(message string, _ ...int) {
-		t.Helper()
-		t.Errorf("received error message: %s", message)
-		t.FailNow()
-	})
-}
 
 // ServerToMultiClientConfig is used to create a multi client configuration from existing server(s)
 // given a client TLS configuration.


### PR DESCRIPTION
#### Type of change

- Bug fix
- Test update
 
#### Description

- Remove unnecessary gomega fail handler in verifier tests.

#### Related issues

- resolves #468
