### PR TITLE
Add MkDocs documentation site with Material theme 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,18 @@ jobs:
     steps:
       - run: echo "CI gate passed"
 
+  docs:
+    name: Documentation Build
+    needs: [gate]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - run: pip install mkdocs-material
+      - run: mkdocs build
+
   lint:
     name: Lint and Build
     needs: [gate]

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,26 @@
+# Copyright IBM Corp. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+name: Deploy Documentation
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    name: Deploy to GitHub Pages
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - run: pip install mkdocs-material
+      - run: mkdocs gh-deploy --force

--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ test/**/*.log
 
 .DS_Store
 venv
+
+# MkDocs build output
+site/

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,57 @@
+<!--
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+-->
+# Fabric-X Committer
+
+The Fabric-X Committer implements the validation and commit stage of the Hyperledger Fabric-X transaction lifecycle. It receives ordered blocks of transactions, verifies endorsement signatures, performs MVCC (Multi-Version Concurrency Control) validation against the state database, and commits valid transactions — all through a pipelined architecture designed for high throughput.
+
+## Architecture at a Glance
+
+The system is built around six core services connected by gRPC streams and bounded channels:
+
+```
+Ordering Service
+        │
+        ▼
+    Sidecar ──────────► Coordinator
+                         │        │
+                  Verify │        │  Validate & Commit
+                         ▼        ▼
+                     Verifier     VC ──► Database Cluster
+                                             ▲
+                                  Query ─────┘
+                                 Service
+```
+
+- **Sidecar** — Fetches blocks from the Ordering Service, persists them locally, and delivers committed blocks to clients. Exposes a Notification Service for asynchronous transaction status updates.
+- **Coordinator** — Orchestrates the pipeline using a transaction dependency graph to identify and dispatch conflict-free transactions for parallel processing.
+- **Verifier** — Validates transaction signatures against namespace endorsement policies using a parallel worker pool.
+- **Validator-Committer (VC)** — Executes a three-stage pipeline (Prepare, Validate, Commit) performing MVCC checks and committing valid transactions to the database.
+- **Query Service** — Provides read-only access to the committed world state with configurable isolation levels and query batching.
+- **Database Cluster** — Stores world state, transaction statuses, and namespace policies. Supports YugabyteDB (recommended) and PostgreSQL.
+
+## Key Capabilities
+
+- **High Throughput** — Pipelined processing with parallel dispatch of conflict-free transactions. Exceeds 100,000 TPS on commodity hardware with YugabyteDB.
+- **Fault Tolerance** — Idempotent commit operations enable automatic recovery from service failures without data corruption. Each service recovers independently on restart.
+- **Horizontal Scaling** — Verifier, VC, Query Service, and Database nodes scale horizontally. Sidecar and Coordinator scale vertically.
+- **Flexible Endorsement Policies** — Supports both lightweight threshold rules (single public key) and fine-grained MSP rules (AND/OR/k-of-n over organizational identities).
+- **Observability** — Prometheus metrics for every pipeline stage, with queue-depth gauges for bottleneck identification.
+
+## Getting Started
+
+See the [Setup Guide](setup.md) for prerequisites, build instructions, and running tests.
+
+For production deployments, start with the [Deployment Guide](deployment-guide.md) for hardware sizing and topology, then the [Performance Tuning](performance-tuning.md) guide for configuration parameters.
+
+## Documentation Overview
+
+| Section | What You'll Find |
+|---------|-----------------|
+| [Architecture](architecture.md) | System design, component interactions, state management, failure recovery |
+| [Deployment](deployment-guide.md) | Hardware requirements, reference topology, scaling guidance, startup order |
+| [Services](sidecar.md) | Detailed documentation for each service: workflows, APIs, configuration, recovery |
+| [Configuration](tls-configurations.md) | TLS setup, logging, metrics reference, namespace policies |
+| [Development](core-concurrency-pattern.md) | Internal patterns (errgroup, context-aware channels) and load generator tooling |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,67 @@
+# Copyright IBM Corp. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+---
+site_name: Fabric-X Committer
+site_description: High-throughput transaction validation and commit for Hyperledger Fabric-X
+repo_url: https://github.com/hyperledger/fabric-x-committer
+repo_name: hyperledger/fabric-x-committer
+
+theme:
+  name: material
+  palette:
+    - scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.top
+    - search.suggest
+    - search.highlight
+    - content.code.copy
+
+markdown_extensions:
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
+  - tables
+  - admonition
+  - pymdownx.details
+  - toc:
+      permalink: true
+  - attr_list
+  - md_in_html
+
+nav:
+  - Home: index.md
+  - Getting Started: setup.md
+  - Architecture: architecture.md
+  - Deployment:
+      - Deployment Guide: deployment-guide.md
+      - Performance Tuning: performance-tuning.md
+  - Services:
+      - Sidecar: sidecar.md
+      - Coordinator: coordinator.md
+      - Verifier: verification-service.md
+      - Validator-Committer: validator-committer.md
+      - Query Service: query-service.md
+      - Notification Service: notification-service.md
+  - Configuration:
+      - TLS: tls-configurations.md
+      - Logging: logging.md
+      - Metrics Reference: metrics_reference.md
+      - Namespace Policy: namespace-policy.md
+  - Development:
+      - Core Concurrency Pattern: core-concurrency-pattern.md
+      - Load Generator Artifacts: loadgen-artifacts.md


### PR DESCRIPTION
#### Type of change

- Documentation update
 
#### Description

Set up MkDocs with Material theme to publish project documentation
  on GitHub Pages. Adds mkdocs.yml configuration, a custom landing page
  (docs/index.md), a GitHub Actions workflow to deploy on push to main,
  and a CI check to validate the docs build on pull requests.

#### Related issues

  - resolves #499 