### PR TITLE
[sidecar] add notifier and relay throughput metrics

### DIFF
--- a/docs/metrics_reference.md
+++ b/docs/metrics_reference.md
@@ -10,18 +10,25 @@ SPDX-License-Identifier: Apache-2.0
 
 The following Sidecar metrics are exported for consumption by Prometheus.
 
-| Name                                                       | Type      | Labels | Description                                                                  |
-|------------------------------------------------------------|-----------|--------|------------------------------------------------------------------------------|
-| sidecar_grpc_coordinator_sent_transaction_total            | counter   |        | Total number of transactions sent to the coordinator service.                |
-| sidecar_grpc_coordinator_received_transaction_status_total | counter   | status | Total number of transactions statuses received from the coordinator service. |
-| sidecar_relay_block_mapping_seconds                        | histogram |        | Time spent mapping a received block to an internal block.                    |
-| sidecar_relay_mapped_block_processing_seconds              | histogram |        | Time spent processing an internal block and sending it to the coordinator.   |
-| sidecar_relay_transaction_status_batch_processing_seconds  | histogram |        | Time spent processing a received status batch from the coordinator.          |
-| sidecar_relay_waiting_transactions_queue_size              | gauge     |        | Total number of transactions waiting at the relay for statuses.              |
-| sidecar_relay_input_block_queue_size                       | gauge     |        | Size of the input block queue of the relay service.                          |
-| sidecar_relay_output_committed_block_queue_size            | gauge     |        | Size of the output committed block queue of the relay service.               |
-| sidecar_ledger_append_block_seconds                        | histogram |        | Time spent appending a block to the ledger.                                  |
-| sidecar_ledger_block_height                                | gauge     |        | The current block height of the ledger.                                      |
+| Name                                                       | Type      | Labels | Description                                                                      |
+|------------------------------------------------------------|-----------|--------|----------------------------------------------------------------------------------|
+| sidecar_grpc_coordinator_sent_transaction_total            | counter   |        | Total number of transactions sent to the coordinator service.                    |
+| sidecar_grpc_coordinator_received_transaction_status_total | counter   | status | Total number of transactions statuses received from the coordinator service.     |
+| sidecar_relay_block_mapping_seconds                        | histogram |        | Time spent mapping a received block to an internal block.                        |
+| sidecar_relay_mapped_block_processing_seconds              | histogram |        | Time spent processing an internal block and sending it to the coordinator.       |
+| sidecar_relay_transaction_status_batch_processing_seconds  | histogram |        | Time spent processing a received status batch from the coordinator.              |
+| sidecar_relay_waiting_transactions_queue_size              | gauge     |        | Total number of transactions waiting at the relay for statuses.                  |
+| sidecar_relay_input_block_queue_size                       | gauge     |        | Size of the input block queue of the relay service.                              |
+| sidecar_relay_output_committed_block_queue_size            | gauge     |        | Size of the output committed block queue of the relay service.                   |
+| sidecar_ledger_append_block_seconds                        | histogram |        | Time spent appending a block to the ledger.                                      |
+| sidecar_ledger_block_height                                | gauge     |        | The current block height of the ledger.                                          |
+| sidecar_relay_transaction_in_total                         | counter   |        | Total number of transactions received from the orderer.                          |
+| sidecar_relay_transaction_out_total                        | counter   |        | Total number of transaction statuses processed from the coordinator.             |
+| sidecar_notifier_active_streams                            | gauge     |        | Number of active notification streams.                                           |
+| sidecar_notifier_pending_tx_ids                            | gauge     |        | Number of pending (txID, request) subscriptions waiting for status notification. |
+| sidecar_notifier_unique_pending_tx_ids                     | gauge     |        | Number of unique transaction IDs pending across all requests.                    |
+| sidecar_notifier_tx_ids_status_deliveries_total            | counter   |        | Total number of transaction IDs' status deliveries to clients.                   |
+| sidecar_notifier_tx_ids_timeout_deliveries_total           | counter   |        | Total number of transaction IDs' timeout deliveries to clients.                  |
 
 ## Coordinator Metrics
 

