### PR TITLE
update fabric-x-common dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.4
 	github.com/hyperledger/fabric-lib-go v1.1.3
 	github.com/hyperledger/fabric-protos-go-apiv2 v0.3.7
-	github.com/hyperledger/fabric-x-common v0.1.1-0.20260325083241-a20cecf8e82d
+	github.com/hyperledger/fabric-x-common v0.1.1-0.20260406135811-b18df7089b57
 	github.com/jackc/puddle/v2 v2.2.2
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/onsi/gomega v1.38.2

--- a/go.sum
+++ b/go.sum
@@ -1116,8 +1116,8 @@ github.com/hyperledger/fabric-lib-go v1.1.3 h1:alvgtBlbm373P3BLIxdHKVT4I64mORDwQ
 github.com/hyperledger/fabric-lib-go v1.1.3/go.mod h1:zwnGaLwmQ/usgC6Xbzh8jCnOniViRHSsg7WYErxbr30=
 github.com/hyperledger/fabric-protos-go-apiv2 v0.3.7 h1:sQ5qv8vQQfwewa1JlCiSCC8dLElmaU2/frLolpgibEY=
 github.com/hyperledger/fabric-protos-go-apiv2 v0.3.7/go.mod h1:bJnwzfv03oZQeCc863pdGTDgf5nmCy6Za3RAE7d2XsQ=
-github.com/hyperledger/fabric-x-common v0.1.1-0.20260325083241-a20cecf8e82d h1:o0oCpWS9sG1WdBbck7cmVvxqhgmX1ndxpJQCCdaHPIs=
-github.com/hyperledger/fabric-x-common v0.1.1-0.20260325083241-a20cecf8e82d/go.mod h1:SSvKRokJbSKTZnVt0XzVsyyALldy+5MKly5couC9lC8=
+github.com/hyperledger/fabric-x-common v0.1.1-0.20260406135811-b18df7089b57 h1:pfdYCKHHRuj7Xa0MQae+43OfQgtUkaBfp26UsI2FvH0=
+github.com/hyperledger/fabric-x-common v0.1.1-0.20260406135811-b18df7089b57/go.mod h1:SSvKRokJbSKTZnVt0XzVsyyALldy+5MKly5couC9lC8=
 github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=


### PR DESCRIPTION
#### Type of change

- Improvement (improvement to code, performance, etc)
 
#### Description

This commit updates the fabric-x-common dependency to use the latest `protoutil.ComputeDataHash` so that the committer can be compatible with the orderer. 
