### PR TITLE
[util] discover client user dir instead of hardcoding .com suffix

### DIFF
--- a/utils/testcrypto/load_crypto.go
+++ b/utils/testcrypto/load_crypto.go
@@ -9,6 +9,7 @@ package testcrypto
 import (
 	"os"
 	"path"
+	"strings"
 	"time"
 
 	"github.com/cockroachdb/errors"
@@ -47,12 +48,20 @@ func GetSigningIdentities(mspDirs ...*msp.DirLoadParameters) ([]msp.SigningIdent
 }
 
 // GetPeersMspDirs returns the peers' MSP directory path.
+// It discovers the client user directory by scanning the users/ directory
+// for an entry matching "client@*", rather than assuming a specific domain suffix.
 func GetPeersMspDirs(cryptoPath string) []*msp.DirLoadParameters {
 	peerOrgPath := path.Join(cryptoPath, cryptogen.PeerOrganizationsDir)
 	peerMspDirs := GetMspDirs(peerOrgPath)
 	for _, mspItem := range peerMspDirs {
-		clientName := "client@" + mspItem.MspName + ".com"
-		mspItem.MspDir = path.Join(mspItem.MspDir, "users", clientName, "msp")
+		usersDir := path.Join(mspItem.MspDir, "users")
+		entries, _ := os.ReadDir(usersDir)
+		for _, entry := range entries {
+			if entry.IsDir() && strings.HasPrefix(entry.Name(), "client@") {
+				mspItem.MspDir = path.Join(usersDir, entry.Name(), "msp")
+				break
+			}
+		}
 	}
 	return peerMspDirs
 }

--- a/utils/testcrypto/testcrypto_test.go
+++ b/utils/testcrypto/testcrypto_test.go
@@ -452,6 +452,22 @@ func TestMspDirectoryRetrieval(t *testing.T) {
 		}
 	})
 
+	t.Run("peer MSP directories without domain suffix", func(t *testing.T) {
+		t.Parallel()
+		cryptoPath := t.TempDir()
+		peerOrgPath := filepath.Join(cryptoPath, cryptogen.PeerOrganizationsDir)
+
+		// Simulate crypto generated with Domain: "peer-org-0" (no .com).
+		// Org directory uses Name, user directory uses "client@<Domain>".
+		userMspDir := filepath.Join(peerOrgPath, "peer-org-0", "users", "client@peer-org-0", "msp")
+		require.NoError(t, os.MkdirAll(userMspDir, 0o750))
+
+		mspDirs := GetPeersMspDirs(cryptoPath)
+		require.Len(t, mspDirs, 1)
+		require.Equal(t, "peer-org-0", mspDirs[0].MspName)
+		require.Equal(t, userMspDir, mspDirs[0].MspDir)
+	})
+
 	t.Run("edge cases", func(t *testing.T) {
 		t.Parallel()
 


### PR DESCRIPTION
#### Type of change

- Bug fix
 
#### Description

  GetPeersMspDirs hardcoded ".com" when constructing user MSP paths,
  which broke when crypto-config used a domain without that suffix.
  Scan the users/ directory for a "client@" entry instead.

#### Related issues

 - resolves #520 