### PR TITLE
dynamic TLS CA rotation for sidecar and query service

### DIFF
--- a/cmd/committer/start_cmd.go
+++ b/cmd/committer/start_cmd.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hyperledger/fabric-x-committer/service/sidecar"
 	"github.com/hyperledger/fabric-x-committer/service/vc"
 	"github.com/hyperledger/fabric-x-committer/service/verifier"
+	"github.com/hyperledger/fabric-x-committer/utils/connection"
 	"github.com/hyperledger/fabric-x-committer/utils/grpcservice"
 )
 
@@ -58,15 +59,19 @@ func startService(ctx context.Context, name, configPath string) error {
 
 	switch c := conf.(type) {
 	case *sidecar.Config:
-		service, err := sidecar.New(c)
+		tlsUpdater, tlsProvider, err := newDynamicTLS(c.Server)
+		if err != nil {
+			return err
+		}
+		service, err := sidecar.New(c, tlsUpdater)
 		if err != nil {
 			return errors.Wrap(err, "failed to create sidecar service")
 		}
 		defer service.Close()
-		return grpcservice.StartAndServe(ctx, service, c.Server)
+		return grpcservice.StartAndServe(ctx, service, tlsProvider, c.Server)
 
 	case *coordinator.Config:
-		return grpcservice.StartAndServe(ctx, coordinator.NewCoordinatorService(c), c.Server)
+		return grpcservice.StartAndServe(ctx, coordinator.NewCoordinatorService(c), nil, c.Server)
 
 	case *vc.Config:
 		service, err := vc.NewValidatorCommitterService(ctx, c)
@@ -74,15 +79,39 @@ func startService(ctx context.Context, name, configPath string) error {
 			return errors.Wrap(err, "failed to create validator committer service")
 		}
 		defer service.Close()
-		return grpcservice.StartAndServe(ctx, service, c.Server)
+		return grpcservice.StartAndServe(ctx, service, nil, c.Server)
 
 	case *verifier.Config:
-		return grpcservice.StartAndServe(ctx, verifier.New(c), c.Server)
+		return grpcservice.StartAndServe(ctx, verifier.New(c), nil, c.Server)
 
 	case *query.Config:
-		return grpcservice.StartAndServe(ctx, query.NewQueryService(c), c.Server)
+		tlsUpdater, tlsProvider, err := newDynamicTLS(c.Server)
+		if err != nil {
+			return err
+		}
+		return grpcservice.StartAndServe(ctx, query.NewQueryService(c, tlsUpdater), tlsProvider, c.Server)
 
 	default:
 		return errors.Newf("unknown config type: %T", conf)
 	}
+}
+
+// newDynamicTLS returns the TLS interfaces separately to avoid the Go
+// nil-interface trap: a nil *DynamicTLS assigned to an interface becomes a
+// non-nil interface wrapping a nil pointer, which passes != nil checks but
+// panics on method calls. Returning interfaces directly ensures that when
+// TLS is disabled, callers receive true nil values.
+func newDynamicTLS(
+	serverConfig *connection.ServerConfig,
+) (connection.TLSCertUpdater, connection.TLSConfigProvider, error) {
+	if serverConfig == nil || serverConfig.TLS.Mode != connection.MutualTLSMode {
+		return nil, nil, nil
+	}
+
+	dynamicTLS, err := connection.NewDynamicTLSFromConfig(serverConfig.TLS)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "failed to create dynamic TLS config")
+	}
+
+	return dynamicTLS, dynamicTLS, nil
 }

--- a/cmd/config/app_config_test.go
+++ b/cmd/config/app_config_test.go
@@ -292,6 +292,7 @@ func TestReadConfigQuery(t *testing.T) {
 			MaxActiveViews:        query.DefaultMaxActiveViews,
 			MaxViewTimeout:        query.DefaultMaxViewTimeout,
 			MaxRequestKeys:        query.DefaultMaxRequestKeys,
+			TLSRefreshInterval:    query.DefaultTLSRefreshInterval,
 		},
 	}, {
 		name:           "sample",
@@ -307,6 +308,7 @@ func TestReadConfigQuery(t *testing.T) {
 			MaxActiveViews:        query.DefaultMaxActiveViews,
 			MaxViewTimeout:        query.DefaultMaxViewTimeout,
 			MaxRequestKeys:        query.DefaultMaxRequestKeys,
+			TLSRefreshInterval:    query.DefaultTLSRefreshInterval,
 		},
 	}}
 

--- a/cmd/config/create_config_file.go
+++ b/cmd/config/create_config_file.go
@@ -42,17 +42,18 @@ type (
 		DB       DatabaseConfig
 
 		// Per service configurations.
-		BlockSize            uint64                      // orderer, loadgen
-		BlockTimeout         time.Duration               // orderer
-		LedgerPath           string                      // sidecar
-		Policy               *workload.PolicyProfile     // loadgen
-		LoadGenBlockLimit    uint64                      // loadgen
-		LoadGenTXLimit       uint64                      // loadgen
-		LoadGenWorkers       uint64                      // loadgen
-		Logging              flogging.Config             // for all
-		RateLimit            *connection.RateLimitConfig // query, sidecar
-		MaxRequestKeys       int                         // query
-		MaxConcurrentStreams int                         // sidecar
+		BlockSize               uint64                      // orderer, loadgen
+		BlockTimeout            time.Duration               // orderer
+		LedgerPath              string                      // sidecar
+		Policy                  *workload.PolicyProfile     // loadgen
+		LoadGenBlockLimit       uint64                      // loadgen
+		LoadGenTXLimit          uint64                      // loadgen
+		LoadGenWorkers          uint64                      // loadgen
+		Logging                 flogging.Config             // for all
+		RateLimit               *connection.RateLimitConfig // query, sidecar
+		MaxRequestKeys          int                         // query
+		QueryTLSRefreshInterval time.Duration               // query
+		MaxConcurrentStreams    int                         // sidecar
 
 		// VC service batching configuration (for testing).
 		VCMinTransactionBatchSize           int           // vc

--- a/cmd/config/templates/query.yaml.tmpl
+++ b/cmd/config/templates/query.yaml.tmpl
@@ -8,3 +8,6 @@
 {{ include "database" . | indent 0 }}
 
 max-request-keys: {{ .MaxRequestKeys }}
+{{- if .QueryTLSRefreshInterval }}
+tls-refresh-interval: {{ .QueryTLSRefreshInterval }}
+{{- end }}

--- a/cmd/config/viper.go
+++ b/cmd/config/viper.go
@@ -82,6 +82,7 @@ func NewViperWithQueryDefaults() *viper.Viper {
 	v.SetDefault("max-active-views", query.DefaultMaxActiveViews)
 	v.SetDefault("max-view-timeout", query.DefaultMaxViewTimeout)
 	v.SetDefault("max-request-keys", query.DefaultMaxRequestKeys)
+	v.SetDefault("tls-refresh-interval", query.DefaultTLSRefreshInterval)
 	return v
 }
 

--- a/cmd/loadgen/main.go
+++ b/cmd/loadgen/main.go
@@ -76,7 +76,7 @@ func loadGenCMD() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			return grpcservice.StartAndServe(cmd.Context(), client, conf.Server)
+			return grpcservice.StartAndServe(cmd.Context(), client, nil, conf.Server)
 		},
 	}
 	cliutil.SetDefaultFlags(cmd, &configPath)

