### PR TITLE
[cmd] add `committer healthcheck <service>` subcommands

### DIFF
--- a/cmd/cliutil/test_exports.go
+++ b/cmd/cliutil/test_exports.go
@@ -35,6 +35,7 @@ type CommandTest struct {
 	Args              []string
 	CmdLoggerOutputs  []string
 	CmdStdOutput      string
+	CmdStdErrOutput   string
 	Err               error
 	UseConfigTemplate string
 	System            config.SystemConfig
@@ -147,7 +148,7 @@ func UnitTestRunner(
 	})
 
 	assert.Eventually(t, func() bool {
-		return len(getMissing(cmdTest, cmdStdOut.String(), loggerPath)) == 0
+		return len(getMissing(cmdTest, cmdStdOut.String(), cmdStdErr.String(), loggerPath)) == 0
 	}, 10*time.Minute, 500*time.Millisecond)
 
 	t.Log("Stopping command, and waiting for finish")
@@ -164,7 +165,7 @@ func UnitTestRunner(
 	if err == nil {
 		t.Log("LOG:\n", string(logOut))
 	}
-	for _, m := range getMissing(cmdTest, cmdStdOut.String(), loggerPath) {
+	for _, m := range getMissing(cmdTest, cmdStdOut.String(), cmdStdErr.String(), loggerPath) {
 		t.Logf("Missing: %s", m)
 	}
 }
@@ -184,9 +185,12 @@ func defaultTestDBConfig() config.DatabaseConfig {
 	}
 }
 
