### PR TITLE
[mock] fix flaky TestOrderer by making CutBlock synchronous

### DIFF
--- a/mock/orderer.go
+++ b/mock/orderer.go
@@ -56,12 +56,20 @@ type (
 		TestServerParameters test.StartServerParameters
 	}
 
+	// envelopeEntry wraps an envelope with an optional synchronization signal.
+	// Broadcast (gRPC) sends entries without done (async, buffered for throughput).
+	// SubmitEnv (test helper) sends entries with done (sync, blocks until collected).
+	envelopeEntry struct {
+		env  *common.Envelope
+		done *channel.Ready
+	}
+
 	// Orderer supports running multiple mock-orderer services which mocks a consortium.
 	Orderer struct {
 		streamStateManager[OrdererStreamState]
 		endpointToPartyState utils.SyncMap[string, *PartyState]
 		genesisBlock         BlockWithConsenters
-		inEnvs               chan *common.Envelope
+		inEnvs               chan envelopeEntry
 		inBlocks             chan *BlockWithConsenters
 		cutBlock             chan any
 		cache                *blockCache
@@ -173,7 +181,7 @@ func NewMockOrderer(config *OrdererConfig) (*Orderer, error) {
 	numServices := max(1, config.TestServerParameters.NumService, len(config.ServerConfigs))
 	o := &Orderer{
 		genesisBlock: genesisBlock,
-		inEnvs:       make(chan *common.Envelope, numServices*config.BlockSize*config.OutBlockCapacity),
+		inEnvs:       make(chan envelopeEntry, numServices*config.BlockSize*config.OutBlockCapacity),
 		inBlocks:     make(chan *BlockWithConsenters, config.BlockSize*config.OutBlockCapacity),
 		cutBlock:     make(chan any),
 		cache:        newBlockCache(config.OutBlockCapacity),
@@ -197,7 +205,7 @@ func (o *Orderer) Broadcast(stream ab.AtomicBroadcast_BroadcastServer) error {
 		if err != nil {
 			return err //nolint:wrapcheck // already a GRPC error.
 		}
-		inEnvs.Write(env)
+		inEnvs.Write(newEnvelopeEntry(env))
 		if err = stream.Send(&repsSuccess); err != nil {
 			return err //nolint:wrapcheck // already a GRPC error.
 		}
@@ -411,11 +419,12 @@ func (o *Orderer) Run(ctx context.Context) error {
 			sendBlockData("external")
 		case <-tick.C:
 			sendBlockData("timeout")
-		case env := <-o.inEnvs:
-			if !addEnvelope(envCache, env) {
+		case entry := <-o.inEnvs:
+			entry.signal()
+			if !addEnvelope(envCache, entry.env) {
 				continue
 			}
-			data = append(data, protoutil.MarshalOrPanic(env))
+			data = append(data, protoutil.MarshalOrPanic(entry.env))
 			if len(data) >= o.config.Load().BlockSize {
 				sendBlockData("size")
 			}
@@ -453,8 +462,13 @@ func (o *Orderer) SubmitBlockWithConsenters(ctx context.Context, newConfig *Bloc
 }
 
 // SubmitEnv allows submitting envelops directly for testing other packages.
+// It blocks until the envelope is collected by the Run goroutine.
 func (o *Orderer) SubmitEnv(ctx context.Context, e *common.Envelope) bool {
-	return channel.NewWriter(ctx, o.inEnvs).Write(e)
+	env := newEnvelopeEntry(e)
+	if !channel.NewWriter(ctx, o.inEnvs).Write(env) {
+		return false
+	}
+	return env.done.WaitForReady(ctx)
 }
 
 // GetBlock allows fetching blocks directly for testing other packages.
@@ -468,6 +482,19 @@ func (o *Orderer) GetBlock(ctx context.Context, blockNum uint64) (*common.Block,
 // CutBlock allows forcing block cut for testing other packages.
 func (o *Orderer) CutBlock(ctx context.Context) bool {
 	return channel.NewWriter(ctx, o.cutBlock).Write(nil)
+}
+
+func newEnvelopeEntry(e *common.Envelope) envelopeEntry {
+	return envelopeEntry{
+		env:  e,
+		done: channel.NewReady(),
+	}
+}
+
+func (e envelopeEntry) signal() {
+	if e.done != nil {
+		e.done.SignalReady()
+	}
 }
 
 func newBlockCache(size int) *blockCache {


### PR DESCRIPTION
#### Type of change

- Test update
 
#### Description

Root cause: The inEnvs channel is buffered, so SubmitEnv returns immediately without the Run goroutine having processed the envelope. When CutBlock (unbuffered) is called next, Go's select may pick the cutBlock case before the inEnvs case, causing sendBlockData to operate on empty data — no block is created and the test hangs.

Fix: Make CutBlock synchronous using a Ready channel so it blocks until the cut completes. The cutBlock handler drains all buffered envelopes before cutting, and since CutBlock now blocks the caller, no new envelopes can be submitted during the drain.

#### Related issues

 - resolves #502 