--- a/cmd/mock/main.go
+++ b/cmd/mock/main.go
@@ -84,7 +84,7 @@ func startMockOrderer() *cobra.Command {
 			if conf.Server != nil && !conf.Server.Endpoint.Empty() {
 				serverConfigs = append(serverConfigs, conf.Server)
 			}
-			return grpcservice.StartAndServe(cmd.Context(), service, serverConfigs...)
+			return grpcservice.StartAndServe(cmd.Context(), service, nil, serverConfigs...)
 		},
 	}
 	cliutil.SetDefaultFlags(cmd, &configPath)
@@ -109,7 +109,7 @@ func startMockCoordinator() *cobra.Command {
 			defer cmd.Printf("%v ended\n", mockVerifierName)
 
 			service := mock.NewMockCoordinator()
-			return grpcservice.Serve(cmd.Context(), service, conf.Server)
+			return grpcservice.Serve(cmd.Context(), service, conf.Server, nil)
 		},
 	}
 	cliutil.SetDefaultFlags(cmd, &configPath)
@@ -134,7 +134,7 @@ func startMockVerifier() *cobra.Command {
 			defer cmd.Printf("%v ended\n", mockVerifierName)
 
 			sv := mock.NewMockSigVerifier()
-			return grpcservice.Serve(cmd.Context(), sv, conf.Server)
+			return grpcservice.Serve(cmd.Context(), sv, conf.Server, nil)
 		},
 	}
 	cliutil.SetDefaultFlags(cmd, &configPath)
@@ -159,7 +159,7 @@ func startMockVC() *cobra.Command {
 			defer cmd.Printf("%v ended\n", mockVcName)
 
 			vcs := mock.NewMockVcService()
-			return grpcservice.Serve(cmd.Context(), vcs, conf.Server)
+			return grpcservice.Serve(cmd.Context(), vcs, conf.Server, nil)
 		},
 	}
 	cliutil.SetDefaultFlags(cmd, &configPath)

--- a/integration/runner/runtime.go
+++ b/integration/runner/runtime.go
@@ -102,6 +102,14 @@ type (
 		VerifierBatchTimeCutoff time.Duration
 		// VerifierBatchSizeCutoff configures the batch size cutoff for verifier service.
 		VerifierBatchSizeCutoff int
+
+		// QueryTLSRefreshInterval configures how often the query service polls the DB
+		// for config block updates to refresh dynamic TLS CA certificates.
+		QueryTLSRefreshInterval time.Duration
+
+		// PeerOrganizationCount is the number of peer organizations in the genesis config block.
+		// Defaults to 2 if not set.
+		PeerOrganizationCount uint32
 	}
 )
 
