### PR TITLE
[utils] rename TLSMaterials to TLSCredentials, ClientMaterial to DialInfo

### DIFF
--- a/integration/test/loadgen_test.go
+++ b/integration/test/loadgen_test.go
@@ -73,9 +73,9 @@ func TestLoadGenWithTLSModes(t *testing.T) {
 					})
 					c.Start(t, serviceFlags)
 
-					metricsMaterials, err := connection.NewClientTLSMaterials(c.SystemConfig.ClientTLS)
+					metricsCreds, err := connection.NewClientTLSCredentials(c.SystemConfig.ClientTLS)
 					require.NoError(t, err)
-					metricsClientTLSConfig, err := metricsMaterials.CreateClientTLSConfig()
+					metricsClientTLSConfig, err := metricsCreds.CreateClientTLSConfig()
 					require.NoError(t, err)
 
 					metricsURL, err := monitoring.MakeMetricsURL(

--- a/loadgen/adapters/broadcast.go
+++ b/loadgen/adapters/broadcast.go
@@ -50,7 +50,7 @@ type (
 
 // NewBroadcastStream starts a new broadcast stream (non-production).
 func NewBroadcastStream(ctx context.Context, config *ordererdial.Config) (Broadcaster, error) {
-	tls, err := ordererdial.NewTLSMaterials(config.TLS)
+	tls, err := ordererdial.NewTLSCredentials(config.TLS)
 	if err != nil {
 		return nil, err
 	}
@@ -58,7 +58,7 @@ func NewBroadcastStream(ctx context.Context, config *ordererdial.Config) (Broadc
 	if err != nil {
 		return nil, err
 	}
-	m := ordererdial.NewClientMaterial(configMaterial, ordererdial.Parameters{
+	m := ordererdial.NewDialInfo(configMaterial, ordererdial.Parameters{
 		API:   commontypes.Broadcast,
 		TLS:   *tls,
 		Retry: config.Retry,
@@ -72,8 +72,8 @@ func NewBroadcastStream(ctx context.Context, config *ordererdial.Config) (Broadc
 		return newCFTBroadcaster(ctx, m.Joint)
 	}
 
-	streams := make(map[uint32]*cftBroadcaster, len(m.PartyIDToMaterial))
-	for id, mPerID := range m.PartyIDToMaterial {
+	streams := make(map[uint32]*cftBroadcaster, len(m.PartyIDToDialInfo))
+	for id, mPerID := range m.PartyIDToDialInfo {
 		streams[id], err = newCFTBroadcaster(ctx, mPerID)
 		if err != nil {
 			return nil, errors.Join(err, connection.CloseConnections(slices.Collect(maps.Values(streams))...))
@@ -83,9 +83,9 @@ func NewBroadcastStream(ctx context.Context, config *ordererdial.Config) (Broadc
 }
 
 func newCFTBroadcaster(
-	ctx context.Context, m *connection.ClientMaterial,
+	ctx context.Context, d *connection.DialInfo,
 ) (*cftBroadcaster, error) {
-	conn, err := m.NewLoadBalancedConnection()
+	conn, err := d.NewLoadBalancedConnection()
 	if err != nil {
 		return nil, err
 	}

--- a/loadgen/client.go
+++ b/loadgen/client.go
@@ -193,11 +193,11 @@ func (c *Client) runHTTPServer(ctx context.Context) error {
 		return nil
 	}
 
-	tlsMaterials, err := connection.NewServerTLSMaterials(serverConfig.TLS)
+	tlsCreds, err := connection.NewServerTLSCredentials(serverConfig.TLS)
 	if err != nil {
 		return err
 	}
-	tlsCfg, err := tlsMaterials.CreateServerTLSConfig()
+	tlsCfg, err := tlsCreds.CreateServerTLSConfig()
 	if err != nil {
 		return err
 	}

--- a/utils/connection/client.go
+++ b/utils/connection/client.go
@@ -49,10 +49,10 @@ type (
 		Address() string
 	}
 
-	// ClientMaterial contains the parameters to create a connection.
-	ClientMaterial struct {
+	// DialInfo contains the parameters to dial a connection.
+	DialInfo struct {
 		Endpoints []*Endpoint
-		TLS       TLSMaterials
+		TLS       TLSCredentials
 		Retry     *retry.Profile
 	}
 
@@ -71,13 +71,13 @@ var knownConnectionIssues = regexp.MustCompile(
 	`(?i)EOF|connection\s+refused|closed\s+network\s+connection|connection\s+reset`,
 )
 
-// NewClientMaterial creates a connection material from a client config.
-func NewClientMaterial(config *MultiClientConfig) (*ClientMaterial, error) {
-	tls, err := NewClientTLSMaterials(config.TLS)
+// NewDialInfo creates dial info from a client config.
+func NewDialInfo(config *MultiClientConfig) (*DialInfo, error) {
+	tls, err := NewClientTLSCredentials(config.TLS)
 	if err != nil {
 		return nil, err
 	}
-	return &ClientMaterial{
+	return &DialInfo{
 		Endpoints: config.Endpoints,
 		Retry:     config.Retry,
 		TLS:       *tls,
@@ -87,39 +87,39 @@ func NewClientMaterial(config *MultiClientConfig) (*ClientMaterial, error) {
 // NewLoadBalancedConnection creates a connection with load balancing between the endpoints
 // in the given config.
 func NewLoadBalancedConnection(config *MultiClientConfig) (*grpc.ClientConn, error) {
-	m, err := NewClientMaterial(config)
+	d, err := NewDialInfo(config)
 	if err != nil {
 		return nil, err
 	}
-	return m.NewLoadBalancedConnection()
+	return d.NewLoadBalancedConnection()
 }
 
 // NewConnectionPerEndpoint creates a list of connections; one for each endpoint in the given config.
 func NewConnectionPerEndpoint(config *MultiClientConfig) ([]*grpc.ClientConn, error) {
-	m, err := NewClientMaterial(config)
+	d, err := NewDialInfo(config)
 	if err != nil {
 		return nil, err
 	}
-	return m.NewConnectionPerEndpoint()
+	return d.NewConnectionPerEndpoint()
 }
 
 // NewLoadBalancedConnection creates a connection with load balancing between the endpoints.
-func (m *ClientMaterial) NewLoadBalancedConnection() (*grpc.ClientConn, error) {
-	tlsCredentials, err := NewClientCredentialsFromMaterial(&m.TLS)
+func (d *DialInfo) NewLoadBalancedConnection() (*grpc.ClientConn, error) {
+	tlsCredentials, err := NewClientGRPCTransportCredentials(&d.TLS)
 	if err != nil {
 		return nil, err
 	}
 
-	if len(m.Endpoints) == 1 {
+	if len(d.Endpoints) == 1 {
 		return NewConnection(ClientParameters{
-			Address: m.Endpoints[0].Address(),
-			Retry:   m.Retry,
+			Address: d.Endpoints[0].Address(),
+			Retry:   d.Retry,
 			Creds:   tlsCredentials,
 		})
 	}
 
-	resolverEndpoints := make([]resolver.Endpoint, len(m.Endpoints))
-	for i, e := range m.Endpoints {
+	resolverEndpoints := make([]resolver.Endpoint, len(d.Endpoints))
+	for i, e := range d.Endpoints {
 		// we're setting ServerName for each address because each service-instance has its own certificates.
 		resolverEndpoints[i] = resolver.Endpoint{
 			Addresses: []resolver.Address{{Addr: e.Address(), ServerName: e.Host}},
@@ -129,27 +129,27 @@ func (m *ClientMaterial) NewLoadBalancedConnection() (*grpc.ClientConn, error) {
 	r.UpdateState(resolver.State{Endpoints: resolverEndpoints})
 
 	// Create a meaningful target string for debugging by joining all endpoint addresses.
-	targetName := AddressString(m.Endpoints...)
+	targetName := AddressString(d.Endpoints...)
 	return NewConnection(ClientParameters{
 		Address:        fmt.Sprintf("%s:///%s", r.Scheme(), targetName),
 		Creds:          tlsCredentials,
-		Retry:          m.Retry,
+		Retry:          d.Retry,
 		AdditionalOpts: []grpc.DialOption{grpc.WithResolvers(r)},
 	})
 }
 
 // NewConnectionPerEndpoint creates a list of connections; one for each endpoint.
-func (m *ClientMaterial) NewConnectionPerEndpoint() ([]*grpc.ClientConn, error) {
-	tlsCreds, err := NewClientCredentialsFromMaterial(&m.TLS)
+func (d *DialInfo) NewConnectionPerEndpoint() ([]*grpc.ClientConn, error) {
+	tlsCreds, err := NewClientGRPCTransportCredentials(&d.TLS)
 	if err != nil {
 		return nil, err
 	}
-	connections := make([]*grpc.ClientConn, len(m.Endpoints))
-	for i, e := range m.Endpoints {
+	connections := make([]*grpc.ClientConn, len(d.Endpoints))
+	for i, e := range d.Endpoints {
 		connections[i], err = NewConnection(ClientParameters{
 			Address: e.Address(),
 			Creds:   tlsCreds,
-			Retry:   m.Retry,
+			Retry:   d.Retry,
 		})
 		if err != nil {
 			CloseConnectionsLog(connections[:i]...)

--- a/utils/connection/config.go
+++ b/utils/connection/config.go
@@ -103,22 +103,22 @@ const (
 	DefaultTLSMinVersion = tls.VersionTLS12
 )
 
-// ClientCredentials converts TLSConfig into a TLSMaterials struct and generates client creds.
+// ClientCredentials converts TLSConfig into a TLSCredentials struct and generates client creds.
 func (c TLSConfig) ClientCredentials() (credentials.TransportCredentials, error) {
-	tlsMaterials, err := NewClientTLSMaterials(c)
+	tlsCreds, err := NewClientTLSCredentials(c)
 	if err != nil {
 		return nil, err
 	}
-	return NewClientCredentialsFromMaterial(tlsMaterials)
+	return NewClientGRPCTransportCredentials(tlsCreds)
 }
 
-// ServerCredentials converts TLSConfig into a TLSMaterials struct and generates server creds.
+// ServerCredentials converts TLSConfig into a TLSCredentials struct and generates server creds.
 func (c TLSConfig) ServerCredentials() (credentials.TransportCredentials, error) {
-	tlsMaterials, err := NewServerTLSMaterials(c)
+	tlsCreds, err := NewServerTLSCredentials(c)
 	if err != nil {
 		return nil, err
 	}
-	return NewServerCredentialsFromMaterial(tlsMaterials)
+	return NewServerGRPCTransportCredentials(tlsCreds)
 }
 
 // Validate checks that the rate limit configuration is valid.

--- a/utils/connection/tls.go
+++ b/utils/connection/tls.go
@@ -17,23 +17,23 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-// TLSMaterials holds the loaded runtime TLS material (certificate, key, CA certs).
-type TLSMaterials struct {
+// TLSCredentials holds the loaded runtime TLS credentials (certificate, key, CA certs).
+type TLSCredentials struct {
 	Mode    string
 	Cert    []byte
 	Key     []byte
 	CACerts [][]byte
 }
 
-// NewClientCredentialsFromMaterial returns the gRPC transport credentials to be used by a client,
-// based on the provided TLS configuration.
-func NewClientCredentialsFromMaterial(c *TLSMaterials) (credentials.TransportCredentials, error) {
+// NewClientGRPCTransportCredentials returns the gRPC transport credentials to be used by a client,
+// based on the provided TLS credentials.
+func NewClientGRPCTransportCredentials(c *TLSCredentials) (credentials.TransportCredentials, error) {
 	return newCredentials(c.CreateClientTLSConfig())
 }
 
-// NewServerCredentialsFromMaterial returns the gRPC transport credentials to be used by a client,
-// based on the provided TLS configuration.
-func NewServerCredentialsFromMaterial(c *TLSMaterials) (credentials.TransportCredentials, error) {
+// NewServerGRPCTransportCredentials returns the gRPC transport credentials to be used by a server,
+// based on the provided TLS credentials.
+func NewServerGRPCTransportCredentials(c *TLSCredentials) (credentials.TransportCredentials, error) {
 	return newCredentials(c.CreateServerTLSConfig())
 }
 
@@ -47,47 +47,47 @@ func newCredentials(tlsCfg *tls.Config, err error) (credentials.TransportCredent
 	return credentials.NewTLS(tlsCfg), nil
 }
 
-// NewServerTLSMaterials converts a server TLSConfig with path fields into a struct
+// NewServerTLSCredentials converts a server TLSConfig with path fields into a struct
 // that holds the actual bytes of the certificates.
 //
 // Certificate loading behavior by mode:
 //   - none/unmentioned: No certificates loaded
 //   - tls (one-way): Loads server cert + key only (CA certs NOT loaded)
 //   - mtls (mutual): Loads server cert + key + CA certs for client verification
-func NewServerTLSMaterials(c TLSConfig) (*TLSMaterials, error) {
+func NewServerTLSCredentials(c TLSConfig) (*TLSCredentials, error) {
 	mode := c.Mode
 	if mode == UnmentionedTLSMode {
 		mode = DefaultTLSMode
 	}
-	materials := &TLSMaterials{Mode: mode}
+	creds := &TLSCredentials{Mode: mode}
 
 	switch mode {
 	case NoneTLSMode:
-		return materials, nil
+		return creds, nil
 
 	case OneSideTLSMode, MutualTLSMode:
 		var err error
-		materials.Cert, err = os.ReadFile(c.CertPath)
+		creds.Cert, err = os.ReadFile(c.CertPath)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to load certificate from %s", c.CertPath)
 		}
 
-		materials.Key, err = os.ReadFile(c.KeyPath)
+		creds.Key, err = os.ReadFile(c.KeyPath)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to load private key from %s", c.KeyPath)
 		}
 
 		if mode == MutualTLSMode {
-			materials.CACerts = make([][]byte, 0, len(c.CACertPaths))
+			creds.CACerts = make([][]byte, 0, len(c.CACertPaths))
 			for _, path := range c.CACertPaths {
 				caBytes, err := os.ReadFile(path)
 				if err != nil {
 					return nil, errors.Wrapf(err, "failed to load root CA cert from %s", path)
 				}
-				materials.CACerts = append(materials.CACerts, caBytes)
+				creds.CACerts = append(creds.CACerts, caBytes)
 			}
 		}
-		return materials, nil
+		return creds, nil
 
 	default:
 		return nil, errors.Newf("unknown TLS mode: %s (valid: %s, %s, %s)",
@@ -95,47 +95,47 @@ func NewServerTLSMaterials(c TLSConfig) (*TLSMaterials, error) {
 	}
 }
 
-// NewClientTLSMaterials converts a client TLSConfig with path fields into a struct
+// NewClientTLSCredentials converts a client TLSConfig with path fields into a struct
 // that holds the actual bytes of the certificates.
 //
 // Certificate loading behavior by mode:
 //   - none/unmentioned: No certificates loaded
 //   - tls (one-way): Loads CA certs only for server verification (client cert + key NOT loaded)
 //   - mtls (mutual): Loads CA certs + client cert + key for mutual authentication
-func NewClientTLSMaterials(c TLSConfig) (*TLSMaterials, error) {
+func NewClientTLSCredentials(c TLSConfig) (*TLSCredentials, error) {
 	mode := c.Mode
 	if mode == UnmentionedTLSMode {
 		mode = DefaultTLSMode
 	}
-	materials := &TLSMaterials{Mode: mode}
+	creds := &TLSCredentials{Mode: mode}
 
 	switch mode {
 	case NoneTLSMode:
-		return materials, nil
+		return creds, nil
 
 	case OneSideTLSMode, MutualTLSMode:
-		materials.CACerts = make([][]byte, 0, len(c.CACertPaths))
+		creds.CACerts = make([][]byte, 0, len(c.CACertPaths))
 		for _, path := range c.CACertPaths {
 			caBytes, err := os.ReadFile(path)
 			if err != nil {
 				return nil, errors.Wrapf(err, "failed to load root CA cert from %s", path)
 			}
-			materials.CACerts = append(materials.CACerts, caBytes)
+			creds.CACerts = append(creds.CACerts, caBytes)
 		}
 
 		if mode == MutualTLSMode {
 			var err error
-			materials.Cert, err = os.ReadFile(c.CertPath)
+			creds.Cert, err = os.ReadFile(c.CertPath)
 			if err != nil {
 				return nil, errors.Wrapf(err, "failed to load client certificate from %s", c.CertPath)
 			}
 
-			materials.Key, err = os.ReadFile(c.KeyPath)
+			creds.Key, err = os.ReadFile(c.KeyPath)
 			if err != nil {
 				return nil, errors.Wrapf(err, "failed to load client private key from %s", c.KeyPath)
 			}
 		}
-		return materials, nil
+		return creds, nil
 
 	default:
 		return nil, errors.Newf("unknown TLS mode: %s (valid: %s, %s, %s)",
@@ -144,7 +144,7 @@ func NewClientTLSMaterials(c TLSConfig) (*TLSMaterials, error) {
 }
 
 // CreateServerTLSConfig returns a TLS config to be used by a server.
-func (c *TLSMaterials) CreateServerTLSConfig() (*tls.Config, error) {
+func (c *TLSCredentials) CreateServerTLSConfig() (*tls.Config, error) {
 	switch c.Mode {
 	case NoneTLSMode, UnmentionedTLSMode:
 		return nil, nil
@@ -178,7 +178,7 @@ func (c *TLSMaterials) CreateServerTLSConfig() (*tls.Config, error) {
 }
 
 // CreateClientTLSConfig returns a TLS config to be used by a server.
-func (c *TLSMaterials) CreateClientTLSConfig() (*tls.Config, error) {
+func (c *TLSCredentials) CreateClientTLSConfig() (*tls.Config, error) {
 	switch c.Mode {
 	case NoneTLSMode, UnmentionedTLSMode:
 		return nil, nil

--- a/utils/connection/tls_test.go
+++ b/utils/connection/tls_test.go
@@ -27,13 +27,13 @@ type (
 	}
 )
 
-// TestNewServerAndClientTLSMaterials verifies that TLSConfig can be loaded into TLSMaterials and converted
+// TestNewServerAndClientTLSCredentials verifies that TLSConfig can be loaded into TLSCredentials and converted
 // to tls.Config with the correct certificates for each mode.
-func TestNewServerAndClientTLSMaterials(t *testing.T) {
+func TestNewServerAndClientTLSCredentials(t *testing.T) {
 	t.Parallel()
 	p := setupTestFiles(t)
 
-	t.Run("server materials", func(t *testing.T) {
+	t.Run("server credentials", func(t *testing.T) {
 		t.Parallel()
 		for _, tc := range []struct {
 			name       string
@@ -68,9 +68,9 @@ func TestNewServerAndClientTLSMaterials(t *testing.T) {
 				t.Parallel()
 				cfg := tc.setupCfg(tc.mode)
 
-				m, err := NewServerTLSMaterials(cfg)
-				require.NoError(t, err, "error while creating TLS materials")
-				requireMaterials(t, m, tc.expectKeys)
+				m, err := NewServerTLSCredentials(cfg)
+				require.NoError(t, err, "error while creating TLS credentials")
+				requireCredentials(t, m, tc.expectKeys)
 
 				_, err = m.CreateServerTLSConfig()
 				require.NoError(t, err)
@@ -78,7 +78,7 @@ func TestNewServerAndClientTLSMaterials(t *testing.T) {
 		}
 	})
 
-	t.Run("client materials", func(t *testing.T) {
+	t.Run("client credentials", func(t *testing.T) {
 		t.Parallel()
 		for _, tc := range []struct {
 			name       string
@@ -113,9 +113,9 @@ func TestNewServerAndClientTLSMaterials(t *testing.T) {
 				t.Parallel()
 				cfg := tc.setupCfg(tc.mode)
 
-				m, err := NewClientTLSMaterials(cfg)
-				require.NoError(t, err, "error while creating TLS materials")
-				requireMaterials(t, m, tc.expectKeys)
+				m, err := NewClientTLSCredentials(cfg)
+				require.NoError(t, err, "error while creating TLS credentials")
+				requireCredentials(t, m, tc.expectKeys)
 
 				_, err = m.CreateClientTLSConfig()
 				require.NoError(t, err)
@@ -146,7 +146,7 @@ func setupTestFiles(t *testing.T) testPaths {
 	return paths
 }
 
-func requireMaterials(t *testing.T, m *TLSMaterials, e expect) {
+func requireCredentials(t *testing.T, m *TLSCredentials, e expect) {
 	t.Helper()
 	require.Equal(t, e.cert, m.Cert != nil, "cert presence mismatch")
 	require.Equal(t, e.key, m.Key != nil, "key presence mismatch")

--- a/utils/deliverorderer/config.go
+++ b/utils/deliverorderer/config.go
@@ -78,7 +78,7 @@ type (
 	// and the system will unnecessarily switch between orderers.
 	Parameters struct {
 		FaultToleranceLevel string
-		TLS                 connection.TLSMaterials
+		TLS                 connection.TLSCredentials
 		TLSCertHash         []byte
 		Retry               *retry.Profile
 		Signer              identity.SignerSerializer
@@ -107,7 +107,7 @@ const DefaultSuspicionGracePeriodPerBlock = time.Second
 
 // LoadParametersFromConfig returns orderer delivery parameters and channel-ID from a given config.
 func LoadParametersFromConfig(c *ordererdial.Config) (p Parameters, err error) {
-	tls, err := ordererdial.NewTLSMaterials(c.TLS)
+	tls, err := ordererdial.NewTLSCredentials(c.TLS)
 	if err != nil {
 		return p, err
 	}

--- a/utils/deliverorderer/orderer.go
+++ b/utils/deliverorderer/orderer.go
@@ -66,7 +66,7 @@ type (
 	// when accessing shared state between startSingleDeliveryStream() and processBlocks().
 	streamExecutionParams struct {
 		deliver.Parameters
-		connMaterial *connection.ClientMaterial
+		dialInfo *connection.DialInfo
 	}
 )
 
@@ -310,7 +310,7 @@ func (d *ftDelivery) checkBlockWithholding() error {
 // CRITICAL: This also updates d.curDataBlockSourceID before goroutines spawn to prevent
 // race conditions with getProcessingState() which reads this field.
 func (d *ftDelivery) initStreams() (dataWorker streamExecutionParams, headerWorkers []streamExecutionParams) {
-	m := ordererdial.NewClientMaterial(d.latestConfig.ConfigBlockMaterial, ordererdial.Parameters{
+	m := ordererdial.NewDialInfo(d.latestConfig.ConfigBlockMaterial, ordererdial.Parameters{
 		API:   types.Deliver,
 		TLS:   d.params.TLS,
 		Retry: d.params.Retry,
@@ -335,28 +335,28 @@ func (d *ftDelivery) initStreams() (dataWorker streamExecutionParams, headerWork
 	headerSourceParameters.NextBlockNum = d.headerOnlyStream.nextBlockNum
 
 	// If not monitoring block withholding or only one party, create single data worker.
-	if !d.monitorBlockWithholding || len(m.PartyIDToMaterial) < 2 {
+	if !d.monitorBlockWithholding || len(m.PartyIDToDialInfo) < 2 {
 		return streamExecutionParams{
-			Parameters:   dataSourceParameters,
-			connMaterial: m.Joint,
+			Parameters: dataSourceParameters,
+			dialInfo:   m.Joint,
 		}, nil
 	}
 
 	// Create worker params for data stream + all header-only streams.
 	dataWorker = streamExecutionParams{
-		Parameters:   dataSourceParameters,
-		connMaterial: m.PartyIDToMaterial[d.curDataBlockSourceID],
+		Parameters: dataSourceParameters,
+		dialInfo:   m.PartyIDToDialInfo[d.curDataBlockSourceID],
 	}
-	headerWorkers = make([]streamExecutionParams, 0, len(m.PartyIDToMaterial)-1)
-	for id, connMaterial := range m.PartyIDToMaterial {
+	headerWorkers = make([]streamExecutionParams, 0, len(m.PartyIDToDialInfo)-1)
+	for id, dialInfo := range m.PartyIDToDialInfo {
 		if id == d.curDataBlockSourceID {
 			continue
 		}
 		p := headerSourceParameters
 		p.SourceID = id
 		headerWorkers = append(headerWorkers, streamExecutionParams{
-			Parameters:   p,
-			connMaterial: connMaterial,
+			Parameters: p,
+			dialInfo:   dialInfo,
 		})
 	}
 	return dataWorker, headerWorkers
@@ -364,12 +364,12 @@ func (d *ftDelivery) initStreams() (dataWorker streamExecutionParams, headerWork
 
 // pickDataBlockStreamID returns one of the parties.
 // It prefers the party that delivered the latest block.
-func (d *ftDelivery) pickDataBlockStreamID(m *ordererdial.ClientMaterial) uint32 {
-	if !d.monitorBlockWithholding || len(m.PartyIDToMaterial) < 2 {
+func (d *ftDelivery) pickDataBlockStreamID(m *ordererdial.DialInfo) uint32 {
+	if !d.monitorBlockWithholding || len(m.PartyIDToDialInfo) < 2 {
 		return 0
 	}
 
-	parties := slices.Collect(maps.Keys(m.PartyIDToMaterial))
+	parties := slices.Collect(maps.Keys(m.PartyIDToDialInfo))
 
 	// We start the delivery with the most advanced source as the data block source.
 	// If the headers only stream is ahead, and it uses the latest config block (as expected),
@@ -413,7 +413,7 @@ func startSingleDeliveryStream(ctx context.Context, params streamExecutionParams
 	}
 	workerErr := errors.NewWithDepthf(0, "[%s] delivery worker [ID:%d] ended", workerType, params.SourceID)
 
-	conn, connErr := params.connMaterial.NewLoadBalancedConnection()
+	conn, connErr := params.dialInfo.NewLoadBalancedConnection()
 	if connErr != nil {
 		logger.Errorf("%s with error: %v", workerErr, connErr)
 		return errors.Join(workerErr, connErr)

--- a/utils/deliverorderer/orderer_no_ft.go
+++ b/utils/deliverorderer/orderer_no_ft.go
@@ -42,7 +42,7 @@ func ToQueueWithNoFT(ctx context.Context, noFtParams NoFTParameters) error {
 		return err
 	}
 
-	m := ordererdial.NewClientMaterial(configMaterial, ordererdial.Parameters{
+	m := ordererdial.NewDialInfo(configMaterial, ordererdial.Parameters{
 		API:   types.Deliver,
 		TLS:   params.TLS,
 		Retry: params.Retry,

--- a/utils/deliverorderer/orderer_test.go
+++ b/utils/deliverorderer/orderer_test.go
@@ -160,7 +160,7 @@ func TestNewOrdererDeliverEdgeCases(t *testing.T) {
 	require.NoError(t, confErr)
 
 	serverTLSConfig, _ := test.CreateServerAndClientTLSConfig(t, connection.MutualTLSMode)
-	tls, tlsErr := connection.NewClientTLSMaterials(serverTLSConfig)
+	tls, tlsErr := connection.NewClientTLSCredentials(serverTLSConfig)
 	require.NoError(t, tlsErr)
 
 	invalidBlock := &common.Block{

--- a/utils/monitoring/provider.go
+++ b/utils/monitoring/provider.go
@@ -53,11 +53,11 @@ func (p *Provider) StartPrometheusServer(
 ) error {
 	logger.Debugf("Creating prometheus server with secure mode: %v", serverConfig.TLS.Mode)
 	// Generate TLS configuration from the server config.
-	serverMaterials, err := connection.NewServerTLSMaterials(serverConfig.TLS)
+	serverCreds, err := connection.NewServerTLSCredentials(serverConfig.TLS)
 	if err != nil {
-		return errors.Wrap(err, "failed to create TLS materials for prometheus server")
+		return errors.Wrap(err, "failed to create TLS credentials for prometheus server")
 	}
-	serverTLSConfig, err := serverMaterials.CreateServerTLSConfig()
+	serverTLSConfig, err := serverCreds.CreateServerTLSConfig()
 	if err != nil {
 		return err
 	}

--- a/utils/monitoring/provider_test.go
+++ b/utils/monitoring/provider_test.go
@@ -239,9 +239,9 @@ func newMetricsProviderTestEnv(t *testing.T, serverTLS, clientTLS connection.TLS
 		assert.NoError(t, p.StartPrometheusServer(ctx, c))
 	}()
 
-	clientMaterials, err := connection.NewClientTLSMaterials(clientTLS)
+	clientCreds, err := connection.NewClientTLSCredentials(clientTLS)
 	require.NoError(t, err)
-	clientTLSConfig, err := clientMaterials.CreateClientTLSConfig()
+	clientTLSConfig, err := clientCreds.CreateClientTLSConfig()
 	require.NoError(t, err)
 
 	client := &http.Client{

--- a/utils/ordererdial/config.go
+++ b/utils/ordererdial/config.go
@@ -83,9 +83,9 @@ func GetFaultToleranceLevel(ftLevel string) (string, error) {
 	}
 }
 
-// NewTLSMaterials is a wrapper for [connection.NewTLSMaterials] with the orderer's config.
-func NewTLSMaterials(c TLSConfig) (*connection.TLSMaterials, error) {
-	return connection.NewClientTLSMaterials(connection.TLSConfig{
+// NewTLSCredentials is a wrapper for [connection.NewClientTLSCredentials] with the orderer's config.
+func NewTLSCredentials(c TLSConfig) (*connection.TLSCredentials, error) {
+	return connection.NewClientTLSCredentials(connection.TLSConfig{
 		Mode:        c.Mode,
 		KeyPath:     c.KeyPath,
 		CertPath:    c.CertPath,

--- a/utils/ordererdial/dialinfo.go
+++ b/utils/ordererdial/dialinfo.go
@@ -16,31 +16,31 @@ import (
 )
 
 type (
-	// ClientMaterial contains the connection material for an orderer.
-	ClientMaterial struct {
-		Joint             *connection.ClientMaterial
-		PartyIDToMaterial map[uint32]*connection.ClientMaterial
+	// DialInfo contains the connection dial info for an orderer.
+	DialInfo struct {
+		Joint             *connection.DialInfo
+		PartyIDToDialInfo map[uint32]*connection.DialInfo
 	}
 
-	// Parameters are the parameters to create connection material.
+	// Parameters are the parameters to create connection dial info.
 	// The API can be "deliver" or "broadcast".
 	// In the committer, we only use "deliver" for production code (sidecar).
 	// "broadcast" is used by the load generator to apply load on the orderer and for testing.
 	Parameters struct {
-		TLS   connection.TLSMaterials
+		TLS   connection.TLSCredentials
 		Retry *retry.Profile
 		API   string
 	}
 )
 
-// NewClientMaterial returns the client connection material given the config block material and the given parameters.
-func NewClientMaterial(m *channelconfig.ConfigBlockMaterial, p Parameters) *ClientMaterial {
-	res := &ClientMaterial{
-		Joint: &connection.ClientMaterial{
+// NewDialInfo returns the client connection dial info given the config block material and the given parameters.
+func NewDialInfo(m *channelconfig.ConfigBlockMaterial, p Parameters) *DialInfo {
+	res := &DialInfo{
+		Joint: &connection.DialInfo{
 			TLS:   p.TLS,
 			Retry: p.Retry,
 		},
-		PartyIDToMaterial: make(map[uint32]*connection.ClientMaterial),
+		PartyIDToDialInfo: make(map[uint32]*connection.DialInfo),
 	}
 	for _, org := range m.OrdererOrganizations {
 		var caCerts [][]byte
@@ -53,14 +53,14 @@ func NewClientMaterial(m *channelconfig.ConfigBlockMaterial, p Parameters) *Clie
 			if !ep.SupportsAPI(p.API) {
 				continue
 			}
-			perID, ok := res.PartyIDToMaterial[ep.ID]
+			perID, ok := res.PartyIDToDialInfo[ep.ID]
 			if !ok {
-				perID = &connection.ClientMaterial{
+				perID = &connection.DialInfo{
 					TLS:   p.TLS,
 					Retry: p.Retry,
 				}
 				perID.TLS.CACerts = append(perID.TLS.CACerts, caCerts...)
-				res.PartyIDToMaterial[ep.ID] = perID
+				res.PartyIDToDialInfo[ep.ID] = perID
 			}
 			connEp := &connection.Endpoint{Host: ep.Host, Port: ep.Port}
 
@@ -76,8 +76,8 @@ func NewClientMaterial(m *channelconfig.ConfigBlockMaterial, p Parameters) *Clie
 
 	// We shuffle the endpoints for load balancing.
 	shuffle(res.Joint.Endpoints)
-	for _, mat := range res.PartyIDToMaterial {
-		shuffle(mat.Endpoints)
+	for _, di := range res.PartyIDToDialInfo {
+		shuffle(di.Endpoints)
 	}
 	return res
 }

--- a/utils/ordererdial/dialinfo_test.go
+++ b/utils/ordererdial/dialinfo_test.go
@@ -101,7 +101,7 @@ func TestOrdererConnectionMaterial(t *testing.T) {
 			name:      "TLS mode server includes CA certs",
 			endpoints: nil,
 			params: ordererdial.Parameters{
-				TLS: connection.TLSMaterials{Mode: connection.OneSideTLSMode},
+				TLS: connection.TLSCredentials{Mode: connection.OneSideTLSMode},
 				API: commontypes.Deliver,
 			},
 			expectedJointEndpointCount: 1,
@@ -113,7 +113,7 @@ func TestOrdererConnectionMaterial(t *testing.T) {
 			name:      "mTLS mode server includes CA certs",
 			endpoints: nil,
 			params: ordererdial.Parameters{
-				TLS: connection.TLSMaterials{Mode: connection.MutualTLSMode},
+				TLS: connection.TLSCredentials{Mode: connection.MutualTLSMode},
 				API: commontypes.Deliver,
 			},
 			expectedJointEndpointCount: 1,
@@ -125,17 +125,17 @@ func TestOrdererConnectionMaterial(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			material := createConfigBlockMaterial(t, 1, tc.endpoints)
-			connMaterial := ordererdial.NewClientMaterial(material, tc.params)
-			require.NotNil(t, connMaterial)
-			require.Len(t, connMaterial.Joint.Endpoints, tc.expectedJointEndpointCount)
-			require.ElementsMatch(t, tc.expectedIDs, slices.Collect(maps.Keys(connMaterial.PartyIDToMaterial)))
-			for _, m := range connMaterial.PartyIDToMaterial {
-				require.Len(t, m.Endpoints, tc.expectedEndpointCountPerID)
+			dialInfo := ordererdial.NewDialInfo(material, tc.params)
+			require.NotNil(t, dialInfo)
+			require.Len(t, dialInfo.Joint.Endpoints, tc.expectedJointEndpointCount)
+			require.ElementsMatch(t, tc.expectedIDs, slices.Collect(maps.Keys(dialInfo.PartyIDToDialInfo)))
+			for _, di := range dialInfo.PartyIDToDialInfo {
+				require.Len(t, di.Endpoints, tc.expectedEndpointCountPerID)
 			}
 			if tc.expectCACerts {
-				require.NotEmpty(t, connMaterial.Joint.TLS.CACerts)
+				require.NotEmpty(t, dialInfo.Joint.TLS.CACerts)
 			} else {
-				require.Empty(t, connMaterial.Joint.TLS.CACerts)
+				require.Empty(t, dialInfo.Joint.TLS.CACerts)
 			}
 		})
 	}
@@ -157,7 +157,7 @@ func TestOrdererConnectionMaterialShuffling(t *testing.T) {
 	})
 
 	params := ordererdial.Parameters{
-		TLS: connection.TLSMaterials{Mode: connection.NoneTLSMode},
+		TLS: connection.TLSCredentials{Mode: connection.NoneTLSMode},
 		API: commontypes.Deliver,
 	}
 
@@ -166,15 +166,15 @@ func TestOrdererConnectionMaterialShuffling(t *testing.T) {
 	for i := range uint32(3) {
 		perIDOrders[i] = make(map[string]any)
 	}
-	firstCall := ordererdial.NewClientMaterial(material, params)
+	firstCall := ordererdial.NewDialInfo(material, params)
 	for range 10 {
-		connMaterial := ordererdial.NewClientMaterial(material, params)
-		require.ElementsMatch(t, firstCall.Joint.Endpoints, connMaterial.Joint.Endpoints)
+		dialInfo := ordererdial.NewDialInfo(material, params)
+		require.ElementsMatch(t, firstCall.Joint.Endpoints, dialInfo.Joint.Endpoints)
 
-		jointOrders[connection.AddressString(connMaterial.Joint.Endpoints...)] = nil
-		for id, m := range connMaterial.PartyIDToMaterial {
-			require.ElementsMatch(t, firstCall.PartyIDToMaterial[id].Endpoints, m.Endpoints)
-			perIDOrders[id][connection.AddressString(m.Endpoints...)] = nil
+		jointOrders[connection.AddressString(dialInfo.Joint.Endpoints...)] = nil
+		for id, di := range dialInfo.PartyIDToDialInfo {
+			require.ElementsMatch(t, firstCall.PartyIDToDialInfo[id].Endpoints, di.Endpoints)
+			perIDOrders[id][connection.AddressString(di.Endpoints...)] = nil
 		}
 	}
 
@@ -192,28 +192,28 @@ func TestParameterPropagation(t *testing.T) {
 		{ID: 0, Host: "orderer2.example.com", Port: 7051},
 	})
 	retryProfile := &retry.Profile{MaxElapsedTime: 30}
-	tlsMaterials := connection.TLSMaterials{
+	tlsCreds := connection.TLSCredentials{
 		Mode:    connection.OneSideTLSMode,
 		Cert:    []byte("fake-cert"),
 		Key:     []byte("fake-key"),
 		CACerts: [][]byte{[]byte("fake-ca-cert")},
 	}
 	params := ordererdial.Parameters{
-		TLS:   tlsMaterials,
+		TLS:   tlsCreds,
 		Retry: retryProfile,
 		API:   commontypes.Deliver,
 	}
-	connMaterial := ordererdial.NewClientMaterial(material, params)
-	require.Equal(t, retryProfile, connMaterial.Joint.Retry)
-	for _, mat := range connMaterial.PartyIDToMaterial {
-		require.Equal(t, retryProfile, mat.Retry)
+	dialInfo := ordererdial.NewDialInfo(material, params)
+	require.Equal(t, retryProfile, dialInfo.Joint.Retry)
+	for _, di := range dialInfo.PartyIDToDialInfo {
+		require.Equal(t, retryProfile, di.Retry)
 	}
-	require.Equal(t, connection.OneSideTLSMode, connMaterial.Joint.TLS.Mode)
-	for _, mat := range connMaterial.PartyIDToMaterial {
-		require.Equal(t, tlsMaterials.Mode, mat.TLS.Mode)
-		require.Equal(t, tlsMaterials.Cert, mat.TLS.Cert)
-		require.Equal(t, tlsMaterials.Key, mat.TLS.Key)
-		require.Contains(t, mat.TLS.CACerts, tlsMaterials.CACerts[0])
+	require.Equal(t, connection.OneSideTLSMode, dialInfo.Joint.TLS.Mode)
+	for _, di := range dialInfo.PartyIDToDialInfo {
+		require.Equal(t, tlsCreds.Mode, di.TLS.Mode)
+		require.Equal(t, tlsCreds.Cert, di.TLS.Cert)
+		require.Equal(t, tlsCreds.Key, di.TLS.Key)
+		require.Contains(t, di.TLS.CACerts, tlsCreds.CACerts[0])
 	}
 }
 

--- a/utils/test/grpc.go
+++ b/utils/test/grpc.go
@@ -423,9 +423,9 @@ func MustGetTLSConfig(t *testing.T, tlsConfig *connection.TLSConfig) *tls.Config
 	if tlsConfig == nil {
 		return nil
 	}
-	tlsMaterials, err := connection.NewClientTLSMaterials(*tlsConfig)
+	tlsCreds, err := connection.NewClientTLSCredentials(*tlsConfig)
 	require.NoError(t, err)
-	clientTLSConfig, err := tlsMaterials.CreateClientTLSConfig()
+	clientTLSConfig, err := tlsCreds.CreateClientTLSConfig()
 	require.NoError(t, err)
 	return clientTLSConfig
 }


### PR DESCRIPTION
#### Type of change

- Improvement (improvement to code, performance, etc)
 
#### Description

The term "material" is strongly associated with "crypto material" in the
blockchain ecosystem, causing confusion. These structs hold resolved binary
connection data (loaded certs, endpoints, retry), not raw cryptographic
artifacts.

New naming convention:
- "Config" = user-provided structure (YAML, file paths)
- "TLSCredentials" = resolved TLS data (binary cert/key/CA bytes),
  aligned with gRPC's credentials terminology
- "DialInfo" = complete connection bundle (endpoints + credentials + retry),
  named for what consumers do with it: dial connections

#### Additional details (Optional)

Renames:
- TLSMaterials -> TLSCredentials
- ClientMaterial -> DialInfo (connection and ordererdial packages)
- NewClientCredentialsFromMaterial -> NewClientGRPCTransportCredentials
- NewServerCredentialsFromMaterial -> NewServerGRPCTransportCredentials
- NewClientTLSMaterials -> NewClientTLSCredentials
- NewServerTLSMaterials -> NewServerTLSCredentials
- NewClientMaterial -> NewDialInfo
- NewTLSMaterials -> NewTLSCredentials
- PartyIDToMaterial -> PartyIDToDialInfo
- connMaterial -> dialInfo
- material.go -> dialinfo.go (file rename)

#### Related issues

  - resolves #467 