--- a/service/sidecar/metrics.go
+++ b/service/sidecar/metrics.go
@@ -35,6 +35,17 @@ type perfMetrics struct {
 
 	appendBlockToLedgerSeconds prometheus.Histogram
 	blockHeight                prometheus.Gauge
+
+	// throughput metrics
+	transactionInThroughput  prometheus.Counter
+	transactionOutThroughput prometheus.Counter
+
+	// notifier metrics
+	notifierActiveStreams          prometheus.Gauge
+	notifierPendingTxIDs           prometheus.Gauge
+	notifierUniquePendingTxIDs     prometheus.Gauge
+	notifierTxIDsStatusDeliveries  prometheus.Counter
+	notifierTxIDsTimeoutDeliveries prometheus.Counter
 }
 
 func newPerformanceMetrics() *perfMetrics {
@@ -110,6 +121,48 @@ func newPerformanceMetrics() *perfMetrics {
 			Subsystem: "ledger",
 			Name:      "block_height",
 			Help:      "The current block height of the ledger.",
+		}),
+		transactionInThroughput: p.NewCounter(prometheus.CounterOpts{
+			Namespace: "sidecar",
+			Subsystem: "relay",
+			Name:      "transaction_in_total",
+			Help:      "Total number of transactions received from the orderer.",
+		}),
+		transactionOutThroughput: p.NewCounter(prometheus.CounterOpts{
+			Namespace: "sidecar",
+			Subsystem: "relay",
+			Name:      "transaction_out_total",
+			Help:      "Total number of transaction statuses processed from the coordinator.",
+		}),
+		notifierActiveStreams: p.NewGauge(prometheus.GaugeOpts{
+			Namespace: "sidecar",
+			Subsystem: "notifier",
+			Name:      "active_streams",
+			Help:      "Number of active notification streams.",
+		}),
+		notifierPendingTxIDs: p.NewGauge(prometheus.GaugeOpts{
+			Namespace: "sidecar",
+			Subsystem: "notifier",
+			Name:      "pending_tx_ids",
+			Help:      "Number of pending (txID, request) subscriptions waiting for status notification.",
+		}),
+		notifierUniquePendingTxIDs: p.NewGauge(prometheus.GaugeOpts{
+			Namespace: "sidecar",
+			Subsystem: "notifier",
+			Name:      "unique_pending_tx_ids",
+			Help:      "Number of unique transaction IDs pending across all requests.",
+		}),
+		notifierTxIDsStatusDeliveries: p.NewCounter(prometheus.CounterOpts{
+			Namespace: "sidecar",
+			Subsystem: "notifier",
+			Name:      "tx_ids_status_deliveries_total",
+			Help:      "Total number of transaction IDs' status deliveries to clients.",
+		}),
+		notifierTxIDsTimeoutDeliveries: p.NewCounter(prometheus.CounterOpts{
+			Namespace: "sidecar",
+			Subsystem: "notifier",
+			Name:      "tx_ids_timeout_deliveries_total",
+			Help:      "Total number of transaction IDs' timeout deliveries to clients.",
 		}),
 	}
 }

--- a/service/sidecar/notify.go
+++ b/service/sidecar/notify.go
@@ -113,20 +113,20 @@ func (n *notifier) run(ctx context.Context, statusQueue chan []*committerpb.TxSt
 				})
 			}
 		case status := <-statusQueue:
-			removed, uniqueRemoved := notifyMap.removeAndEnqueueStatusEvents(status)
-			n.recordRemovals(removed, uniqueRemoved)
-			promutil.AddToCounter(n.metrics.notifierTxIDsStatusDeliveries, removed)
+			pendingTxIDsRemoved, uniquePendingTxIDsRemoved := notifyMap.removeAndEnqueueStatusEvents(status)
+			n.recordRemovals(pendingTxIDsRemoved, uniquePendingTxIDsRemoved)
+			promutil.AddToCounter(n.metrics.notifierTxIDsStatusDeliveries, pendingTxIDsRemoved)
 		case req := <-timeoutQueue:
-			removed, uniqueRemoved := notifyMap.removeAndEnqueueTimeoutEvents(req)
-			n.recordRemovals(removed, uniqueRemoved)
-			promutil.AddToCounter(n.metrics.notifierTxIDsTimeoutDeliveries, removed)
+			pendingTxIDsRemoved, uniquePendingTxIDsRemoved := notifyMap.removeAndEnqueueTimeoutEvents(req)
+			n.recordRemovals(pendingTxIDsRemoved, uniquePendingTxIDsRemoved)
+			promutil.AddToCounter(n.metrics.notifierTxIDsTimeoutDeliveries, pendingTxIDsRemoved)
 		}
 	}
 }
 