@@ -163,7 +171,7 @@ func NewRuntime(t *testing.T, conf *Config) *CommitterRuntime {
 	ordererEnv := mock.NewOrdererTestEnv(t, &mock.OrdererTestParameters{
 		NumIDs:                3,
 		ServerPerID:           2,
-		PeerOrganizationCount: 2,
+		PeerOrganizationCount: max(2, conf.PeerOrganizationCount),
 		ChanID:                TestChannelName,
 		ClientTLSConfig:       clientTLS,
 		ServerTLSConfig:       ordererServiceTLS,
@@ -205,6 +213,7 @@ func NewRuntime(t *testing.T, conf *Config) *CommitterRuntime {
 			VCTimeoutForMinTransactionBatchSize: conf.VCTimeoutForMinTransactionBatchSize,
 			VerifierBatchTimeCutoff:             conf.VerifierBatchTimeCutoff,
 			VerifierBatchSizeCutoff:             conf.VerifierBatchSizeCutoff,
+			QueryTLSRefreshInterval:             conf.QueryTLSRefreshInterval,
 		},
 		CommittedBlock:   make(chan *common.Block, 100),
 		SeedForCryptoGen: rand.New(rand.NewSource(10)),

--- a/integration/test/dynamic_tls_test.go
+++ b/integration/test/dynamic_tls_test.go
@@ -1,0 +1,180 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/hyperledger/fabric-x-common/api/committerpb"
+	"github.com/onsi/gomega"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+
+	"github.com/hyperledger/fabric-x-committer/integration/runner"
+	"github.com/hyperledger/fabric-x-committer/utils/connection"
+	"github.com/hyperledger/fabric-x-committer/utils/grpcerror"
+	"github.com/hyperledger/fabric-x-committer/utils/test"
+	"github.com/hyperledger/fabric-x-committer/utils/testcrypto"
+)
+
+// TestDynamicTLS verifies that the sidecar and query service dynamically update
+// their trusted TLS CA pool when config blocks add or remove peer organizations,
+// while preserving static (YAML-configured) root CAs.
+func TestDynamicTLS(t *testing.T) {
+	t.Parallel()
+	gomega.RegisterTestingT(t)
+
+	c := runner.NewRuntime(t, &runner.Config{
+		TLSMode:                 connection.MutualTLSMode,
+		PeerOrganizationCount:   3,
+		BlockTimeout:            2 * time.Second,
+		QueryTLSRefreshInterval: 5 * time.Second,
+		CrashTest:               true,
+	})
+	// Start orderer servers in-process so SubmitConfigBlock can write directly
+	// to the orderer's block channel (separate-process orderers don't share memory).
+	c.OrdererEnv.StartServers(t)
+	c.Start(t, runner.CommitterTxPath|runner.QueryService)
+
+	serverCACertPaths := c.SystemConfig.ClientTLS.CACertPaths
+	sidecarEndpoint := c.SystemConfig.Services.Sidecar.GrpcEndpoint
+	queryEndpoint := c.SystemConfig.Services.Query.GrpcEndpoint
+
+	// Per-org mTLS configs. Crypto artifacts don't change across config block updates,
+	// so these remain valid throughout the test.
+	orgTLS := [3]connection.TLSConfig{}
+	for i := range orgTLS {
+		orgTLS[i] = test.OrgClientTLSConfig(c.OrdererEnv.ArtifactsPath, i, serverCACertPaths)
+	}
+
+	// Step 1: Assert all three peer orgs can connect to sidecar and query service.
+	// The sidecar updates dynamic TLS immediately when processing the genesis config block.
+	// The query service polls the DB periodically, so we use Eventually for it.
+	t.Log("Step 1: Initial connection - all three orgs should connect")
+	for orgIdx, tlsCfg := range orgTLS {
+		require.NoError(t, tryRPC(sidecarEndpoint, tlsCfg), "sidecar: peer-org-%d should connect", orgIdx)
+		require.EventuallyWithT(t, func(ct *assert.CollectT) {
+			require.NoError(ct, tryRPC(queryEndpoint, tlsCfg), "query: peer-org-%d should connect", orgIdx)
+		}, 15*time.Second, time.Second)
+	}
+
+	// Step 2: Submit config block removing peer-org-2 (keep only peer-org-0 and peer-org-1).
+	// CreateOrExtendConfigBlockWithCrypto retains existing crypto on disk, so peer-org-2's
+	// certs remain available for reconnection in Step 4.
+	t.Log("Step 2: Dynamic removal - submit config with 2 peer orgs")
+	c.OrdererEnv.SubmitConfigBlock(t, &testcrypto.ConfigBlock{
+		OrdererEndpoints:      c.OrdererEnv.AllEndpoints,
+		PeerOrganizationCount: 2,
+	})
+	c.ValidateExpectedResultsInCommittedBlock(t, &runner.ExpectedStatusInBlock{
+		Statuses: []committerpb.Status{committerpb.Status_COMMITTED},
+	})
+
+	// Step 3: Verify peer-org-2 is rejected and peer-org-0 remains trusted.
+	t.Log("Step 3: Negative assertion - peer-org-2 rejected, peer-org-0 accepted")
+
+	// Sidecar updates immediately from config block processing.
+	require.NoError(t, tryRPC(sidecarEndpoint, orgTLS[0]), "sidecar: peer-org-0 should connect")
+	require.Error(t, tryRPC(sidecarEndpoint, orgTLS[2]), "sidecar: peer-org-2 should be rejected")
+
+	// Query service polls the DB; wait for the TLS refresh (up to 15s).
+	require.NoError(t, tryRPC(queryEndpoint, orgTLS[0]), "query: peer-org-0 should connect")
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		require.Error(ct, tryRPC(queryEndpoint, orgTLS[2]), "query service should reject peer-org-2 after TLS refresh")
+	}, 15*time.Second, time.Second)
+
+	// Step 4: Restore peer-org-2.
+	t.Log("Step 4: Restoration - add peer-org-2 back")
+	c.OrdererEnv.SubmitConfigBlock(t, &testcrypto.ConfigBlock{
+		OrdererEndpoints:      c.OrdererEnv.AllEndpoints,
+		PeerOrganizationCount: 3,
+	})
+	c.ValidateExpectedResultsInCommittedBlock(t, &runner.ExpectedStatusInBlock{
+		Statuses: []committerpb.Status{committerpb.Status_COMMITTED},
+	})
+
+	// Sidecar: peer-org-2 connects immediately.
+	require.NoError(t, tryRPC(sidecarEndpoint, orgTLS[2]), "sidecar: peer-org-2 should connect")
+
+	// Query service: wait for TLS refresh.
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		require.NoError(ct, tryRPC(queryEndpoint, orgTLS[2]), "query: peer-org-2 should connect")
+	}, 15*time.Second, time.Second)
+
+	// Step 5: Static persistence - CredentialsFactory client still works.
+	t.Log("Step 5: Static persistence - static TLS client still trusted")
+	require.NoError(t, tryRPC(sidecarEndpoint, c.SystemConfig.ClientTLS), "sidecar (static) should connect")
+	require.NoError(t, tryRPC(queryEndpoint, c.SystemConfig.ClientTLS), "query (static) should connect")
+
+	// Step 6: Restart sidecar and query service, then verify all clients can reconnect.
+	// This ensures that TLS initialization from persisted config blocks works correctly
+	// and that the static TLS config is still honored after restart.
+	t.Log("Step 6: Service restart - all clients should reconnect with persisted TLS config")
+
+	// Stop and restart sidecar and query service.
+	// The restart reuses the same config, so endpoints don't change.
+	c.Sidecar.Restart(t)
+	c.QueryService.Restart(t)
+
+	// Brief pause to allow old sockets to clear TIME_WAIT; prevents bind failure.
+	time.Sleep(2 * time.Second)
+
+	// Wait for services to be ready. Poll frequently to minimize latency.
+	t.Log("Waiting for services to be ready after restart...")
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		require.NoError(ct, tryRPC(sidecarEndpoint, orgTLS[0]), "sidecar should be ready after restart")
+	}, 60*time.Second, 100*time.Millisecond)
+
+	// All orgs should now connect (sidecar TLS was loaded from persisted config during startup).
+	for orgIdx, tlsCfg := range orgTLS {
+		require.NoError(t, tryRPC(sidecarEndpoint, tlsCfg), "sidecar after restart: peer-org-%d should connect", orgIdx)
+		require.EventuallyWithT(t, func(ct *assert.CollectT) {
+			require.NoError(ct, tryRPC(queryEndpoint, tlsCfg),
+				"query after restart: peer-org-%d should connect", orgIdx)
+		}, 15*time.Second, time.Second)
+	}
+
+	// Static TLS client should still work after restart.
+	require.NoError(t, tryRPC(sidecarEndpoint, c.SystemConfig.ClientTLS),
+		"sidecar (static) after restart should connect")
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		require.NoError(ct, tryRPC(queryEndpoint, c.SystemConfig.ClientTLS),
+			"query (static) after restart should connect")
+	}, 15*time.Second, time.Second)
+}
+
+// tryRPC attempts a lightweight gRPC call and returns an error only if the TLS
+// handshake fails. Application-level gRPC errors (InvalidArgument, Unimplemented,
+// etc.) indicate a successful TLS connection and are treated as success.
+func tryRPC(endpoint connection.WithAddress, tlsConfig connection.TLSConfig) error {
+	creds, err := tlsConfig.ClientCredentials()
+	if err != nil {
+		return err
+	}
+	conn, err := grpc.NewClient(endpoint.Address(), grpc.WithTransportCredentials(creds))
+	if err != nil {
+		return err
+	}
+	defer conn.Close() //nolint:errcheck
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	client := committerpb.NewQueryServiceClient(conn)
+	_, err = client.GetTransactionStatus(ctx, &committerpb.TxStatusQuery{})
+	// FilterUnavailableErrorCode returns nil for transient connectivity errors
+	// (Unavailable, DeadlineExceeded) and passes through application-level errors.
+	// An application-level error means TLS succeeded, so we invert: if the filter
+	// passes through an error, the connection worked.
+	if grpcerror.FilterUnavailableErrorCode(err) != nil {
+		return nil
+	}
+	return err
+}

