### PR TITLE
restructure from `start-<service>` to `start <service>`

### DIFF
--- a/cmd/committer/main.go
+++ b/cmd/committer/main.go
@@ -30,10 +30,6 @@ func committerCMD() *cobra.Command {
 		Short: fmt.Sprintf("Fabric-X %s.", config.CommitterName),
 	}
 	cmd.AddCommand(config.VersionCmd())
-	cmd.AddCommand(config.SidecarCMD("start-sidecar"))
-	cmd.AddCommand(config.CoordinatorCMD("start-coordinator"))
-	cmd.AddCommand(config.VcCMD("start-vc"))
-	cmd.AddCommand(config.VerifierCMD("start-verifier"))
-	cmd.AddCommand(config.QueryCMD("start-query"))
+	cmd.AddCommand(config.StartCMD())
 	return cmd
 }

--- a/cmd/committer/main_test.go
+++ b/cmd/committer/main_test.go
@@ -61,21 +61,21 @@ func TestCommitterCMD(t *testing.T) {
 	}
 
 	for _, serviceCase := range []struct {
-		Command  string
+		Command  []string
 		Name     string
 		Template string
 	}{
-		{Command: "start-sidecar", Name: config.SidecarName, Template: config.TemplateSidecar},
-		{Command: "start-coordinator", Name: config.CoordinatorName, Template: config.TemplateCoordinator},
-		{Command: "start-vc", Name: config.VcName, Template: config.TemplateVC},
-		{Command: "start-verifier", Name: config.VerifierName, Template: config.TemplateVerifier},
-		{Command: "start-query", Name: config.QueryName, Template: config.TemplateQueryService},
+		{Command: []string{"start", "sidecar"}, Name: config.SidecarName, Template: config.TemplateSidecar},
+		{Command: []string{"start", "coordinator"}, Name: config.CoordinatorName, Template: config.TemplateCoordinator},
+		{Command: []string{"start", "vc"}, Name: config.VcName, Template: config.TemplateVC},
+		{Command: []string{"start", "verifier"}, Name: config.VerifierName, Template: config.TemplateVerifier},
+		{Command: []string{"start", "query"}, Name: config.QueryName, Template: config.TemplateQueryService},
 	} {
 		t.Run(serviceCase.Name, func(t *testing.T) {
 			cases := []config.CommandTest{
 				{
 					Name:              "start with endpoint",
-					Args:              []string{serviceCase.Command, "--endpoint", "localhost:8003"},
+					Args:              append(serviceCase.Command, "--endpoint", "localhost:8003"),
 					CmdLoggerOutputs:  []string{"Serving", "localhost:8003"},
 					CmdStdOutput:      fmt.Sprintf("Starting %v", serviceCase.Name),
 					UseConfigTemplate: serviceCase.Template,
@@ -83,7 +83,7 @@ func TestCommitterCMD(t *testing.T) {
 				},
 				{
 					Name:              "start",
-					Args:              []string{serviceCase.Command},
+					Args:              serviceCase.Command,
 					CmdLoggerOutputs:  []string{"Serving", s.ThisService.GrpcEndpoint.String()},
 					CmdStdOutput:      fmt.Sprintf("Starting %v", serviceCase.Name),
 					UseConfigTemplate: serviceCase.Template,

--- a/cmd/config/cmd.go
+++ b/cmd/config/cmd.go
@@ -53,12 +53,26 @@ func FullCommitterVersion() string {
 	return fmt.Sprintf("%s version %s %s/%s", CommitterName, CommitterVersion, runtime.GOOS, runtime.GOARCH)
 }
 
-// SidecarCMD creates a sidecar command.
-func SidecarCMD(use string) *cobra.Command {
+// StartCMD creates the "start" parent command with all service subcommands.
+func StartCMD() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "start",
+		Short: "Start a service.",
+	}
+	cmd.AddCommand(StartSidecar())
+	cmd.AddCommand(StartCoordinator())
+	cmd.AddCommand(StartVC())
+	cmd.AddCommand(StartVerifier())
+	cmd.AddCommand(StartQuery())
+	return cmd
+}
+
+// StartSidecar creates the start sidecar command.
+func StartSidecar() *cobra.Command {
 	v := NewViperWithSidecarDefaults()
 	var configPath string
 	cmd := &cobra.Command{
-		Use:   use,
+		Use:   "sidecar",
 		Short: fmt.Sprintf("Starts %v.", SidecarName),
 		Long:  fmt.Sprintf("%v links between the system services.", SidecarName),
 		Args:  cobra.NoArgs,
@@ -93,12 +107,12 @@ func SidecarCMD(use string) *cobra.Command {
 	return cmd
 }
 
-// CoordinatorCMD creates a coordinator command.
-func CoordinatorCMD(use string) *cobra.Command {
+// StartCoordinator creates the start coordinator command.
+func StartCoordinator() *cobra.Command {
 	v := NewViperWithCoordinatorDefaults()
 	var configPath string
 	cmd := &cobra.Command{
-		Use:   use,
+		Use:   "coordinator",
 		Short: fmt.Sprintf("Starts %v.", CoordinatorName),
 		Long:  fmt.Sprintf("%v is a transaction flow coordinator.", CoordinatorName),
 		Args:  cobra.NoArgs,
@@ -119,12 +133,12 @@ func CoordinatorCMD(use string) *cobra.Command {
 	return cmd
 }
 
-// VcCMD creates a validator-committer command.
-func VcCMD(use string) *cobra.Command {
+// StartVC creates the start validator-committer command.
+func StartVC() *cobra.Command {
 	v := NewViperWithVCDefaults()
 	var configPath string
 	cmd := &cobra.Command{
-		Use:   use,
+		Use:   "vc",
 		Short: fmt.Sprintf("Starts %v.", VcName),
 		Long:  fmt.Sprintf("%v is a validator and committer service.", VcName),
 		Args:  cobra.NoArgs,
@@ -149,12 +163,12 @@ func VcCMD(use string) *cobra.Command {
 	return cmd
 }
 
-// VerifierCMD creates a verifier command.
-func VerifierCMD(use string) *cobra.Command {
+// StartVerifier creates the start verifier command.
+func StartVerifier() *cobra.Command {
 	v := NewViperWithVerifierDefaults()
 	var configPath string
 	cmd := &cobra.Command{
-		Use:   use,
+		Use:   "verifier",
 		Short: fmt.Sprintf("Starts %v.", VerifierName),
 		Long:  fmt.Sprintf("%v verifies the transaction's form and signatures.", VerifierName),
 		Args:  cobra.NoArgs,
@@ -195,12 +209,12 @@ func VerifierCMD(use string) *cobra.Command {
 	return cmd
 }
 
-// QueryCMD creates a query command.
-func QueryCMD(use string) *cobra.Command {
+// StartQuery creates the start query command.
+func StartQuery() *cobra.Command {
 	v := NewViperWithQueryDefaults()
 	var configPath string
 	cmd := &cobra.Command{
-		Use:   use,
+		Use:   "query",
 		Short: fmt.Sprintf("Starts %v.", QueryName),
 		Long:  fmt.Sprintf("%v is a service to query the state.", QueryName),
 		Args:  cobra.NoArgs,

--- a/cmd/mock/main.go
+++ b/cmd/mock/main.go
@@ -43,18 +43,27 @@ func mockCMD() *cobra.Command {
 		Short: "Fabric-X services mock.",
 	}
 	cmd.AddCommand(config.VersionCmd())
-	cmd.AddCommand(mockOrdererCMD())
-	cmd.AddCommand(mockCoordinatorCMD())
-	cmd.AddCommand(mockVerifierCMD())
-	cmd.AddCommand(mockVcCMD())
+	cmd.AddCommand(mockStartCMD())
 	return cmd
 }
 
-func mockOrdererCMD() *cobra.Command {
+func mockStartCMD() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "start",
+		Short: "Start a mock service.",
+	}
+	cmd.AddCommand(startMockOrderer())
+	cmd.AddCommand(startMockCoordinator())
+	cmd.AddCommand(startMockVerifier())
+	cmd.AddCommand(startMockVC())
+	return cmd
+}
+
+func startMockOrderer() *cobra.Command {
 	v := config.NewViperWithLoggingDefault()
 	var configPath string
 	cmd := &cobra.Command{
-		Use:   "start-orderer",
+		Use:   "orderer",
 		Short: fmt.Sprintf("Starts %v.", mockOrdererName),
 		Long:  fmt.Sprintf("%v is a mock ordering service.", mockOrdererName),
 		Args:  cobra.NoArgs,
@@ -82,11 +91,11 @@ func mockOrdererCMD() *cobra.Command {
 	return cmd
 }
 
-func mockCoordinatorCMD() *cobra.Command {
+func startMockCoordinator() *cobra.Command {
 	v := config.NewViperWithCoordinatorDefaults()
 	var configPath string
 	cmd := &cobra.Command{
-		Use:   "start-coordinator",
+		Use:   "coordinator",
 		Short: fmt.Sprintf("Starts %v", mockCoordinatorName),
 		Long:  fmt.Sprintf("%v is a mock coordinator service.", mockCoordinatorName),
 		Args:  cobra.NoArgs,
@@ -107,12 +116,11 @@ func mockCoordinatorCMD() *cobra.Command {
 	return cmd
 }
 
-//nolint:dupl // similar to mockVcCMD.
-func mockVerifierCMD() *cobra.Command {
+func startMockVerifier() *cobra.Command {
 	v := config.NewViperWithVerifierDefaults()
 	var configPath string
 	cmd := &cobra.Command{
-		Use:   "start-verifier",
+		Use:   "verifier",
 		Short: fmt.Sprintf("Starts %v", mockVerifierName),
 		Long:  fmt.Sprintf("%v is a mock signature verification service.", mockVerifierName),
 		Args:  cobra.NoArgs,
@@ -133,12 +141,11 @@ func mockVerifierCMD() *cobra.Command {
 	return cmd
 }
 
-//nolint:dupl // similar to mockVerifierCMD.
-func mockVcCMD() *cobra.Command {
+func startMockVC() *cobra.Command {
 	v := config.NewViperWithVCDefaults()
 	var configPath string
 	cmd := &cobra.Command{
-		Use:   "start-vc",
+		Use:   "vc",
 		Short: fmt.Sprintf("Starts %v.", mockVcName),
 		Long:  fmt.Sprintf("%v is a mock validator and committer service.", mockVcName),
 		Args:  cobra.NoArgs,

--- a/cmd/mock/main_test.go
+++ b/cmd/mock/main_test.go
@@ -44,19 +44,19 @@ func TestMockCMD(t *testing.T) {
 	}
 
 	for _, serviceCase := range []struct {
-		Command  string
+		Command  []string
 		Name     string
 		Template string
 	}{
-		{Command: "start-vc", Name: mockVcName, Template: config.TemplateVC},
-		{Command: "start-verifier", Name: mockVerifierName, Template: config.TemplateVerifier},
-		{Command: "start-orderer", Name: mockOrdererName, Template: config.TemplateMockOrderer},
+		{Command: []string{"start", "vc"}, Name: mockVcName, Template: config.TemplateVC},
+		{Command: []string{"start", "verifier"}, Name: mockVerifierName, Template: config.TemplateVerifier},
+		{Command: []string{"start", "orderer"}, Name: mockOrdererName, Template: config.TemplateMockOrderer},
 	} {
 		t.Run(serviceCase.Name, func(t *testing.T) {
 			cases := []config.CommandTest{
 				{
 					Name:              "start with endpoint",
-					Args:              []string{serviceCase.Command, "--endpoint", "localhost:8004"},
+					Args:              append(serviceCase.Command, "--endpoint", "localhost:8004"),
 					CmdLoggerOutputs:  []string{"Serving", "localhost:8004"},
 					CmdStdOutput:      fmt.Sprintf("Starting %v", serviceCase.Name),
 					UseConfigTemplate: serviceCase.Template,
@@ -64,7 +64,7 @@ func TestMockCMD(t *testing.T) {
 				},
 				{
 					Name:              "start",
-					Args:              []string{serviceCase.Command},
+					Args:              serviceCase.Command,
 					CmdLoggerOutputs:  []string{"Serving", s.ThisService.GrpcEndpoint.String()},
 					CmdStdOutput:      fmt.Sprintf("Starting %v", serviceCase.Name),
 					UseConfigTemplate: serviceCase.Template,

--- a/docker/images/test_node/run
+++ b/docker/images/test_node/run
@@ -44,15 +44,15 @@ if [[ $ops == *"db"* ]]; then
 fi
 
 if [[ $ops == *"orderer"* ]]; then
-  "$BINS_PATH/mock"      start-orderer     --config "$CONFIGS_PATH/mock-orderer.yaml" &
+  "$BINS_PATH/mock"      start orderer     --config "$CONFIGS_PATH/mock-orderer.yaml" &
 fi
 
 if [[ $ops == *"committer"* ]]; then
-  "$BINS_PATH/committer" start-verifier    --config "$CONFIGS_PATH/verifier.yaml" &
-  "$BINS_PATH/committer" start-vc          --config "$CONFIGS_PATH/vc.yaml" &
-  "$BINS_PATH/committer" start-query       --config "$CONFIGS_PATH/query.yaml" &
-  "$BINS_PATH/committer" start-coordinator --config "$CONFIGS_PATH/coordinator.yaml" &
-  "$BINS_PATH/committer" start-sidecar     --config "$CONFIGS_PATH/sidecar.yaml" &
+  "$BINS_PATH/committer" start verifier    --config "$CONFIGS_PATH/verifier.yaml" &
+  "$BINS_PATH/committer" start vc          --config "$CONFIGS_PATH/vc.yaml" &
+  "$BINS_PATH/committer" start query       --config "$CONFIGS_PATH/query.yaml" &
+  "$BINS_PATH/committer" start coordinator --config "$CONFIGS_PATH/coordinator.yaml" &
+  "$BINS_PATH/committer" start sidecar     --config "$CONFIGS_PATH/sidecar.yaml" &
 fi
 
 if [[ $ops == *"loadgen"* ]]; then

--- a/docker/test/container_release_image_test.go
+++ b/docker/test/container_release_image_test.go
@@ -186,7 +186,8 @@ func startCommitterNodeWithReleaseImage(ctx context.Context, t *testing.T, param
 		config: &container.Config{
 			Image: committerReleaseImage,
 			Cmd: []string{
-				fmt.Sprintf("start-%s", params.node),
+				"start",
+				params.node,
 				"--config",
 				fmt.Sprintf("%s.yaml", configPath),
 			},

--- a/integration/runner/process.go
+++ b/integration/runner/process.go
@@ -32,7 +32,7 @@ type (
 	CmdParameters struct {
 		Name     string
 		Bin      string
-		Arg      string
+		Args     []string
 		Template string
 	}
 )
@@ -47,43 +47,43 @@ var (
 	cmdOrderer = CmdParameters{
 		Name:     "orderer",
 		Bin:      mockCMD,
-		Arg:      "start-orderer",
+		Args:     []string{"start", "orderer"},
 		Template: config.TemplateMockOrderer,
 	}
 	cmdVerifier = CmdParameters{
 		Name:     "verifier",
 		Bin:      committerCMD,
-		Arg:      "start-verifier",
+		Args:     []string{"start", "verifier"},
 		Template: config.TemplateVerifier,
 	}
 	cmdVC = CmdParameters{
 		Name:     "vc",
 		Bin:      committerCMD,
-		Arg:      "start-vc",
+		Args:     []string{"start", "vc"},
 		Template: config.TemplateVC,
 	}
 	cmdCoordinator = CmdParameters{
 		Name:     "coordinator",
 		Bin:      committerCMD,
-		Arg:      "start-coordinator",
+		Args:     []string{"start", "coordinator"},
 		Template: config.TemplateCoordinator,
 	}
 	cmdSidecar = CmdParameters{
 		Name:     "sidecar",
 		Bin:      committerCMD,
-		Arg:      "start-sidecar",
+		Args:     []string{"start", "sidecar"},
 		Template: config.TemplateSidecar,
 	}
 	cmdQuery = CmdParameters{
 		Name:     "query",
 		Bin:      committerCMD,
-		Arg:      "start-query",
+		Args:     []string{"start", "query"},
 		Template: config.TemplateQueryService,
 	}
 	cmdLoadGen = CmdParameters{
 		Name: "loadgen",
 		Bin:  loadgenCMD,
-		Arg:  "start",
+		Args: []string{"start"},
 	}
 )
 
@@ -126,7 +126,7 @@ func (p *ProcessWithConfig) Restart(t *testing.T) {
 	t.Helper()
 	p.Stop(t)
 	cmdPath := path.Join("bin", p.params.Bin)
-	c := exec.Command(cmdPath, p.params.Arg, "--config", p.configFilePath)
+	c := exec.Command(cmdPath, append(p.params.Args, "--config", p.configFilePath)...)
 	dir, err := os.Getwd()
 	require.NoError(t, err)
 	c.Dir = path.Clean(path.Join(dir, "../.."))


### PR DESCRIPTION
#### Type of change

- Improvement (improvement to code, performance, etc)
 
#### Description

Change the CLI from flat `start-<service>` commands to nested `start <service>` subcommands, enabling future verb commands like `healthcheck <service>`.

- Remove `use` parameter from service command functions in `cmd/config/cmd.go`; each now uses a fixed name. Add `StartCMD()` parent that groups all service subcommands.
- Update `cmd/committer` and `cmd/mock` to use the new parent command.
- Change `CmdParameters.Arg` to `Args []string` in integration runner.
- Update test node shell script invocations.
- Update all unit tests for the new command format.

#### Related issues

  - resolves #490 