-func (n *notifier) recordRemovals(removed, uniqueRemoved int) {
-	promutil.AddToGauge(n.metrics.notifierPendingTxIDs, -removed)
-	promutil.AddToGauge(n.metrics.notifierUniquePendingTxIDs, -uniqueRemoved)
+func (n *notifier) recordRemovals(pendingTxIDsRemoved, uniquePendingTxIDsRemoved int) {
+	promutil.AddToGauge(n.metrics.notifierPendingTxIDs, -pendingTxIDsRemoved)
+	promutil.AddToGauge(n.metrics.notifierUniquePendingTxIDs, -uniquePendingTxIDsRemoved)
 }
 
 // OpenNotificationStream implements the [protonotify.NotifierServer] API.
@@ -135,7 +135,7 @@ func (n *notifier) OpenNotificationStream(stream committerpb.Notifier_OpenNotifi
 	defer n.metrics.notifierActiveStreams.Dec()
 
 	g, gCtx := errgroup.WithContext(stream.Context())
-	globalRequestQueue := channel.NewWriter(gCtx, n.requestQueue)
+	requestQueue := channel.NewWriter(gCtx, n.requestQueue)
 	streamEventQueue := channel.Make[*committerpb.NotificationResponse](gCtx, n.bufferSize)
 
 	g.Go(func() error {
@@ -145,7 +145,7 @@ func (n *notifier) OpenNotificationStream(stream committerpb.Notifier_OpenNotifi
 				return errors.Wrap(err, "error receiving request")
 			}
 			fixTimeout(req, n.maxTimeout)
-			globalRequestQueue.Write(&notificationRequest{
+			requestQueue.Write(&notificationRequest{
 				request:          req,
 				streamEventQueue: streamEventQueue,
 			})
@@ -214,8 +214,10 @@ func (m *subscriptions) addRequest(req *notificationRequest) (rejected []string,
 }
 
 // removeAndEnqueueStatusEvents removes TXs from the subscriptions and reports the responses to the subscribers.
-// Returns the number of (txID, request) subscriptions enqueued and the number of unique txIDs removed from the map.
-func (m *subscriptions) removeAndEnqueueStatusEvents(status []*committerpb.TxStatus) (removed, uniqueRemoved int) {
+// Returns the number of pending txIDs removed across all requests, and the number of unique txIDs removed from the map.
+func (m *subscriptions) removeAndEnqueueStatusEvents(
+	status []*committerpb.TxStatus,
+) (pendingTxIDsRemoved, uniquePendingTxIDsRemoved int) {
 	respMap := make(map[channel.Writer[*committerpb.NotificationResponse]][]*committerpb.TxStatus)
 	for _, response := range status {
 		reqList, ok := m.txIDToRequests[response.Ref.TxId]
@@ -223,12 +225,12 @@ func (m *subscriptions) removeAndEnqueueStatusEvents(status []*committerpb.TxSta
 			continue
 		}
 		delete(m.txIDToRequests, response.Ref.TxId)
-		uniqueRemoved++
+		uniquePendingTxIDsRemoved++
 		for req := range reqList {
 			respMap[req.streamEventQueue] = append(respMap[req.streamEventQueue], response)
 			req.pending--
 			m.availableSlots++
-			removed++
+			pendingTxIDsRemoved++
 			if req.pending == 0 {
 				req.timer.Stop()
 			}
@@ -239,13 +241,15 @@ func (m *subscriptions) removeAndEnqueueStatusEvents(status []*committerpb.TxSta
 			TxStatusEvents: response,
 		})
 	}
-	return removed, uniqueRemoved
+	return pendingTxIDsRemoved, uniquePendingTxIDsRemoved
 }
 
 // removeAndEnqueueTimeoutEvents removes a request from the subscriptions, and
 // reports the timed out TX IDs for this request.
-// Returns the number of enqueued (txID, request) subscriptions and the number of unique txIDs removed from the map.
-func (m *subscriptions) removeAndEnqueueTimeoutEvents(req *notificationRequest) (removed, uniqueRemoved int) {
+// Returns the number of pending txIDs removed for this request, and the number of unique txIDs removed from the map.
+func (m *subscriptions) removeAndEnqueueTimeoutEvents(
+	req *notificationRequest,
+) (pendingTxIDsRemoved, uniquePendingTxIDsRemoved int) {
 	txIDs := make([]string, 0, len(req.request.TxStatusRequest.TxIds))
 	for _, id := range req.request.TxStatusRequest.TxIds {
 		requests, ok := m.txIDToRequests[id]
@@ -259,11 +263,11 @@ func (m *subscriptions) removeAndEnqueueTimeoutEvents(req *notificationRequest) 
 			continue
 		}
 		txIDs = append(txIDs, id)
-		removed++
+		pendingTxIDsRemoved++
 		m.availableSlots++
 		if len(requests) == 1 {
 			delete(m.txIDToRequests, id)
-			uniqueRemoved++
+			uniquePendingTxIDsRemoved++
 		} else {
 			delete(requests, req)
 		}
@@ -271,5 +275,5 @@ func (m *subscriptions) removeAndEnqueueTimeoutEvents(req *notificationRequest) 
 	req.streamEventQueue.Write(&committerpb.NotificationResponse{
 		TimeoutTxIds: txIDs,
 	})
-	return removed, uniqueRemoved
+	return pendingTxIDsRemoved, uniquePendingTxIDsRemoved
 }

--- a/service/sidecar/notify.go
+++ b/service/sidecar/notify.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/hyperledger/fabric-x-committer/utils/channel"
 	"github.com/hyperledger/fabric-x-committer/utils/grpcerror"
+	"github.com/hyperledger/fabric-x-committer/utils/monitoring/promutil"
 )
 
 type (
@@ -33,6 +34,7 @@ type (
 		maxTimeout         time.Duration
 		maxActiveTxIDs     int
 		maxTxIDsPerRequest int
+		metrics            *perfMetrics
 		// requestQueue receives requests from users.
 		requestQueue chan *notificationRequest
 	}
@@ -55,12 +57,13 @@ type (
 	}
 )
 
-func newNotifier(bufferSize int, conf *NotificationServiceConfig) *notifier {
+func newNotifier(bufferSize int, conf *NotificationServiceConfig, metrics *perfMetrics) *notifier {
 	return &notifier{
 		bufferSize:         bufferSize,
 		maxTimeout:         conf.MaxTimeout,
 		maxActiveTxIDs:     conf.MaxActiveTxIDs,
 		maxTxIDsPerRequest: conf.MaxTxIDsPerRequest,
+		metrics:            metrics,
 		requestQueue:       make(chan *notificationRequest, bufferSize),
 	}
 }
@@ -98,26 +101,41 @@ func (n *notifier) run(ctx context.Context, statusQueue chan []*committerpb.TxSt
 			// Global active limit: accept what fits, reject the rest. Unlike the per-request limit,
 			// the global limit depends on factors outside the client's control (other streams,
 			// pending subscriptions), so partial acceptance is more appropriate.
-			if rejected := notifyMap.addRequest(req); len(rejected) > 0 {
+			rejected, uniqueNew := notifyMap.addRequest(req)
+			if len(rejected) > 0 {
 				reject(req, rejected, "active tx IDs limit reached")
 			}
+			promutil.AddToGauge(n.metrics.notifierPendingTxIDs, req.pending)
+			promutil.AddToGauge(n.metrics.notifierUniquePendingTxIDs, uniqueNew)
 			if req.pending > 0 {
 				req.timer = time.AfterFunc(req.request.Timeout.AsDuration(), func() {
 					timeoutQueueCtx.Write(req)
 				})
 			}
 		case status := <-statusQueue:
-			notifyMap.removeAndEnqueueStatusEvents(status)
+			removed, uniqueRemoved := notifyMap.removeAndEnqueueStatusEvents(status)
+			n.recordRemovals(removed, uniqueRemoved)
+			promutil.AddToCounter(n.metrics.notifierTxIDsStatusDeliveries, removed)
 		case req := <-timeoutQueue:
-			notifyMap.removeAndEnqueueTimeoutEvents(req)
+			removed, uniqueRemoved := notifyMap.removeAndEnqueueTimeoutEvents(req)
+			n.recordRemovals(removed, uniqueRemoved)
+			promutil.AddToCounter(n.metrics.notifierTxIDsTimeoutDeliveries, removed)
 		}
 	}
 }
 
+func (n *notifier) recordRemovals(removed, uniqueRemoved int) {
+	promutil.AddToGauge(n.metrics.notifierPendingTxIDs, -removed)
+	promutil.AddToGauge(n.metrics.notifierUniquePendingTxIDs, -uniqueRemoved)
+}
+
 // OpenNotificationStream implements the [protonotify.NotifierServer] API.
 func (n *notifier) OpenNotificationStream(stream committerpb.Notifier_OpenNotificationStreamServer) error {
+	n.metrics.notifierActiveStreams.Inc()
+	defer n.metrics.notifierActiveStreams.Dec()
+
 	g, gCtx := errgroup.WithContext(stream.Context())
-	requestQueue := channel.NewWriter(gCtx, n.requestQueue)
+	globalRequestQueue := channel.NewWriter(gCtx, n.requestQueue)
 	streamEventQueue := channel.Make[*committerpb.NotificationResponse](gCtx, n.bufferSize)
 
 	g.Go(func() error {
@@ -127,7 +145,7 @@ func (n *notifier) OpenNotificationStream(stream committerpb.Notifier_OpenNotifi
 				return errors.Wrap(err, "error receiving request")
 			}
 			fixTimeout(req, n.maxTimeout)
-			requestQueue.Write(&notificationRequest{
+			globalRequestQueue.Write(&notificationRequest{
 				request:          req,
 				streamEventQueue: streamEventQueue,
 			})
@@ -169,8 +187,9 @@ func fixTimeout(request *committerpb.NotificationRequest, maxTimeout time.Durati
 }
 
 // addRequest adds tx IDs from the request to the subscriptions up to available slots.
-// It returns any tx IDs that were rejected due to the limit being reached.
-func (m *subscriptions) addRequest(req *notificationRequest) []string {
+// It returns any tx IDs that were rejected due to the limit being reached,
+// and the number of new unique txIDs added to the map.
+func (m *subscriptions) addRequest(req *notificationRequest) (rejected []string, uniqueNew int) {
 	txIDs := req.request.TxStatusRequest.GetTxIds()
 	for i, id := range txIDs {
 		requests, ok := m.txIDToRequests[id]
@@ -180,21 +199,23 @@ func (m *subscriptions) addRequest(req *notificationRequest) []string {
 			}
 		}
 		if m.availableSlots <= 0 {
-			return txIDs[i:]
+			return txIDs[i:], uniqueNew
 		}
 		if !ok {
 			requests = make(map[*notificationRequest]any)
 			m.txIDToRequests[id] = requests
+			uniqueNew++
 		}
 		requests[req] = nil
 		req.pending++
 		m.availableSlots--
 	}
-	return nil
+	return nil, uniqueNew
 }
 
 // removeAndEnqueueStatusEvents removes TXs from the subscriptions and reports the responses to the subscribers.
-func (m *subscriptions) removeAndEnqueueStatusEvents(status []*committerpb.TxStatus) {
+// Returns the number of (txID, request) subscriptions enqueued and the number of unique txIDs removed from the map.
+func (m *subscriptions) removeAndEnqueueStatusEvents(status []*committerpb.TxStatus) (removed, uniqueRemoved int) {
 	respMap := make(map[channel.Writer[*committerpb.NotificationResponse]][]*committerpb.TxStatus)
 	for _, response := range status {
 		reqList, ok := m.txIDToRequests[response.Ref.TxId]
@@ -202,10 +223,12 @@ func (m *subscriptions) removeAndEnqueueStatusEvents(status []*committerpb.TxSta
 			continue
 		}
 		delete(m.txIDToRequests, response.Ref.TxId)
+		uniqueRemoved++
 		for req := range reqList {
 			respMap[req.streamEventQueue] = append(respMap[req.streamEventQueue], response)
 			req.pending--
 			m.availableSlots++
+			removed++
 			if req.pending == 0 {
 				req.timer.Stop()
 			}
@@ -216,24 +239,31 @@ func (m *subscriptions) removeAndEnqueueStatusEvents(status []*committerpb.TxSta
 			TxStatusEvents: response,
 		})
 	}
+	return removed, uniqueRemoved
 }
 
 // removeAndEnqueueTimeoutEvents removes a request from the subscriptions, and
 // reports the timed out TX IDs for this request.
-func (m *subscriptions) removeAndEnqueueTimeoutEvents(req *notificationRequest) {
+// Returns the number of enqueued (txID, request) subscriptions and the number of unique txIDs removed from the map.
+func (m *subscriptions) removeAndEnqueueTimeoutEvents(req *notificationRequest) (removed, uniqueRemoved int) {
 	txIDs := make([]string, 0, len(req.request.TxStatusRequest.TxIds))
 	for _, id := range req.request.TxStatusRequest.TxIds {
 		requests, ok := m.txIDToRequests[id]
 		if !ok {
 			continue
 		}
-		txIDs = append(txIDs, id)
+		// Check that this request is actually subscribed to this txID before appending.
+		// A txID may exist in the map from other subscribers but not from this request
+		// (e.g., if it was rejected by the global active limit).
 		if _, ok = requests[req]; !ok {
 			continue
 		}
+		txIDs = append(txIDs, id)
+		removed++
 		m.availableSlots++
 		if len(requests) == 1 {
 			delete(m.txIDToRequests, id)
+			uniqueRemoved++
 		} else {
 			delete(requests, req)
 		}
@@ -241,4 +271,5 @@ func (m *subscriptions) removeAndEnqueueTimeoutEvents(req *notificationRequest) 
 	req.streamEventQueue.Write(&committerpb.NotificationResponse{
 		TimeoutTxIds: txIDs,
 	})
+	return removed, uniqueRemoved
 }

--- a/service/sidecar/notify_test.go
+++ b/service/sidecar/notify_test.go
@@ -59,8 +59,8 @@ func BenchmarkNotifier(b *testing.B) {
 		statusTxIDs = statusTxIDs[sz:]
 	}
 
-	env := newNotifierTestEnv(b)
-	q := env.notificationQueues[0]
+	env := newNotifierTestEnv(b, 5)
+	q := env.responseQueues[0]
 
 	// We benchmark a full cycle, adding TX IDs, removing them, and getting the notifications.
 	b.ResetTimer()
@@ -93,18 +93,26 @@ func BenchmarkNotifier(b *testing.B) {
 }
 
 type notifierTestEnv struct {
-	n                  *notifier
-	requestQueue       channel.Writer[*notificationRequest]
-	statusQueue        channel.Writer[[]*committerpb.TxStatus]
-	notificationQueues []channel.ReaderWriter[*committerpb.NotificationResponse]
+	n              *notifier
+	metrics        *perfMetrics
+	requestQueue   channel.Writer[*notificationRequest]
+	statusQueue    channel.Writer[[]*committerpb.TxStatus]
+	responseQueues []channel.ReaderWriter[*committerpb.NotificationResponse]
 }
 
 func TestNotifierDirect(t *testing.T) {
 	t.Parallel()
-	env := newNotifierTestEnv(t)
+	env := newNotifierTestEnv(t, 5)
+	m := env.metrics
+
+	// Initial metrics should be zero
+	test.RequireIntMetricValue(t, 0, m.notifierPendingTxIDs)
+	test.RequireIntMetricValue(t, 0, m.notifierUniquePendingTxIDs)
+	test.RequireIntMetricValue(t, 0, m.notifierTxIDsStatusDeliveries)
+	test.RequireIntMetricValue(t, 0, m.notifierTxIDsTimeoutDeliveries)
 
 	t.Log("Submitting requests")
-	for _, q := range env.notificationQueues {
+	for _, q := range env.responseQueues {
 		env.requestQueue.Write(&notificationRequest{
 			request: &committerpb.NotificationRequest{
 				TxStatusRequest: &committerpb.TxIDsBatch{
@@ -118,10 +126,15 @@ func TestNotifierDirect(t *testing.T) {
 
 	t.Log("No events - not expecting notifications")
 	time.Sleep(3 * time.Second)
-	for _, q := range env.notificationQueues {
+	for _, q := range env.responseQueues {
 		_, ok := q.ReadWithTimeout(10 * time.Millisecond)
 		require.False(t, ok, "should not receive notification")
 	}
+
+	// Verify pending txIDs: 5 queues * 6 unique txIDs = 30 pending subscriptions
+	// Unique pending: only 6 unique txIDs across all queues (first request adds 6, rest add 0)
+	test.RequireIntMetricValue(t, 30, m.notifierPendingTxIDs)
+	test.RequireIntMetricValue(t, 6, m.notifierUniquePendingTxIDs)
 
 	t.Log("Submitting events - expecting notifications")
 	expected := []*committerpb.TxStatus{
@@ -129,7 +142,7 @@ func TestNotifierDirect(t *testing.T) {
 		{Ref: committerpb.NewTxRef("2", 5, 1)},
 	}
 	env.statusQueue.Write(expected)
-	for _, q := range env.notificationQueues {
+	for _, q := range env.responseQueues {
 		res, ok := q.ReadWithTimeout(10 * time.Second)
 		require.True(t, ok)
 		require.NotNil(t, res)
@@ -137,9 +150,15 @@ func TestNotifierDirect(t *testing.T) {
 		test.RequireProtoElementsMatch(t, expected, res.TxStatusEvents)
 	}
 
+	// Verify metrics: 2 statuses delivered to 5 queues = 10 deliveries, pending 30-10=20
+	// Unique pending: 6-2=4 (txIDs "1" and "2" removed from map)
+	test.RequireIntMetricValue(t, 20, m.notifierPendingTxIDs)
+	test.RequireIntMetricValue(t, 4, m.notifierUniquePendingTxIDs)
+	test.RequireIntMetricValue(t, 10, m.notifierTxIDsStatusDeliveries)
+
 	t.Log("Not expecting more notifications")
 	time.Sleep(3 * time.Second)
-	for _, q := range env.notificationQueues {
+	for _, q := range env.responseQueues {
 		_, ok := q.ReadWithTimeout(10 * time.Millisecond)
 		require.False(t, ok, "should not receive notification")
 	}
@@ -150,7 +169,7 @@ func TestNotifierDirect(t *testing.T) {
 		{Ref: committerpb.NewTxRef("200", 5, 1)},
 	})
 	time.Sleep(3 * time.Second)
-	for _, q := range env.notificationQueues {
+	for _, q := range env.responseQueues {
 		_, ok := q.ReadWithTimeout(10 * time.Millisecond)
 		require.False(t, ok, "should not receive notification")
 	}
@@ -161,7 +180,7 @@ func TestNotifierDirect(t *testing.T) {
 		{Ref: committerpb.NewTxRef("4", 3, 10)},
 	}
 	env.statusQueue.Write(expected)
-	for _, q := range env.notificationQueues {
+	for _, q := range env.responseQueues {
 		res, ok := q.Read()
 		require.True(t, ok)
 		require.NotNil(t, res)
@@ -169,9 +188,15 @@ func TestNotifierDirect(t *testing.T) {
 		test.RequireProtoElementsMatch(t, expected, res.TxStatusEvents)
 	}
 
+	// Verify metrics: 2 more statuses to 5 queues = 10 more deliveries, pending 20-10=10
+	// Unique pending: 4-2=2 (txIDs "3" and "4" removed from map, "5" and "6" remain)
+	test.RequireIntMetricValue(t, 10, m.notifierPendingTxIDs)
+	test.RequireIntMetricValue(t, 2, m.notifierUniquePendingTxIDs)
+	test.RequireIntMetricValue(t, 20, m.notifierTxIDsStatusDeliveries)
+
 	t.Log("Submitting requests with short timeout - expecting notifications")
 	timeoutIDs := []string{"5", "6", "7", "8"}
-	for _, q := range env.notificationQueues {
+	for _, q := range env.responseQueues {
 		env.requestQueue.Write(&notificationRequest{
 			request: &committerpb.NotificationRequest{
 				TxStatusRequest: &committerpb.TxIDsBatch{
@@ -182,7 +207,7 @@ func TestNotifierDirect(t *testing.T) {
 			streamEventQueue: q,
 		})
 	}
-	for _, q := range env.notificationQueues {
+	for _, q := range env.responseQueues {
 		res, ok := q.ReadWithTimeout(10 * time.Second)
 		require.True(t, ok)
 		require.NotNil(t, res)
@@ -190,18 +215,31 @@ func TestNotifierDirect(t *testing.T) {
 		require.ElementsMatch(t, timeoutIDs, res.TimeoutTxIds)
 	}
 
+	// Verify timeout metrics: 4 txIDs timed out for 5 queues = 20 timeout deliveries
+	// pending was 10 + 5*4 = 30, now 30-20 = 10 (original "5" and "6" still pending)
+	// Unique pending: was 2+2=4 (first timeout req added "7", "8"), now 4-2=2 ("7", "8" fully removed)
+	test.RequireIntMetricValue(t, 10, m.notifierPendingTxIDs)
+	test.RequireIntMetricValue(t, 2, m.notifierUniquePendingTxIDs)
+	test.RequireIntMetricValue(t, 20, m.notifierTxIDsTimeoutDeliveries)
+
 	t.Log("Submitting event with duplicate request - expecting single notification")
 	expected = []*committerpb.TxStatus{
 		{Ref: committerpb.NewTxRef("5", 3, 0)},
 	}
 	env.statusQueue.Write(expected)
-	for _, q := range env.notificationQueues {
+	for _, q := range env.responseQueues {
 		res, ok := q.Read()
 		require.True(t, ok)
 		require.NotNil(t, res)
 		require.Empty(t, res.TimeoutTxIds)
 		test.RequireProtoElementsMatch(t, expected, res.TxStatusEvents)
 	}
+
+	// Verify metrics: 1 status to 5 queues = 5 deliveries, pending 10-5=5
+	// Unique pending: 2-1=1 (txID "5" removed, "6" remains)
+	test.RequireIntMetricValue(t, 5, m.notifierPendingTxIDs)
+	test.RequireIntMetricValue(t, 1, m.notifierUniquePendingTxIDs)
+	test.RequireIntMetricValue(t, 25, m.notifierTxIDsStatusDeliveries)
 
 	t.Log("Submitting duplicated event - expecting single notification")
 	expected = []*committerpb.TxStatus{
@@ -210,7 +248,7 @@ func TestNotifierDirect(t *testing.T) {
 		{Ref: committerpb.NewTxRef("6", 4, 2)},
 	}
 	env.statusQueue.Write(expected)
-	for _, q := range env.notificationQueues {
+	for _, q := range env.responseQueues {
 		res, ok := q.Read()
 		require.True(t, ok)
 		require.NotNil(t, res)
@@ -218,13 +256,19 @@ func TestNotifierDirect(t *testing.T) {
 		test.RequireProtoElementsMatch(t, expected[:1], res.TxStatusEvents)
 	}
 
+	// Final metrics: 1 more status to 5 queues = 5 more deliveries, pending 5-5=0
+	// Unique pending: 1-1=0 (txID "6" removed, all done)
+	test.RequireIntMetricValue(t, 0, m.notifierPendingTxIDs)
+	test.RequireIntMetricValue(t, 0, m.notifierUniquePendingTxIDs)
+	test.RequireIntMetricValue(t, 30, m.notifierTxIDsStatusDeliveries)
+
 	t.Log("Submitting request exceeding per-request limit - expecting rejection")
 	perRequestLimit := env.n.maxTxIDsPerRequest
 	overLimitTxIDs := make([]string, perRequestLimit+1)
 	for i := range overLimitTxIDs {
 		overLimitTxIDs[i] = fmt.Sprintf("over-%d", i)
 	}
-	for _, q := range env.notificationQueues {
+	for _, q := range env.responseQueues {
 		env.requestQueue.Write(&notificationRequest{
 			request: &committerpb.NotificationRequest{
 				TxStatusRequest: &committerpb.TxIDsBatch{
@@ -235,7 +279,7 @@ func TestNotifierDirect(t *testing.T) {
 			streamEventQueue: q,
 		})
 	}
-	for _, q := range env.notificationQueues {
+	for _, q := range env.responseQueues {
 		res, ok := q.ReadWithTimeout(10 * time.Second)
 		require.True(t, ok)
 		require.NotNil(t, res.RejectedTxIds)
@@ -246,7 +290,8 @@ func TestNotifierDirect(t *testing.T) {
 
 func TestNotifierStream(t *testing.T) {
 	t.Parallel()
-	env := newNotifierTestEnv(t)
+	env := newNotifierTestEnv(t, 5)
+	m := env.metrics
 	config := test.NewLocalHostServer(test.InsecureTLSConfig)
 	test.RunGrpcServerForTest(t.Context(), t, config, func(server *grpc.Server) {
 		committerpb.RegisterNotifierServer(server, env.n)
@@ -257,6 +302,9 @@ func TestNotifierStream(t *testing.T) {
 
 	stream, err := client.OpenNotificationStream(t.Context())
 	require.NoError(t, err)
+
+	// Verify active stream metric
+	test.EventuallyIntMetric(t, 1, m.notifierActiveStreams, 5*time.Second, 100*time.Millisecond)
 
 	t.Log("Submitting requests")
 	err = stream.Send(&committerpb.NotificationRequest{
@@ -345,12 +393,12 @@ func TestNotifierStream(t *testing.T) {
 func TestNotifierGlobalLimit(t *testing.T) {
 	t.Parallel()
 
-	env := newNotifierTestEnvWithConfig(t, &NotificationServiceConfig{
+	env := newNotifierTestEnvWithConfig(t, 1, &NotificationServiceConfig{
 		MaxTimeout:         DefaultNotificationMaxTimeout,
 		MaxActiveTxIDs:     5,
 		MaxTxIDsPerRequest: 10,
 	})
-	q := env.notificationQueues[0]
+	q := env.responseQueues[0]
 
 	submitRequest := func(timeout time.Duration, txIDs ...string) {
 		env.requestQueue.Write(&notificationRequest{
@@ -420,26 +468,28 @@ func TestNotifierGlobalLimit(t *testing.T) {
 	require.Len(t, res.TxStatusEvents, 2)
 }
 
-func newNotifierTestEnv(tb testing.TB) *notifierTestEnv {
+func newNotifierTestEnv(tb testing.TB, numOfClients int) *notifierTestEnv {
 	tb.Helper()
-	return newNotifierTestEnvWithConfig(tb, &NotificationServiceConfig{
+	return newNotifierTestEnvWithConfig(tb, numOfClients, &NotificationServiceConfig{
 		MaxTimeout:         DefaultNotificationMaxTimeout,
 		MaxActiveTxIDs:     DefaultMaxActiveTxIDs,
 		MaxTxIDsPerRequest: DefaultMaxTxIDsPerRequest,
 	})
 }
 
-func newNotifierTestEnvWithConfig(tb testing.TB, conf *NotificationServiceConfig) *notifierTestEnv {
+func newNotifierTestEnvWithConfig(tb testing.TB, numOfClients int, conf *NotificationServiceConfig) *notifierTestEnv {
 	tb.Helper()
+	metrics := newPerformanceMetrics()
 	env := &notifierTestEnv{
-		n:                  newNotifier(DefaultBufferSize, conf),
-		notificationQueues: make([]channel.ReaderWriter[*committerpb.NotificationResponse], 5),
+		n:              newNotifier(DefaultBufferSize, conf, metrics),
+		metrics:        metrics,
+		responseQueues: make([]channel.ReaderWriter[*committerpb.NotificationResponse], numOfClients),
 	}
 	statusQueue := make(chan []*committerpb.TxStatus, DefaultBufferSize)
 	env.requestQueue = channel.NewWriter(tb.Context(), env.n.requestQueue)
 	env.statusQueue = channel.NewWriter(tb.Context(), statusQueue)
-	for i := range env.notificationQueues {
-		env.notificationQueues[i] = channel.Make[*committerpb.NotificationResponse](tb.Context(), 10)
+	for i := range env.responseQueues {
+		env.responseQueues[i] = channel.Make[*committerpb.NotificationResponse](tb.Context(), 10)
 	}
 
 	test.RunServiceForTest(tb.Context(), tb, func(ctx context.Context) error {

--- a/service/sidecar/relay.go
+++ b/service/sidecar/relay.go
@@ -146,6 +146,7 @@ func (r *relay) preProcessBlock(
 		}
 
 		txsCount := len(mappedBlock.block.Txs)
+		promutil.AddToCounter(r.metrics.transactionInThroughput, txsCount)
 		r.waitingTxsSlots.Acquire(ctx, int64(txsCount))
 		promutil.AddToGauge(r.metrics.waitingTransactionsQueueSize, txsCount)
 		queue.Write(mappedBlock)
@@ -271,6 +272,7 @@ func (r *relay) processStatusBatch(
 			outgoingStatusUpdates.Write(statusReport)
 		}
 
+		promutil.AddToCounter(r.metrics.transactionOutThroughput, int(txStatusProcessedCount))
 		r.waitingTxsSlots.Release(txStatusProcessedCount)
 		promutil.AddToGauge(r.metrics.waitingTransactionsQueueSize, -int(txStatusProcessedCount))
 		r.processCommittedBlocksInOrder(ctx, outgoingCommittedBlock)

--- a/service/sidecar/relay_test.go
+++ b/service/sidecar/relay_test.go
@@ -90,6 +90,7 @@ func TestRelayNormalBlock(t *testing.T) {
 	relayEnv.incomingBlockToBeCommitted <- blk0
 
 	t.Log("Block #0: Check submit metrics")
+	test.EventuallyIntMetric(t, txCount, m.transactionInThroughput, 5*time.Second, 10*time.Millisecond)
 	test.EventuallyIntMetric(t, txCount, m.transactionsSentTotal, 5*time.Second, 10*time.Millisecond)
 	test.EventuallyIntMetric(t, txCount, m.waitingTransactionsQueueSize, 5*time.Second, 10*time.Millisecond)
 	require.Equal(t, int64(relayEnv.waitingTxsLimit-txCount), relayEnv.relay.waitingTxsSlots.Load(t))
@@ -123,6 +124,7 @@ func TestRelayNormalBlock(t *testing.T) {
 	test.RequireIntMetricValue(t, txCount, m.transactionsStatusReceivedTotal.WithLabelValues(
 		committerpb.Status_COMMITTED.String(),
 	))
+	test.RequireIntMetricValue(t, txCount, m.transactionOutThroughput)
 	test.EventuallyIntMetric(t, 0, m.waitingTransactionsQueueSize, 5*time.Second, 10*time.Millisecond)
 	require.Greater(t, test.GetMetricValue(t, m.blockMappingInRelaySeconds), float64(0))
 	require.Greater(t, test.GetMetricValue(t, m.mappedBlockProcessingInRelaySeconds), float64(0))

--- a/service/sidecar/sidecar.go
+++ b/service/sidecar/sidecar.go
@@ -77,7 +77,7 @@ func New(c *Config) (*Service, error) {
 	return &Service{
 		deliveryParams: deliveryParams,
 		relay:          relayService,
-		notifier:       newNotifier(c.ChannelBufferSize, &c.Notification),
+		notifier:       newNotifier(c.ChannelBufferSize, &c.Notification, metrics),
 		blockStore:     blockStoreInstance,
 		blockDelivery:  newBlockDelivery(blockStoreInstance),
 		blockQuery:     newBlockQuery(blockStoreInstance),


### PR DESCRIPTION
#### Type of change

- New feature
 
#### Description

  Add Prometheus metrics for the notifier subsystem: active streams,
  pending subscriptions, unique pending tx IDs, status deliveries, and
  timeout deliveries. Move transaction_out_total from notifier to
  relay
  where it counts statuses actually processed from the coordinator,
  making it a true counterpart to transaction_in_total.

  Also adds per-request and global active tx ID limits with partial
  acceptance, and fixes removeAndEnqueueTimeoutEvents to count actual
  subscription removals instead of all matching tx IDs.

#### Related issues

  - resolves #250 