--- a/loadgen/adapters/sidecar.go
+++ b/loadgen/adapters/sidecar.go
@@ -55,7 +55,7 @@ func (c *SidecarAdapter) RunWorkload(ctx context.Context, txStream *workload.Str
 	g, gCtx := errgroup.WithContext(dCtx)
 
 	g.Go(func() error {
-		return grpcservice.StartAndServe(gCtx, orderer, c.config.OrdererServers...)
+		return grpcservice.StartAndServe(gCtx, orderer, nil, c.config.OrdererServers...)
 	})
 
 	g.Go(func() error {

--- a/loadgen/client_test.go
+++ b/loadgen/client_test.go
@@ -243,7 +243,7 @@ func TestLoadGenForSidecar(t *testing.T) {
 				},
 				Orderer: e.OrdererConnConfig,
 			}
-			service, err := sidecar.New(sidecarConf)
+			service, err := sidecar.New(sidecarConf, nil)
 			require.NoError(t, err)
 			t.Cleanup(service.Close)
 			test.RunServiceAndGrpcForTest(t.Context(), t, service, sidecarConf.Server)
@@ -291,7 +291,7 @@ func TestLoadGenForOrderer(t *testing.T) {
 			}
 
 			// Start sidecar.
-			service, err := sidecar.New(sidecarConf)
+			service, err := sidecar.New(sidecarConf, nil)
 			require.NoError(t, err)
 			t.Cleanup(service.Close)
 			test.RunServiceAndGrpcForTest(t.Context(), t, service, sidecarConf.Server)

--- a/service/query/config.go
+++ b/service/query/config.go
@@ -48,6 +48,9 @@ type Config struct {
 	// GetTransactionStatus (number of transaction IDs).
 	// Set to 0 to disable the limit.
 	MaxRequestKeys int `mapstructure:"max-request-keys" validate:"gte=0"`
+	// TLSRefreshInterval is the interval at which the query service polls the database
+	// for config block updates to refresh TLS CA certificates. Defaults to 1 minute.
+	TLSRefreshInterval time.Duration `mapstructure:"tls-refresh-interval" validate:"gt=0"`
 }
 
 // Default configuration values for the query service.
@@ -63,4 +66,5 @@ const (
 	DefaultMaxActiveViews        = 4096
 	DefaultMaxViewTimeout        = 10 * time.Second
 	DefaultMaxRequestKeys        = 10000
+	DefaultTLSRefreshInterval    = time.Minute
 )

--- a/service/query/query_service.go
+++ b/service/query/query_service.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/google/uuid"
+	"github.com/hyperledger/fabric-lib-go/common/flogging"
 	"github.com/hyperledger/fabric-x-common/api/applicationpb"
 	"github.com/hyperledger/fabric-x-common/api/committerpb"
 	"golang.org/x/sync/semaphore"
@@ -28,6 +29,8 @@ import (
 	"github.com/hyperledger/fabric-x-committer/utils/grpcerror"
 	"github.com/hyperledger/fabric-x-committer/utils/monitoring/promutil"
 )
+
+var logger = flogging.MustGetLogger("query")
 
 var (
 	// ErrInvalidOrStaleView is returned when attempting to use wrong, stale, or cancelled view.
@@ -58,16 +61,20 @@ type (
 		metrics     *perfMetrics
 		ready       *channel.Ready
 		healthcheck *health.Server
+		tlsUpdater  connection.TLSCertUpdater
 	}
 )
 
 // NewQueryService create a new QueryService given a configuration.
-func NewQueryService(config *Config) *Service {
+// The tlsUpdater is optional; when non-nil, it is used to push updated
+// root CA certificates read from the database.
+func NewQueryService(config *Config, tlsUpdater connection.TLSCertUpdater) *Service {
 	return &Service{
 		config:      config,
 		metrics:     newQueryServiceMetrics(),
 		ready:       channel.NewReady(),
 		healthcheck: connection.DefaultHealthCheckService(),
+		tlsUpdater:  tlsUpdater,
 	}
 }
 
@@ -106,6 +113,10 @@ func (q *Service) Run(ctx context.Context) error {
 		},
 	}
 	q.ready.SignalReady()
+
+	// TLS refresh runs as a standalone goroutine rather than in an errgroup because
+	// a transient failure to read config from the DB should not stop the query service.
+	go q.refreshTLSFromDB(ctx, pool)
 
 	_ = q.metrics.StartPrometheusServer(ctx, q.config.Monitoring)
 	// We don't use the error here as we avoid stopping the service due to monitoring error.
@@ -318,6 +329,62 @@ func (q *Service) validateKeysCount(count int) error {
 
 func (q *Service) requestLatency(method string, start time.Time) {
 	promutil.Observe(q.metrics.requestsLatency.WithLabelValues(method), time.Since(start))
+}
+
+// refreshTLSFromDB periodically polls the database for the config transaction
+// and updates the dynamic TLS CA certificates only when the config version changes.
+func (q *Service) refreshTLSFromDB(ctx context.Context, pool querier) {
+	if q.tlsUpdater == nil {
+		return
+	}
+
+	var lastVersion uint64
+	seen := false
+
+	// tryRefresh attempts a single refresh. Errors are logged but not returned,
+	// as this is a background polling loop that should continue on transient failures.
+	tryRefresh := func() {
+		configTX, err := queryConfig(ctx, pool)
+		if err != nil {
+			logger.Errorf("Failed to read config transaction from DB: %v", err)
+			return
+		}
+
+		if len(configTX.Envelope) == 0 || (seen && configTX.Version == lastVersion) {
+			return
+		}
+
+		certs, err := connection.ExtractAppTLSCAsFromEnvelope(configTX.Envelope)
+		if err != nil {
+			logger.Errorf("Failed to extract TLS CAs from config envelope: %v", err)
+			return
+		}
+
+		if err := q.tlsUpdater.SetClientRootCAs(certs); err != nil {
+			logger.Errorf("Failed to update dynamic TLS: %v", err)
+			return
+		}
+
+		seen = true
+		lastVersion = configTX.Version
+		logger.Infof("Updated dynamic TLS with %d CA certificates from config version %d", len(certs), lastVersion)
+	}
+
+	// Attempt immediate refresh at startup to pick up existing config without waiting the
+	// full polling interval.
+	tryRefresh()
+
+	ticker := time.NewTicker(q.config.TLSRefreshInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			tryRefresh()
+		}
+	}
 }
 
 // wrapQueryError wraps query errors with appropriate gRPC status codes.

--- a/service/query/query_service_test.go
+++ b/service/query/query_service_test.go
@@ -537,7 +537,7 @@ func newQueryServiceTestEnv(t *testing.T, opts *queryServiceTestOpts) *queryServ
 		Monitoring:            test.NewLocalHostServer(test.InsecureTLSConfig),
 	}
 
-	qs := NewQueryService(config)
+	qs := NewQueryService(config, nil)
 	test.RunServiceAndGrpcForTest(t.Context(), t, qs, qs.config.Server)
 	clientConn := createQueryClientWithTLS(t, &qs.config.Server.Endpoint, opts.clientTLS)
 
@@ -752,6 +752,42 @@ func defaultViewParams(timeout time.Duration) *committerpb.ViewParameters {
 }
 
 //nolint:ireturn // returning a gRPC client interface is intentional for test purpose.
+func TestRefreshTLSFromDB(t *testing.T) {
+	t.Parallel()
+
+	t.Run("updates TLS from config in DB", func(t *testing.T) {
+		t.Parallel()
+		// generateNamespacesUnderTest sets up DB with system tables and a config block.
+		dbConf := generateNamespacesUnderTest(t, []string{"0"})
+
+		ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+		t.Cleanup(cancel)
+
+		pool, err := vc.NewDatabasePool(ctx, dbConf)
+		require.NoError(t, err)
+		t.Cleanup(pool.Close)
+
+		updater := &test.MockTLSUpdater{}
+		qs := &Service{
+			config:     &Config{TLSRefreshInterval: 100 * time.Millisecond},
+			tlsUpdater: updater,
+		}
+
+		go qs.refreshTLSFromDB(ctx, pool)
+
+		require.Eventually(t, func() bool {
+			return len(updater.LastCerts()) > 0
+		}, 10*time.Second, 100*time.Millisecond, "TLS updater should have been called with CAs from config")
+	})
+
+	t.Run("no-op when tlsUpdater is nil", func(t *testing.T) {
+		t.Parallel()
+		qs := &Service{config: &Config{}}
+		// Should return immediately without panic.
+		qs.refreshTLSFromDB(t.Context(), nil)
+	})
+}
+
 func createQueryClientWithTLS(
 	t *testing.T,
 	ep *connection.Endpoint,

--- a/service/sidecar/relay.go
+++ b/service/sidecar/relay.go
@@ -29,6 +29,7 @@ type (
 		incomingBlockToBeCommitted <-chan *common.Block
 		outgoingCommittedBlock     chan<- *common.Block
 		outgoingStatusUpdates      chan<- []*committerpb.TxStatus
+		outgoingConfigBlocks       chan<- *common.Block
 
 		// nextBlockNumberToBeCommitted denotes the next block number of to be committed.
 		nextBlockNumberToBeCommitted atomic.Uint64
@@ -50,6 +51,7 @@ type (
 		incomingBlockToBeCommitted     <-chan *common.Block
 		outgoingCommittedBlock         chan<- *common.Block
 		outgoingStatusUpdates          chan<- []*committerpb.TxStatus
+		outgoingConfigBlocks           chan<- *common.Block
 		waitingTxsLimit                int
 	}
 )
@@ -71,6 +73,7 @@ func (r *relay) run(ctx context.Context, config *relayRunConfig) error { //nolin
 	r.incomingBlockToBeCommitted = config.incomingBlockToBeCommitted
 	r.outgoingCommittedBlock = config.outgoingCommittedBlock
 	r.outgoingStatusUpdates = config.outgoingStatusUpdates
+	r.outgoingConfigBlocks = config.outgoingConfigBlocks
 	r.blkNumToBlkWithStatus.Clear()
 	r.txIDToHeight.Clear()
 	r.waitingTxsSlots = utils.NewSlots(int64(config.waitingTxsLimit))
@@ -120,6 +123,7 @@ func (r *relay) preProcessBlock(
 ) error {
 	incomingBlockToBeCommitted := channel.NewReader(ctx, r.incomingBlockToBeCommitted)
 	queue := channel.NewWriter(ctx, mappedBlockQueue)
+	configBlocks := channel.NewWriter(ctx, r.outgoingConfigBlocks)
 
 	done := context.AfterFunc(ctx, r.waitingTxsSlots.Broadcast)
 	defer done()
@@ -143,6 +147,7 @@ func (r *relay) preProcessBlock(
 			// We wait for all previously submitted transactions to be processed by
 			// the committer before submitting the config block.
 			r.waitingTxsSlots.WaitTillEmpty(ctx)
+			configBlocks.Write(block)
 		}
 
 		txsCount := len(mappedBlock.block.Txs)

--- a/service/sidecar/relay_test.go
+++ b/service/sidecar/relay_test.go
@@ -290,7 +290,9 @@ func (e *relayTestEnv) readAllStatusQueue(t *testing.T) []*committerpb.TxStatus 
 
 func createConfigBlockForTest(t *testing.T) *common.Block {
 	t.Helper()
-	block, err := testcrypto.CreateOrExtendConfigBlockWithCrypto(t.TempDir(), &testcrypto.ConfigBlock{})
+	block, err := testcrypto.CreateOrExtendConfigBlockWithCrypto(t.TempDir(), &testcrypto.ConfigBlock{
+		PeerOrganizationCount: 1,
+	})
 	require.NoError(t, err)
 	return block
 }

--- a/service/sidecar/sidecar.go
+++ b/service/sidecar/sidecar.go
@@ -52,10 +52,12 @@ type Service struct {
 	config             *Config
 	healthcheck        *health.Server
 	metrics            *perfMetrics
+	tlsUpdater         connection.TLSCertUpdater
 }
 
-// New creates a sidecar service.
-func New(c *Config) (*Service, error) {
+// New creates a sidecar service. The tlsUpdater is optional; when non-nil,
+// it is used to push updated root CA certificates from config blocks.
+func New(c *Config, tlsUpdater connection.TLSCertUpdater) (*Service, error) {
 	logger.Info("Initializing new sidecar")
 
 	// 1. Load the delivery parameters for the ordering service.
@@ -86,6 +88,7 @@ func New(c *Config) (*Service, error) {
 		metrics:        metrics,
 		committedBlock: make(chan *common.Block, c.ChannelBufferSize),
 		statusQueue:    make(chan []*committerpb.TxStatus, c.ChannelBufferSize),
+		tlsUpdater:     tlsUpdater,
 	}, nil
 }
 
@@ -170,6 +173,26 @@ func (s *Service) sendBlocksAndReceiveStatus(
 	blocksToBeCommitted := make(chan *common.Block, s.config.ChannelBufferSize)
 	s.blockToBeCommitted.Store(new(blocksToBeCommitted))
 
+	var configBlocks chan *common.Block
+	if s.tlsUpdater != nil {
+		// Config blocks are infrequent, but in rare cases a user may submit
+		// multiple config transactions in rapid succession. Buffer of 5 allows
+		// the relay to enqueue without blocking while TLS updater processes.
+		configBlocks = make(chan *common.Block, 5)
+		// Prime the channel with the latest config block from the store.
+		// This ensures TLS is initialized with current CAs before new blocks arrive.
+		_, configBlk, err := s.getPrevBlockAndItsConfig(nextBlockNum)
+		if err != nil {
+			return errors.Wrap(err, "failed to fetch latest config block for TLS initialization")
+		}
+		if configBlk != nil {
+			configBlocks <- configBlk
+		}
+		g.Go(func() error {
+			return s.updateDynamicTLS(gCtx, configBlocks)
+		})
+	}
+
 	// NOTE: deliver.s.startDelivery and relay.Run must always return an error on exist.
 	g.Go(func() error {
 		return s.startDelivery(gCtx, blocksToBeCommitted, nextBlockNum)
@@ -183,6 +206,7 @@ func (s *Service) sendBlocksAndReceiveStatus(
 			incomingBlockToBeCommitted:     blocksToBeCommitted,
 			outgoingCommittedBlock:         s.committedBlock,
 			outgoingStatusUpdates:          s.statusQueue,
+			outgoingConfigBlocks:           configBlocks,
 			waitingTxsLimit:                s.config.WaitingTxsLimit,
 		})
 	})
@@ -399,6 +423,37 @@ func (s *Service) monitorQueues(ctx context.Context) {
 		}
 		promutil.SetGauge(m.committedBlocksQueueSize, len(s.committedBlock))
 	}
+}
+
+// updateDynamicTLS reads config blocks from the relay and updates the
+// dynamic TLS CA certificates. Errors are non-retryable because a failure
+// to parse a validated config block indicates a serious problem.
+func (s *Service) updateDynamicTLS(ctx context.Context, configBlocks <-chan *common.Block) error {
+	reader := channel.NewReader(ctx, configBlocks)
+	for ctx.Err() == nil {
+		configBlk, ok := reader.Read()
+		if !ok {
+			return errors.Wrap(ctx.Err(), "context ended")
+		}
+
+		if len(configBlk.Data.Data) == 0 {
+			return errors.Join(retry.ErrNonRetryable,
+				errors.Newf("config block %d has no data", configBlk.Header.Number))
+		}
+
+		certs, err := connection.ExtractAppTLSCAsFromEnvelope(configBlk.Data.Data[0])
+		if err != nil {
+			return errors.Join(retry.ErrNonRetryable,
+				errors.Wrap(err, "failed to extract TLS CAs from config envelope"))
+		}
+
+		if err := s.tlsUpdater.SetClientRootCAs(certs); err != nil {
+			return errors.Join(retry.ErrNonRetryable, errors.Wrap(err, "failed to update dynamic TLS"))
+		}
+		logger.Infof("Updated dynamic TLS with %d CA certificates", len(certs))
+	}
+
+	return errors.Wrap(ctx.Err(), "context cancelled")
 }
 
 // Close closes the ledger.

--- a/service/sidecar/sidecar_test.go
+++ b/service/sidecar/sidecar_test.go
@@ -104,7 +104,7 @@ func newSidecarTestEnvWithTLS(
 		Monitoring:                    test.NewLocalHostServer(conf.ServerTLS),
 		Orderer:                       ordererEnv.OrdererConnConfig,
 	}
-	sidecar, err := New(sidecarConf)
+	sidecar, err := New(sidecarConf, nil)
 	require.NoError(t, err)
 	t.Cleanup(sidecar.Close)
 
@@ -317,7 +317,7 @@ func TestSidecarConfigRecovery(t *testing.T) {
 
 	var err error
 	t.Log("Create a new sidecar with the old configuration (only party 0)")
-	env.sidecar, err = New(&env.config)
+	env.sidecar, err = New(&env.config, nil)
 	require.NoError(t, err)
 	t.Cleanup(env.sidecar.Close)
 
@@ -691,6 +691,50 @@ func checkNextBlockNumberToCommit(
 		require.NotNil(ct, nextBlock)
 		require.Equal(ct, expectedBlockNumber, nextBlock.Number)
 	}, expectedProcessingTime, 50*time.Millisecond)
+}
+
+func TestUpdateDynamicTLS(t *testing.T) {
+	t.Parallel()
+
+	t.Run("updates TLS CAs from config envelope", func(t *testing.T) {
+		t.Parallel()
+		updater := &test.MockTLSUpdater{}
+		s := &Service{tlsUpdater: updater}
+
+		block := createConfigBlockForTest(t)
+		ch := make(chan *common.Block, 1)
+		ch <- block
+
+		ctx, cancel := context.WithCancel(t.Context())
+		go func() {
+			// Cancel after the envelope is processed.
+			require.Eventually(t, func() bool { //nolint:testifylint
+				return len(updater.LastCerts()) > 0
+			}, 5*time.Second, 10*time.Millisecond)
+			cancel()
+		}()
+
+		err := s.updateDynamicTLS(ctx, ch)
+		require.ErrorIs(t, err, context.Canceled)
+		require.NotEmpty(t, updater.LastCerts(), "should have received TLS CA certificates")
+	})
+
+	t.Run("returns non-retryable error for invalid envelope", func(t *testing.T) {
+		t.Parallel()
+		updater := &test.MockTLSUpdater{}
+		s := &Service{tlsUpdater: updater}
+
+		block := &common.Block{
+			Header: &common.BlockHeader{Number: 1},
+			Data:   &common.BlockData{Data: [][]byte{[]byte("invalid envelope")}},
+		}
+		ch := make(chan *common.Block, 1)
+		ch <- block
+
+		err := s.updateDynamicTLS(t.Context(), ch)
+		require.Error(t, err)
+		require.Empty(t, updater.LastCerts())
+	})
 }
 
 func makeValidTx(t *testing.T, chanID string) *servicepb.LoadGenTx {

--- a/utils/connection/client_test.go
+++ b/utils/connection/client_test.go
@@ -257,9 +257,9 @@ func TestFilterStreamRPCError(t *testing.T) {
 
 	t.Run("client ctx timeout", func(t *testing.T) {
 		t.Parallel()
+		env := newFilterTestEnv(t)
 		clientCtx, clientCancel := context.WithTimeout(t.Context(), time.Second)
 		t.Cleanup(clientCancel)
-		env := newFilterTestEnv(t)
 		deliver, err := env.client.Deliver(clientCtx)
 		require.NoError(t, err)
 		time.Sleep(time.Second)

--- a/utils/connection/config.go
+++ b/utils/connection/config.go
@@ -135,3 +135,17 @@ func (c *RateLimitConfig) Validate() error {
 	}
 	return nil
 }
+
+// serverCredentials returns transport credentials for this server config.
+// When a TLSConfigProvider is set, each TLS handshake is delegated to
+// GetConfigForClient, enabling dynamic CA rotation without restart.
+func (c *ServerConfig) serverCredentials(tlsProvider TLSConfigProvider) (credentials.TransportCredentials, error) {
+	if tlsProvider == nil {
+		return c.TLS.ServerCredentials()
+	}
+
+	return newCredentials(&tls.Config{
+		MinVersion:         DefaultTLSMinVersion,
+		GetConfigForClient: tlsProvider.GetConfigForClient,
+	}, nil)
+}

--- a/utils/connection/dynamic_tls.go
+++ b/utils/connection/dynamic_tls.go
@@ -1,0 +1,117 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package connection
+
+import (
+	"crypto/tls"
+	"sync/atomic"
+
+	"github.com/cockroachdb/errors"
+	"github.com/hyperledger/fabric-lib-go/bccsp/factory"
+	"github.com/hyperledger/fabric-x-common/common/channelconfig"
+	"github.com/hyperledger/fabric-x-common/protoutil"
+)
+
+// TLSCertUpdater is the write-side interface for dynamic TLS CA rotation.
+// Services (sidecar, query) use this to push updated root CA certificates
+// when new organizations join or config blocks are received.
+type TLSCertUpdater interface {
+	SetClientRootCAs(certs [][]byte) error
+}
+
+// TLSConfigProvider is the read-side interface for dynamic TLS CA rotation.
+// The gRPC server infrastructure uses this to obtain the current TLS config
+// on each new client connection handshake.
+type TLSConfigProvider interface {
+	GetConfigForClient(*tls.ClientHelloInfo) (*tls.Config, error)
+}
+
+// DynamicTLS holds a dynamically updatable TLS configuration.
+// It implements both TLSCertUpdater (for services to push CA updates)
+// and TLSConfigProvider (for the server to read the current config).
+//
+// The design separates writers (services) from readers (server) through
+// interface segregation, ensuring a linear dependency flow:
+//
+//	Service -> TLSCertUpdater -> DynamicTLS <- TLSConfigProvider <- Server
+type DynamicTLS struct {
+	config    atomic.Pointer[tls.Config]
+	staticCAs [][]byte
+}
+
+// NewDynamicTLSFromConfig loads TLS credentials from a TLSConfig and creates a
+// DynamicTLS. Callers should only invoke this for mutual TLS configurations.
+func NewDynamicTLSFromConfig(tlsConfig TLSConfig) (*DynamicTLS, error) {
+	creds, err := NewServerTLSCredentials(tlsConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	baseCfg, err := creds.CreateServerTLSConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	d := &DynamicTLS{staticCAs: creds.CACerts}
+	d.config.Store(baseCfg)
+	return d, nil
+}
+
+// SetClientRootCAs merges the provided dynamic CA certificates with the static CAs,
+// builds a new certificate pool, and atomically swaps the stored TLS config.
+// This is called by services when they receive updated CA certificates
+// (e.g., from config blocks or database reads).
+func (d *DynamicTLS) SetClientRootCAs(certs [][]byte) error {
+	merged := make([][]byte, 0, len(d.staticCAs)+len(certs))
+	merged = append(merged, d.staticCAs...)
+	merged = append(merged, certs...)
+
+	pool, err := buildCertPool(merged)
+	if err != nil {
+		return err
+	}
+
+	cfg := d.config.Load().Clone()
+	cfg.ClientCAs = pool
+	d.config.Store(cfg)
+	return nil
+}
+
+// GetConfigForClient returns the current TLS config for a new client connection.
+// This is a single atomic pointer load with no allocations, making it safe and
+// efficient to call on every TLS handshake.
+func (d *DynamicTLS) GetConfigForClient(*tls.ClientHelloInfo) (*tls.Config, error) {
+	return d.config.Load(), nil
+}
+
+// ExtractAppTLSCAsFromEnvelope parses a Fabric config envelope and extracts
+// TLS root CA certificates from application organizations.
+// Only application org CAs are needed because the sidecar and query services
+// accept connections from application clients, not orderer nodes.
+func ExtractAppTLSCAsFromEnvelope(envelopeBytes []byte) ([][]byte, error) {
+	envelope, err := protoutil.UnmarshalEnvelope(envelopeBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	bundle, err := channelconfig.NewBundleFromEnvelope(envelope, factory.GetDefault())
+	if err != nil {
+		return nil, err
+	}
+
+	app, ok := bundle.ApplicationConfig()
+	if !ok {
+		return nil, errors.New("could not find application config in envelope")
+	}
+
+	var certs [][]byte
+	for _, org := range app.Organizations() {
+		certs = append(certs, org.MSP().GetTLSRootCerts()...)
+	}
+
+	return certs, nil
+}

--- a/utils/connection/dynamic_tls_test.go
+++ b/utils/connection/dynamic_tls_test.go
@@ -1,0 +1,199 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package connection
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/hyperledger/fabric-x-common/api/types"
+	"github.com/hyperledger/fabric-x-common/common/crypto/tlsgen"
+	"github.com/hyperledger/fabric-x-common/tools/configtxgen"
+	"github.com/hyperledger/fabric-x-common/tools/cryptogen"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDynamicTLS(t *testing.T) {
+	t.Parallel()
+
+	var cas [3]tlsgen.CA
+	for i := range cas {
+		ca, err := tlsgen.NewCA()
+		require.NoError(t, err)
+		cas[i] = ca
+	}
+
+	for _, tc := range []struct {
+		name       string
+		updates    []tlsgen.CA // sequential SetClientRootCAs calls
+		contain    []tlsgen.CA
+		notContain []tlsgen.CA
+	}{
+		{
+			name:       "initial config has only static CAs",
+			contain:    []tlsgen.CA{cas[0]},
+			notContain: []tlsgen.CA{cas[1]},
+		},
+		{
+			name:       "after SetClientRootCAs includes dynamic CAs",
+			updates:    []tlsgen.CA{cas[1]},
+			contain:    []tlsgen.CA{cas[0], cas[1]},
+			notContain: []tlsgen.CA{cas[2]},
+		},
+		{
+			name:       "SetClientRootCAs replaces previous dynamic CAs",
+			updates:    []tlsgen.CA{cas[1], cas[2]},
+			contain:    []tlsgen.CA{cas[0], cas[2]},
+			notContain: []tlsgen.CA{cas[1]},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			dtls := newTestDynamicTLS(t, cas[0])
+			for _, ca := range tc.updates {
+				require.NoError(t, dtls.SetClientRootCAs([][]byte{ca.CertBytes()}))
+			}
+
+			cfg, err := dtls.GetConfigForClient(nil)
+			require.NoError(t, err)
+			require.NotNil(t, cfg)
+			requireCAs(t, cfg.ClientCAs, tc.contain, tc.notContain)
+		})
+	}
+
+	t.Run("server certificate is preserved across updates", func(t *testing.T) {
+		t.Parallel()
+		dtls := newTestDynamicTLS(t, cas[0])
+		require.NoError(t, dtls.SetClientRootCAs([][]byte{cas[1].CertBytes()}))
+
+		cfg, err := dtls.GetConfigForClient(nil)
+		require.NoError(t, err)
+		require.Len(t, cfg.Certificates, 1)
+	})
+
+	t.Run("SetClientRootCAs rejects invalid cert", func(t *testing.T) {
+		t.Parallel()
+		dtls := newTestDynamicTLS(t, cas[0])
+		require.Error(t, dtls.SetClientRootCAs([][]byte{[]byte("not a valid cert")}))
+	})
+}
+
+func TestExtractAppTLSCAsFromEnvelope(t *testing.T) {
+	t.Parallel()
+	targetPath := t.TempDir()
+
+	block, err := cryptogen.CreateOrExtendConfigBlockWithCrypto(cryptogen.ConfigBlockParameters{
+		TargetPath:  targetPath,
+		BaseProfile: configtxgen.SampleFabricX,
+		ChannelID:   "test-channel",
+		Organizations: []cryptogen.OrganizationParameters{
+			{
+				Name:   "orderer-org",
+				Domain: "orderer-org.com",
+				OrdererEndpoints: []*types.OrdererEndpoint{
+					{Host: "localhost", Port: 7050},
+				},
+				ConsenterNodes: []cryptogen.Node{
+					{CommonName: "consenter", Hostname: "consenter.com"},
+				},
+				OrdererNodes: []cryptogen.Node{
+					{CommonName: "orderer", Hostname: "orderer.com", SANS: []string{"localhost"}},
+				},
+			},
+			{
+				Name:   "peer-org",
+				Domain: "peer-org.com",
+				PeerNodes: []cryptogen.Node{
+					{CommonName: "peer0", Hostname: "peer0.com", SANS: []string{"localhost"}},
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, block.Data.Data)
+
+	t.Run("extracts TLS CAs from valid config envelope", func(t *testing.T) {
+		t.Parallel()
+		certs, err := ExtractAppTLSCAsFromEnvelope(block.Data.Data[0])
+		require.NoError(t, err)
+		require.NotEmpty(t, certs, "should extract at least one TLS CA certificate")
+
+		for _, cert := range certs {
+			require.NotEmpty(t, cert)
+			blk, _ := pem.Decode(cert)
+			require.NotNil(t, blk, "each cert should be valid PEM")
+		}
+	})
+
+	t.Run("returns error for invalid envelope", func(t *testing.T) {
+		t.Parallel()
+		_, err := ExtractAppTLSCAsFromEnvelope([]byte("invalid"))
+		require.Error(t, err)
+	})
+
+	t.Run("returns error for nil envelope", func(t *testing.T) {
+		t.Parallel()
+		_, err := ExtractAppTLSCAsFromEnvelope(nil)
+		require.Error(t, err)
+	})
+}
+
+// newTestDynamicTLS creates a DynamicTLS via NewDynamicTLSFromConfig using the given CA
+// for both server credentials and client CA trust.
+func newTestDynamicTLS(t *testing.T, ca tlsgen.CA) *DynamicTLS {
+	t.Helper()
+	keyPair, err := ca.NewServerCertKeyPair(localHost)
+	require.NoError(t, err)
+
+	dir := t.TempDir()
+	certPath := filepath.Join(dir, "cert.pem")
+	keyPath := filepath.Join(dir, "key.pem")
+	caPath := filepath.Join(dir, "ca.pem")
+	require.NoError(t, os.WriteFile(certPath, keyPair.Cert, 0o600))
+	require.NoError(t, os.WriteFile(keyPath, keyPair.Key, 0o600))
+	require.NoError(t, os.WriteFile(caPath, ca.CertBytes(), 0o600))
+
+	dtls, err := NewDynamicTLSFromConfig(TLSConfig{
+		Mode:        MutualTLSMode,
+		CertPath:    certPath,
+		KeyPath:     keyPath,
+		CACertPaths: []string{caPath},
+	})
+	require.NoError(t, err)
+	return dtls
+}
+
+// requireCAs asserts that the pool contains all CAs in `contain` and none of the CAs in `notContain`.
+func requireCAs(t *testing.T, pool *x509.CertPool, contain, notContain []tlsgen.CA) {
+	t.Helper()
+	require.NotNil(t, pool)
+
+	for _, ca := range contain {
+		cert := parsePEMCert(t, ca.CertBytes())
+		_, err := cert.Verify(x509.VerifyOptions{Roots: pool})
+		require.NoError(t, err, "pool should contain CA certificate")
+	}
+
+	for _, ca := range notContain {
+		cert := parsePEMCert(t, ca.CertBytes())
+		_, err := cert.Verify(x509.VerifyOptions{Roots: pool})
+		require.Error(t, err, "pool should NOT contain CA certificate")
+	}
+}
+
+func parsePEMCert(t *testing.T, pemBytes []byte) *x509.Certificate {
+	t.Helper()
+	block, _ := pem.Decode(pemBytes)
+	require.NotNil(t, block, "failed to decode PEM block")
+
+	cert, err := x509.ParseCertificate(block.Bytes)
+	require.NoError(t, err)
+	return cert
+}

--- a/utils/connection/server.go
+++ b/utils/connection/server.go
@@ -40,9 +40,9 @@ var (
 )
 
 // GrpcServer instantiate a [grpc.Server].
-func (c *ServerConfig) GrpcServer() (*grpc.Server, error) {
+func (c *ServerConfig) GrpcServer(tlsProvider TLSConfigProvider) (*grpc.Server, error) {
 	opts := []grpc.ServerOption{grpc.MaxRecvMsgSize(maxMsgSize), grpc.MaxSendMsgSize(maxMsgSize)}
-	serverGrpcTransportCreds, err := c.TLS.ServerCredentials()
+	serverGrpcTransportCreds, err := c.serverCredentials(tlsProvider)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed loading the server's grpc credentials")
 	}

--- a/utils/grpcservice/start_serve.go
+++ b/utils/grpcservice/start_serve.go
@@ -39,7 +39,10 @@ type Registerer interface {
 // StartAndServe runs a full lifecycle service: starts the service, waits for it
 // to be ready, then creates and serves gRPC server(s). Stops everything
 // if either the service or any server exits.
-func StartAndServe(ctx context.Context, service Service, serverConfigs ...*connection.ServerConfig) error {
+func StartAndServe(
+	ctx context.Context, service Service, tlsProvider connection.TLSConfigProvider,
+	serverConfigs ...*connection.ServerConfig,
+) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -61,7 +64,7 @@ func StartAndServe(ctx context.Context, service Service, serverConfigs ...*conne
 		g.Go(func() error {
 			// If the GRPC servers stop, there is no reason to continue the service.
 			defer cancel()
-			return Serve(gCtx, service, sc)
+			return Serve(gCtx, service, sc, tlsProvider)
 		})
 	}
 	return g.Wait()
@@ -70,12 +73,15 @@ func StartAndServe(ctx context.Context, service Service, serverConfigs ...*conne
 // Serve creates a gRPC server and listener from the config, registers the
 // service, and serves until the context is done. For services that only
 // implement Registerer (e.g., mock services without Run/WaitForReady).
-func Serve(ctx context.Context, service Registerer, serverConfig *connection.ServerConfig) error {
+func Serve(
+	ctx context.Context, service Registerer, serverConfig *connection.ServerConfig,
+	tlsProvider connection.TLSConfigProvider,
+) error {
 	listener, err := serverConfig.Listener(ctx)
 	if err != nil {
 		return err
 	}
-	server, err := serverConfig.GrpcServer()
+	server, err := serverConfig.GrpcServer(tlsProvider)
 	if err != nil {
 		return errors.Wrapf(err, "failed creating grpc server")
 	}

--- a/utils/grpcservice/start_serve_test.go
+++ b/utils/grpcservice/start_serve_test.go
@@ -92,7 +92,7 @@ func TestStartAndServe(t *testing.T) {
 		ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
 		t.Cleanup(cancel)
 
-		err := grpcservice.StartAndServe(ctx, &slowReadyService{}, serverConfig)
+		err := grpcservice.StartAndServe(ctx, &slowReadyService{}, nil, serverConfig)
 		require.NoError(t, err)
 		assert.Equal(t, 0, serverConfig.Endpoint.Port, "server should not have started")
 	})
@@ -136,7 +136,7 @@ func startInBackground(
 
 	g, gCtx := errgroup.WithContext(ctx)
 	g.Go(func() error {
-		return grpcservice.StartAndServe(gCtx, service, serverConfigs...)
+		return grpcservice.StartAndServe(gCtx, service, nil, serverConfigs...)
 	})
 
 	t.Cleanup(func() { cancel(); assert.NoError(t, g.Wait()) })

--- a/utils/test/grpc.go
+++ b/utils/test/grpc.go
@@ -97,7 +97,7 @@ func RunGrpcServerForTest(
 	tb.Helper()
 	listener, err := serverConfig.Listener(ctx)
 	require.NoError(tb, err)
-	server, err := serverConfig.GrpcServer()
+	server, err := serverConfig.GrpcServer(nil)
 	require.NoError(tb, err)
 
 	if register != nil {
@@ -492,6 +492,22 @@ func NewServiceTLSConfig(artifactsPath, serviceName, mode string) connection.TLS
 		CACertPaths: []string{
 			filepath.Join(artifactsPath, OrgRootCA),
 		},
+	}
+}
+
+// OrgClientTLSConfig creates a mutual TLS client configuration using a specific
+// peer organization's TLS client certificate. The serverCACertPaths are the CA
+// certs needed to verify the server (typically from the CredentialsFactory).
+func OrgClientTLSConfig(artifactsPath string, orgIndex int, serverCACertPaths []string) connection.TLSConfig {
+	orgName := fmt.Sprintf("peer-org-%d", orgIndex)
+	orgDomain := fmt.Sprintf("peer-org-%d.com", orgIndex)
+	tlsDir := filepath.Join(artifactsPath, cryptogen.PeerOrganizationsDir, orgName,
+		cryptogen.UsersDir, fmt.Sprintf("client@%s", orgDomain), cryptogen.TLSDir)
+	return connection.TLSConfig{
+		Mode:        connection.MutualTLSMode,
+		CertPath:    filepath.Join(tlsDir, "client.crt"),
+		KeyPath:     filepath.Join(tlsDir, "client.key"),
+		CACertPaths: serverCACertPaths,
 	}
 }
 

--- a/utils/test/tls_updater.go
+++ b/utils/test/tls_updater.go
@@ -1,0 +1,29 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package test
+
+import "sync/atomic"
+
+// MockTLSUpdater is a thread-safe mock for connection.TLSCertUpdater,
+// used by tests that verify dynamic TLS CA rotation.
+type MockTLSUpdater struct {
+	certs atomic.Pointer[[][]byte]
+}
+
+// SetClientRootCAs stores the given certs.
+func (m *MockTLSUpdater) SetClientRootCAs(certs [][]byte) error {
+	m.certs.Store(&certs)
+	return nil
+}
+
+// LastCerts returns the most recently stored certs.
+func (m *MockTLSUpdater) LastCerts() [][]byte {
+	if p := m.certs.Load(); p != nil {
+		return *p
+	}
+	return nil
+}


### PR DESCRIPTION
#### Type of change

- New feature

#### Description

Add dynamic TLS support so that peer organization CA certificates are automatically updated when config blocks add or remove organizations.

- DynamicTLSManager in utils/connection/ watches config block updates and rebuilds the trusted CA pool on the fly
- Sidecar updates TLS immediately during config block processing
- Query service polls the DB periodically for config changes
- Integration test covers add/remove/restore of peer orgs with mTLS
- Infrastructure plumbing for QueryTLSRefreshInterval and PeerOrganizationCount in runner config

#### Related issues

 - resolves #290 