-func getMissing(cmdTest CommandTest, cmdStdOut, loggerPath string) (missing []string) {
+func getMissing(cmdTest CommandTest, cmdStdOut, cmdStdErr, loggerPath string) (missing []string) {
 	if cmdTest.CmdStdOutput != "" && !strings.Contains(cmdStdOut, cmdTest.CmdStdOutput) {
 		missing = append(missing, cmdTest.CmdStdOutput)
+	}
+	if cmdTest.CmdStdErrOutput != "" && !strings.Contains(cmdStdErr, cmdTest.CmdStdErrOutput) {
+		missing = append(missing, cmdTest.CmdStdErrOutput)
 	}
 	if len(cmdTest.CmdLoggerOutputs) == 0 {
 		return missing

--- a/cmd/committer/config.go
+++ b/cmd/committer/config.go
@@ -1,0 +1,46 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package main
+
+import (
+	"github.com/cockroachdb/errors"
+
+	"github.com/hyperledger/fabric-x-committer/cmd/config"
+)
+
+const (
+	sidecarService     = "sidecar"
+	coordinatorService = "coordinator"
+	vcService          = "vc"
+	verifierService    = "verifier"
+	queryService       = "query"
+)
+
+var serviceNames = map[string]string{
+	sidecarService:     "Sidecar",
+	coordinatorService: "Coordinator",
+	vcService:          "Validator-Committer",
+	verifierService:    "Verifier",
+	queryService:       "Query-Service",
+}
+
+func readConfig(name, configPath string) (any, error) {
+	switch name {
+	case sidecarService:
+		return config.ReadSidecarYamlAndSetupLogging(config.NewViperWithSidecarDefaults(), configPath)
+	case coordinatorService:
+		return config.ReadCoordinatorYamlAndSetupLogging(config.NewViperWithCoordinatorDefaults(), configPath)
+	case vcService:
+		return config.ReadVCYamlAndSetupLogging(config.NewViperWithVCDefaults(), configPath)
+	case verifierService:
+		return config.ReadVerifierYamlAndSetupLogging(config.NewViperWithVerifierDefaults(), configPath)
+	case queryService:
+		return config.ReadQueryYamlAndSetupLogging(config.NewViperWithQueryDefaults(), configPath)
+	default:
+		return nil, errors.Newf("unknown service: %s", name)
+	}
+}

--- a/cmd/committer/healthcheck_cmd.go
+++ b/cmd/committer/healthcheck_cmd.go
@@ -7,7 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 package main
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/cockroachdb/errors"
@@ -22,67 +21,61 @@ import (
 	"github.com/hyperledger/fabric-x-committer/utils/connection"
 )
 
-func startCMD() *cobra.Command {
+// healthcheckCMD creates the "healthcheck" parent command with all service subcommands.
+func healthcheckCMD() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "start",
-		Short: "Start a service.",
+		Use:   "healthcheck",
+		Short: "Check if a service is healthy.",
 	}
 	for _, name := range []string{sidecarService, coordinatorService, vcService, verifierService, queryService} {
-		cmd.AddCommand(startServiceCommand(name))
+		cmd.AddCommand(healthcheckServiceCommand(name))
 	}
 	return cmd
 }
 
-func startServiceCommand(name string) *cobra.Command {
+func healthcheckServiceCommand(name string) *cobra.Command {
 	var configPath string
 	cmd := &cobra.Command{
 		Use:          name,
-		Short:        fmt.Sprintf("Starts %v.", serviceNames[name]),
+		Short:        fmt.Sprintf("Check %v health.", serviceNames[name]),
 		Args:         cobra.NoArgs,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			cmd.Printf("Starting %v\n", serviceNames[name])
-			defer cmd.Printf("%v ended\n", serviceNames[name])
-			return startService(cmd.Context(), name, configPath)
+			return runHealthCheck(cmd, name, configPath)
 		},
 	}
 	cliutil.SetDefaultFlags(cmd, &configPath)
 	return cmd
 }
 
-func startService(ctx context.Context, name, configPath string) error {
+// runHealthCheck reads the service config, performs a gRPC health check, and prints the result.
+func runHealthCheck(cmd *cobra.Command, name, configPath string) error {
 	conf, err := readConfig(name, configPath)
 	if err != nil {
 		return err
 	}
 
+	var server *connection.ServerConfig
 	switch c := conf.(type) {
 	case *sidecar.Config:
-		service, err := sidecar.New(c)
-		if err != nil {
-			return errors.Wrap(err, "failed to create sidecar service")
-		}
-		defer service.Close()
-		return connection.StartService(ctx, service, c.Server)
-
+		server = c.Server
 	case *coordinator.Config:
-		return connection.StartService(ctx, coordinator.NewCoordinatorService(c), c.Server)
-
+		server = c.Server
 	case *vc.Config:
-		service, err := vc.NewValidatorCommitterService(ctx, c)
-		if err != nil {
-			return errors.Wrap(err, "failed to create validator committer service")
-		}
-		defer service.Close()
-		return connection.StartService(ctx, service, c.Server)
-
+		server = c.Server
 	case *verifier.Config:
-		return connection.StartService(ctx, verifier.New(c), c.Server)
-
+		server = c.Server
 	case *query.Config:
-		return connection.StartService(ctx, query.NewQueryService(c), c.Server)
-
+		server = c.Server
 	default:
 		return errors.Newf("unknown config type: %T", conf)
 	}
+
+	displayName := serviceNames[name]
+	if err := connection.RunHealthCheck(cmd.Context(), server.Endpoint, server.TLS); err != nil {
+		cmd.PrintErrf("%s: NOT SERVING: %v\n", displayName, err)
+		return err
+	}
+	cmd.Printf("%s: SERVING\n", displayName)
+	return nil
 }

--- a/cmd/committer/healthcheck_cmd_test.go
+++ b/cmd/committer/healthcheck_cmd_test.go
@@ -59,36 +59,34 @@ func TestHealthcheckCMD(t *testing.T) {
 	})
 	notServingSystem := newSystemConfig(&notServingConfig.Endpoint)
 
-	serviceCases := []struct {
-		Service string
-		Name    string
-		Templ   string
+	for _, sc := range []struct {
+		service string
+		name    string
+		templ   string
 	}{
-		{Service: sidecarService, Name: serviceNames[sidecarService], Templ: config.TemplateSidecar},
-		{Service: coordinatorService, Name: serviceNames[coordinatorService], Templ: config.TemplateCoordinator},
-		{Service: vcService, Name: serviceNames[vcService], Templ: config.TemplateVC},
-		{Service: verifierService, Name: serviceNames[verifierService], Templ: config.TemplateVerifier},
-		{Service: queryService, Name: serviceNames[queryService], Templ: config.TemplateQueryService},
-	}
-
-	for _, sc := range serviceCases {
-		t.Run(fmt.Sprintf("%s/serving", sc.Name), func(t *testing.T) {
+		{service: sidecarService, name: serviceNames[sidecarService], templ: config.TemplateSidecar},
+		{service: coordinatorService, name: serviceNames[coordinatorService], templ: config.TemplateCoordinator},
+		{service: vcService, name: serviceNames[vcService], templ: config.TemplateVC},
+		{service: verifierService, name: serviceNames[verifierService], templ: config.TemplateVerifier},
+		{service: queryService, name: serviceNames[queryService], templ: config.TemplateQueryService},
+	} {
+		t.Run(fmt.Sprintf("%s/serving", sc.name), func(t *testing.T) {
 			cliutil.UnitTestRunner(t, committerCMD(), cliutil.CommandTest{
 				Name:              "healthcheck",
-				Args:              []string{"healthcheck", sc.Service},
-				CmdStdOutput:      fmt.Sprintf("%s: SERVING", sc.Name),
-				UseConfigTemplate: sc.Templ,
+				Args:              []string{"healthcheck", sc.service},
+				CmdStdOutput:      fmt.Sprintf("%s: SERVING", sc.name),
+				UseConfigTemplate: sc.templ,
 				System:            servingSystem,
 			})
 		})
 
-		t.Run(fmt.Sprintf("%s/not-serving", sc.Name), func(t *testing.T) {
+		t.Run(fmt.Sprintf("%s/not-serving", sc.name), func(t *testing.T) {
 			cliutil.UnitTestRunner(t, committerCMD(), cliutil.CommandTest{
 				Name:              "healthcheck",
-				Args:              []string{"healthcheck", sc.Service},
-				CmdStdErrOutput:   fmt.Sprintf("%s: NOT SERVING", sc.Name),
+				Args:              []string{"healthcheck", sc.service},
+				CmdStdErrOutput:   fmt.Sprintf("%s: NOT SERVING", sc.name),
 				Err:               errors.New("service is NOT_SERVING"),
-				UseConfigTemplate: sc.Templ,
+				UseConfigTemplate: sc.templ,
 				System:            notServingSystem,
 			})
 		})

--- a/cmd/committer/healthcheck_cmd_test.go
+++ b/cmd/committer/healthcheck_cmd_test.go
@@ -1,0 +1,96 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package main
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/errors"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/health"
+	healthgrpc "google.golang.org/grpc/health/grpc_health_v1"
+
+	"github.com/hyperledger/fabric-x-committer/cmd/cliutil"
+	"github.com/hyperledger/fabric-x-committer/cmd/config"
+	"github.com/hyperledger/fabric-x-committer/loadgen/workload"
+	"github.com/hyperledger/fabric-x-committer/utils/connection"
+	"github.com/hyperledger/fabric-x-committer/utils/test"
+)
+
+//nolint:paralleltest // Cannot parallelize due to logger.
+func TestHealthcheckCMD(t *testing.T) {
+	newSystemConfig := func(endpoint *connection.Endpoint) config.SystemConfig {
+		dummy := connection.Endpoint{Host: "localhost", Port: 1}
+		dummyServiceConfig := []config.ServiceConfig{{GrpcEndpoint: &dummy}}
+		return config.SystemConfig{
+			ThisService: config.ServiceConfig{
+				GrpcEndpoint: endpoint,
+			},
+			Services: config.SystemServices{
+				Verifier:    dummyServiceConfig,
+				VCService:   dummyServiceConfig,
+				Orderer:     dummyServiceConfig,
+				Coordinator: dummyServiceConfig[0],
+			},
+			DB: config.DatabaseConfig{
+				Endpoints: []*connection.Endpoint{&dummy},
+			},
+			Policy:     &workload.PolicyProfile{ArtifactsPath: t.TempDir()},
+			LedgerPath: t.TempDir(),
+		}
+	}
+
+	// SERVING: start a gRPC server that reports SERVING.
+	serverConfig := test.NewLocalHostServer(test.InsecureTLSConfig)
+	test.RunGrpcServerForTest(t.Context(), t, serverConfig, nil)
+	servingSystem := newSystemConfig(&serverConfig.Endpoint)
+
+	// NOT SERVING: start a separate gRPC server that reports NOT_SERVING.
+	notServingConfig := test.NewLocalHostServer(test.InsecureTLSConfig)
+	test.RunGrpcServerForTest(t.Context(), t, notServingConfig, func(server *grpc.Server) {
+		hs := health.NewServer()
+		hs.SetServingStatus("", healthgrpc.HealthCheckResponse_NOT_SERVING)
+		healthgrpc.RegisterHealthServer(server, hs)
+	})
+	notServingSystem := newSystemConfig(&notServingConfig.Endpoint)
+
+	serviceCases := []struct {
+		Service string
+		Name    string
+		Templ   string
+	}{
+		{Service: sidecarService, Name: serviceNames[sidecarService], Templ: config.TemplateSidecar},
+		{Service: coordinatorService, Name: serviceNames[coordinatorService], Templ: config.TemplateCoordinator},
+		{Service: vcService, Name: serviceNames[vcService], Templ: config.TemplateVC},
+		{Service: verifierService, Name: serviceNames[verifierService], Templ: config.TemplateVerifier},
+		{Service: queryService, Name: serviceNames[queryService], Templ: config.TemplateQueryService},
+	}
+
+	for _, sc := range serviceCases {
+		t.Run(fmt.Sprintf("%s/serving", sc.Name), func(t *testing.T) {
+			cliutil.UnitTestRunner(t, committerCMD(), cliutil.CommandTest{
+				Name:              "healthcheck",
+				Args:              []string{"healthcheck", sc.Service},
+				CmdStdOutput:      fmt.Sprintf("%s: SERVING", sc.Name),
+				UseConfigTemplate: sc.Templ,
+				System:            servingSystem,
+			})
+		})
+
+		t.Run(fmt.Sprintf("%s/not-serving", sc.Name), func(t *testing.T) {
+			cliutil.UnitTestRunner(t, committerCMD(), cliutil.CommandTest{
+				Name:              "healthcheck",
+				Args:              []string{"healthcheck", sc.Service},
+				CmdStdErrOutput:   fmt.Sprintf("%s: NOT SERVING", sc.Name),
+				Err:               errors.New("service is NOT_SERVING"),
+				UseConfigTemplate: sc.Templ,
+				System:            notServingSystem,
+			})
+		})
+	}
+}

--- a/cmd/committer/main.go
+++ b/cmd/committer/main.go
@@ -31,5 +31,6 @@ func committerCMD() *cobra.Command {
 	}
 	cmd.AddCommand(cliutil.VersionCmd())
 	cmd.AddCommand(startCMD())
+	cmd.AddCommand(healthcheckCMD())
 	return cmd
 }

--- a/docker/images/release/Dockerfile
+++ b/docker/images/release/Dockerfile
@@ -51,5 +51,8 @@ LABEL org.opencontainers.image.created="${CREATED}" \
 USER 10001
 WORKDIR /home/${BIN}
 
+# Health check: configure in docker-compose.yml or orchestrator with:
+#   HEALTHCHECK CMD ["/bin/entrypoint", "healthcheck", "<service>", "--config", "<config-path>"]
+
 # Default Entrypoint
 ENTRYPOINT ["/bin/entrypoint"]

--- a/docker/images/test_node/Dockerfile
+++ b/docker/images/test_node/Dockerfile
@@ -45,7 +45,7 @@ ENV SC_VC_DATABASE_TLS_MODE="none"
 ENV SC_QUERY_DATABASE_TLS_MODE="none"
 
 COPY ${SRC_BIN_PATH}/${TARGETOS}-${TARGETARCH}/* ${BINS_PATH}/
-COPY ./docker/images/test_node/run ${BINS_PATH}/
+COPY ./docker/images/test_node/run ./docker/images/test_node/healthcheck ${BINS_PATH}/
 COPY ./cmd/config/samples $CONFIGS_PATH
 RUN chmod a+x ${BINS_PATH}/*
 

--- a/docker/images/test_node/healthcheck
+++ b/docker/images/test_node/healthcheck
@@ -7,7 +7,7 @@
 
 set -e
 
-"$BINS_PATH/committer" healthcheck sidecar     --config "$CONFIGS_PATH/sidecar.yaml"
+"$BINS_PATH/committer" healthcheck sidecar      --config "$CONFIGS_PATH/sidecar.yaml"
 "$BINS_PATH/committer" healthcheck coordinator  --config "$CONFIGS_PATH/coordinator.yaml"
 "$BINS_PATH/committer" healthcheck vc           --config "$CONFIGS_PATH/vc.yaml"
 "$BINS_PATH/committer" healthcheck verifier     --config "$CONFIGS_PATH/verifier.yaml"

--- a/docker/images/test_node/healthcheck
+++ b/docker/images/test_node/healthcheck
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+#
+# Copyright IBM Corp. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set -e
+
+"$BINS_PATH/committer" healthcheck sidecar     --config "$CONFIGS_PATH/sidecar.yaml"
+"$BINS_PATH/committer" healthcheck coordinator  --config "$CONFIGS_PATH/coordinator.yaml"
+"$BINS_PATH/committer" healthcheck vc           --config "$CONFIGS_PATH/vc.yaml"
+"$BINS_PATH/committer" healthcheck verifier     --config "$CONFIGS_PATH/verifier.yaml"
+"$BINS_PATH/committer" healthcheck query        --config "$CONFIGS_PATH/query.yaml"

--- a/docker/test/common.go
+++ b/docker/test/common.go
@@ -202,6 +202,21 @@ func assembleContainerName(node, tlsMode, dbType string) string {
 	return fmt.Sprintf("%s_%s_%s_%s", test.DockerNamesPrefix, node, tlsMode, dbType)
 }
 
+// waitForContainerHealthy waits until Docker reports the container as healthy.
+func waitForContainerHealthy(ctx context.Context, t *testing.T, containerName string) {
+	t.Helper()
+	dockerClient := createDockerClient(t)
+	t.Logf("Waiting for %s to be healthy", containerName)
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		inspect, err := dockerClient.ContainerInspect(ctx, containerName)
+		assert.NoError(ct, err)
+		if inspect.State.Health != nil {
+			assert.Equal(ct, "healthy", inspect.State.Health.Status)
+		}
+	}, 3*time.Minute, 500*time.Millisecond, "%s did not become healthy", containerName)
+	t.Logf("%s is healthy", containerName)
+}
+
 func copyArtifactsFromContainer(ctx context.Context, t *testing.T, containerName string) string {
 	t.Helper()
 

--- a/docker/test/container_release_image_test.go
+++ b/docker/test/container_release_image_test.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/go-connections/nat"
@@ -109,6 +110,10 @@ func TestCommitterReleaseImagesWithTLS(t *testing.T) {
 					// start the committer nodes.
 					for _, node := range committerNodes {
 						startCommitterNodeWithReleaseImage(ctx, t, params.asNode(node))
+					}
+					// Wait for each committer node to be healthy.
+					for _, node := range committerNodes {
+						waitForContainerHealthy(ctx, t, assembleContainerName(node, mode, dbType))
 					}
 					// start the load generator node.
 					startLoadgenNodeWithReleaseImage(ctx, t, params.asNode(loadgenNode))
@@ -215,6 +220,16 @@ func startCommitterNodeWithReleaseImage(ctx context.Context, t *testing.T, param
 				"SC_QUERY_DATABASE_USERNAME=" + params.dbUsername(),
 				"SC_VC_DATABASE_DATABASE=" + params.dbDefaultDatabase(),
 				"SC_QUERY_DATABASE_DATABASE=" + params.dbDefaultDatabase(),
+			},
+			Healthcheck: &container.HealthConfig{
+				Test: []string{
+					"CMD", "/bin/entrypoint", "healthcheck", params.node,
+					"--config", fmt.Sprintf("%s.yaml", configPath),
+				},
+				Interval:    2 * time.Second,
+				Timeout:     5 * time.Second,
+				StartPeriod: 30 * time.Second,
+				Retries:     30,
 			},
 			Tty: true,
 		},

--- a/docker/test/container_test.go
+++ b/docker/test/container_test.go
@@ -69,6 +69,7 @@ func TestStartTestNodeWithTLSModesAndRemoteConnection(t *testing.T) {
 				tlsMode: mode,
 				cmd:     commonTestNodeCMD,
 			})
+			waitForContainerHealthy(ctx, t, containerName)
 
 			v := config.NewViperWithLoadGenDefaults()
 			c, err := config.ReadLoadGenYamlAndSetupLogging(v, filepath.Join(localConfigPath, "loadgen.yaml"))
@@ -213,6 +214,7 @@ func TestStartTestNode(t *testing.T) {
 		tlsMode: connection.NoneTLSMode,
 		cmd:     append(commonTestNodeCMD, "loadgen"),
 	})
+	waitForContainerHealthy(ctx, t, containerName)
 
 	t.Log("Try to fetch the first block")
 	sidecarEndpoint := mustGetEndpoint(ctx, t, containerName, sidecarPort)
@@ -260,6 +262,13 @@ func startCommitter(ctx context.Context, t *testing.T, params startNodeParameter
 				"SC_LOADGEN_MONITORING_TLS_MODE=" + params.tlsMode,
 				"SC_LOADGEN_ORDERER_CLIENT_SIDECAR_CLIENT_TLS_MODE=" + params.tlsMode,
 				"SC_LOADGEN_ORDERER_CLIENT_ORDERER_TLS_MODE=" + params.tlsMode,
+			},
+			Healthcheck: &container.HealthConfig{
+				Test:        []string{"CMD", "healthcheck"},
+				Interval:    2 * time.Second,
+				Timeout:     5 * time.Second,
+				StartPeriod: 30 * time.Second,
+				Retries:     30,
 			},
 			Tty: true,
 		},

--- a/utils/connection/healthcheck.go
+++ b/utils/connection/healthcheck.go
@@ -1,0 +1,41 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package connection
+
+import (
+	"context"
+
+	"github.com/cockroachdb/errors"
+	"google.golang.org/grpc"
+	healthgrpc "google.golang.org/grpc/health/grpc_health_v1"
+)
+
+// RunHealthCheck dials the given endpoint and performs a gRPC health check.
+// Returns nil if the service reports SERVING, otherwise returns an error.
+func RunHealthCheck(ctx context.Context, endpoint Endpoint, tlsConfig TLSConfig) error {
+	creds, err := tlsConfig.ClientCredentials()
+	if err != nil {
+		return errors.Wrap(err, "failed to create client credentials")
+	}
+
+	conn, err := grpc.NewClient(endpoint.Address(), grpc.WithTransportCredentials(creds))
+	if err != nil {
+		return errors.Wrap(err, "failed to create gRPC client")
+	}
+	defer func() { _ = conn.Close() }()
+
+	resp, err := healthgrpc.NewHealthClient(conn).Check(ctx, &healthgrpc.HealthCheckRequest{})
+	if err != nil {
+		return errors.Wrap(err, "health check failed")
+	}
+
+	if resp.Status != healthgrpc.HealthCheckResponse_SERVING {
+		return errors.Newf("service is %s", resp.Status)
+	}
+
+	return nil
+}

--- a/utils/connection/healthcheck.go
+++ b/utils/connection/healthcheck.go
@@ -10,19 +10,16 @@ import (
 	"context"
 
 	"github.com/cockroachdb/errors"
-	"google.golang.org/grpc"
 	healthgrpc "google.golang.org/grpc/health/grpc_health_v1"
 )
 
 // RunHealthCheck dials the given endpoint and performs a gRPC health check.
 // Returns nil if the service reports SERVING, otherwise returns an error.
 func RunHealthCheck(ctx context.Context, endpoint Endpoint, tlsConfig TLSConfig) error {
-	creds, err := tlsConfig.ClientCredentials()
-	if err != nil {
-		return errors.Wrap(err, "failed to create client credentials")
-	}
-
-	conn, err := grpc.NewClient(endpoint.Address(), grpc.WithTransportCredentials(creds))
+	conn, err := NewSingleConnection(&ClientConfig{
+		Endpoint: &endpoint,
+		TLS:      tlsConfig,
+	})
 	if err != nil {
 		return errors.Wrap(err, "failed to create gRPC client")
 	}

--- a/utils/connection/healthcheck_test.go
+++ b/utils/connection/healthcheck_test.go
@@ -1,0 +1,44 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package connection_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger/fabric-x-committer/utils/connection"
+	"github.com/hyperledger/fabric-x-committer/utils/test"
+)
+
+func TestRunHealthCheck(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns nil when service is SERVING", func(t *testing.T) {
+		t.Parallel()
+		serverConfig := test.NewLocalHostServer(test.InsecureTLSConfig)
+
+		ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+		t.Cleanup(cancel)
+		test.RunGrpcServerForTest(ctx, t, serverConfig, nil)
+
+		err := connection.RunHealthCheck(ctx, serverConfig.Endpoint, serverConfig.TLS)
+		require.NoError(t, err)
+	})
+
+	t.Run("returns error when service is not reachable", func(t *testing.T) {
+		t.Parallel()
+		ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+		t.Cleanup(cancel)
+
+		unreachableEndpoint := connection.Endpoint{Host: "localhost", Port: 1}
+		err := connection.RunHealthCheck(ctx, unreachableEndpoint, connection.TLSConfig{Mode: "none"})
+		require.Error(t, err)
+	})
+}


### PR DESCRIPTION
#### Type of change

- New feature
 
#### Description

Add a healthcheck command that performs a gRPC health check against a
  running service using the same config file as 'start'. Each service
  subcommand loads the config, dials the server endpoint with TLS
  credentials, and calls grpc.health.v1.Health/Check. Prints SERVING
  (exit 0) or NOT SERVING (exit 1) for use as a Docker HEALTHCHECK.

  - Add RunHealthCheck utility in utils/connection
  - Add healthcheckCMD with sidecar, coordinator, vc, verifier, query
    subcommands
  - Add readiness gate to container release image tests via docker exec
  - Add HEALTHCHECK usage comment to release Dockerfile

#### Related issues

  - resolves #494 
  - resolves #489 