### PR TITLE
[test] fix flaky TestSignatureVerifierManagerPolicyUpdateAndRecover

### DIFF
--- a/service/coordinator/signature_verifier_manager_test.go
+++ b/service/coordinator/signature_verifier_manager_test.go
@@ -377,13 +377,14 @@ func TestSignatureVerifierManagerPolicyUpdateAndRecover(t *testing.T) {
 	}
 	env.policyManager.update(expectedUpdate)
 
-	t.Log("Verify that all mock policy verifiers have the same verification key")
-	env.requireAllUpdate(t, verifierStreams, 1, expectedUpdate)
-
 	// Drain the output channel in the background to prevent signVerifier goroutines from blocking
-	// on channel writes after requireAllUpdate fills it up. Without this, goroutines stuck on
-	// Write() never reach Recv(), so they can't detect server failures via broken streams.
+	// on channel writes. Without this, goroutines stuck on Write() never reach Recv(), so they
+	// can't detect server failures via broken streams. Starting the drain before requireAllUpdate
+	// ensures signVerifiers never block on Write during batch processing, keeping them responsive
+	// to stream errors when the server is stopped later.
+	drainReady := channel.NewReady()
 	go func() {
+		drainReady.SignalReady()
 		for {
 			select {
 			case <-t.Context().Done():
@@ -392,6 +393,10 @@ func TestSignatureVerifierManagerPolicyUpdateAndRecover(t *testing.T) {
 			}
 		}
 	}()
+	require.True(t, drainReady.WaitForReady(t.Context()))
+
+	t.Log("Verify that all mock policy verifiers have the same verification key")
+	env.requireAllUpdate(t, verifierStreams, 1, expectedUpdate)
 
 	t.Log("Stop the service")
 	env.grpcServers.Servers[0].Stop()


### PR DESCRIPTION
#### Type of change

- Test update
 
#### Description

Root cause: requireAllUpdate submits many batches (3 per 10ms tick), filling the outputValidatedTxs channel (capacity 10). When the channel is full, signVerifier goroutines block on Write() instead of being in Recv(). Both goroutines in the errgroup deadlock: receiveStatus blocks on Write (channel full), sendTransactions blocks on Read (no batches), and neither can cancel gCtx. The drain goroutine was started after requireAllUpdate, so the channel was already full by the time it ran. On busy CI machines, the drain goroutine's scheduling delay combined with buffered responses meant signVerifier[0] could remain stuck on Write for the entire 30-second EventuallyIntMetric timeout, never reaching Recv() to detect the broken stream from server.Stop().

Fix: move the drain goroutine before requireAllUpdate so the output channel never fills up. This ensures signVerifiers are always in their idle state (blocked on Recv) when the server stops, allowing immediate stream break detection. Use channel.Ready to guarantee the drain goroutine is running before proceeding.

#### Related issues

  - resolves #492 