### PR TITLE
[config] Reduce duplicates in config templates

### DIFF
--- a/cmd/config/create_config_file.go
+++ b/cmd/config/create_config_file.go
@@ -10,10 +10,11 @@ import (
 	"bytes"
 	_ "embed"
 	"fmt"
-	"html/template"
 	"os"
 	"path"
+	"strings"
 	"testing"
+	"text/template"
 	"time"
 
 	sprig "github.com/go-task/slim-sprig/v3"
@@ -94,6 +95,11 @@ type (
 
 // Config templates.
 var (
+	//go:embed templates/shared.yaml.tmpl
+	templateShared string
+	//go:embed templates/loadgen_shared.yaml.tmpl
+	templateLoadGenShared string
+
 	//go:embed templates/coordinator.yaml.tmpl
 	TemplateCoordinator string
 	//go:embed templates/mock-orderer.yaml.tmpl
@@ -107,37 +113,42 @@ var (
 	//go:embed templates/verifier.yaml.tmpl
 	TemplateVerifier string
 
-	TemplateLoadGenOnlyOrderer              = templateLoadGenOnlyOrdererClient + templateLoadGenCommon
-	TemplateLoadGenOrderer                  = templateLoadGenOrdererClient + templateLoadGenCommon
-	TemplateLoadGenCommitter                = templateLoadGenCommitterClient + templateLoadGenCommon
-	TemplateLoadGenCoordinator              = templateLoadGenCoordinatorClient + templateLoadGenCommon
-	TemplateLoadGenVC                       = templateLoadGenVCClient + templateLoadGenCommon
-	TemplateLoadGenVerifier                 = templateLoadGenVerifierClient + templateLoadGenCommon
-	TemplateLoadGenDistributedLoadGenClient = templateLoadGenDistributedLoadGenClient + templateLoadGenCommon
-
-	//go:embed templates/loadgen_shared.yaml.tmpl
-	templateLoadGenCommon string
 	//go:embed templates/loadgen_only_orderer.yaml.tmpl
-	templateLoadGenOnlyOrdererClient string
+	TemplateLoadGenOnlyOrderer string
 	//go:embed templates/loadgen_orderer.yaml.tmpl
-	templateLoadGenOrdererClient string
+	TemplateLoadGenOrderer string
 	//go:embed templates/loadgen_committer.yaml.tmpl
-	templateLoadGenCommitterClient string
+	TemplateLoadGenCommitter string
 	//go:embed templates/loadgen_coordinator.yaml.tmpl
-	templateLoadGenCoordinatorClient string
+	TemplateLoadGenCoordinator string
 	//go:embed templates/loadgen_vc.yaml.tmpl
-	templateLoadGenVCClient string
+	TemplateLoadGenVC string
 	//go:embed templates/loadgen_verifier.yaml.tmpl
-	templateLoadGenVerifierClient string
+	TemplateLoadGenVerifier string
 	//go:embed templates/loadgen_distributed.yaml.tmpl
-	templateLoadGenDistributedLoadGenClient string
+	TemplateLoadGenDistributedLoadGenClient string
 )
 
 // createConfigFromTemplate creates a config file using template yaml and writes it to the outputPath.
+// It parses both shared block files (shared.yaml.tmpl and loadgen_shared.yaml.tmpl) before the main template.
 func createConfigFromTemplate(t *testing.T, templateString, outputPath string, conf *SystemConfig) {
 	t.Helper()
 	tmpl := template.New("").Funcs(sprig.FuncMap())
-	tmpl, err := tmpl.Parse(templateString)
+
+	tmpl.Funcs(template.FuncMap{
+		"include": func(name string, data any) (string, error) {
+			var buf bytes.Buffer
+			err := tmpl.ExecuteTemplate(&buf, name, data)
+			return strings.TrimSpace(buf.String()), err
+		},
+	})
+
+	var err error
+	for _, shared := range []string{templateShared, templateLoadGenShared} {
+		tmpl, err = tmpl.Parse(shared)
+		require.NoError(t, err)
+	}
+	tmpl, err = tmpl.Parse(templateString)
 	require.NoError(t, err)
 
 	var renderedConfig bytes.Buffer

--- a/cmd/config/templates/coordinator.yaml.tmpl
+++ b/cmd/config/templates/coordinator.yaml.tmpl
@@ -3,45 +3,11 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 server:
-  endpoint: {{ .ThisService.GrpcEndpoint | default "localhost:0" }}
-  tls:
-    mode: {{ .ThisService.GrpcTLS.Mode }}
-    key-path: {{ .ThisService.GrpcTLS.KeyPath }}
-    cert-path: {{ .ThisService.GrpcTLS.CertPath }}
-    ca-cert-paths:
-      {{- range .ThisService.GrpcTLS.CACertPaths }}
-      - {{ . }}
-      {{- end }}
-monitoring:
-  endpoint: {{ .ThisService.MetricsEndpoint | default "localhost:0" }}
-  tls:
-    mode: {{ .ThisService.MetricsTLS.Mode }}
-    key-path: {{ .ThisService.MetricsTLS.KeyPath }}
-    cert-path: {{ .ThisService.MetricsTLS.CertPath }}
-    ca-cert-paths:
-      {{- range .ThisService.MetricsTLS.CACertPaths }}
-      - {{ . }}
-      {{- end }}
-
+{{ include "endpointWithTLS" (dict "Endpoint" (.ThisService.GrpcEndpoint | default "localhost:0") "TLS" .ThisService.GrpcTLS) | indent 2 }}
 verifier:
-  endpoints:
-    {{- range .Services.Verifier }}
-    - {{ .GrpcEndpoint }}
-    {{- end }}
-  tls: &ClientCreds
-    mode: {{ .ClientTLS.Mode }}
-    key-path: {{ .ClientTLS.KeyPath }}
-    cert-path: {{ .ClientTLS.CertPath }}
-    ca-cert-paths:
-      {{- range .ClientTLS.CACertPaths }}
-      - {{ . }}
-      {{- end }}
+{{ include "endpointListWithSharedTLS" (dict "Servers" .Services.Verifier "TLS" .ClientTLS) | indent 2 }}
 validator-committer:
-  endpoints:
-   {{- range .Services.VCService }}
-    - {{ .GrpcEndpoint }}
-   {{- end }}
-  tls: *ClientCreds
+{{ include "endpointListWithSharedTLS" (dict "Servers" .Services.VCService "TLS" .ClientTLS) | indent 2 }}
 
 dependency-graph:
   num-of-local-dep-constructors: 1
@@ -49,6 +15,5 @@ dependency-graph:
   # Add monitoring configuration here if applicable
 per-channel-buffer-size-per-goroutine: 10
 
-logging:
-  logSpec: {{ .Logging.LogSpec }}
-  format: {{ .Logging.Format }}
+{{ include "monitoring" . | indent 0 }}
+{{ include "logging" . | indent 0 }}

--- a/cmd/config/templates/coordinator.yaml.tmpl
+++ b/cmd/config/templates/coordinator.yaml.tmpl
@@ -2,8 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-server:
-{{ include "endpointWithTLS" (dict "Endpoint" (.ThisService.GrpcEndpoint | default "localhost:0") "TLS" .ThisService.GrpcTLS) | indent 2 }}
+{{ include "service" . | indent 0 }}
 verifier:
 {{ include "endpointListWithSharedTLS" (dict "Servers" .Services.Verifier "TLS" .ClientTLS) | indent 2 }}
 validator-committer:
@@ -14,6 +13,3 @@ dependency-graph:
   waiting-txs-limit: 100_000
   # Add monitoring configuration here if applicable
 per-channel-buffer-size-per-goroutine: 10
-
-{{ include "monitoring" . | indent 0 }}
-{{ include "logging" . | indent 0 }}

--- a/cmd/config/templates/coordinator.yaml.tmpl
+++ b/cmd/config/templates/coordinator.yaml.tmpl
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 {{ include "service" . | indent 0 }}
+
 verifier:
 {{ include "endpointListWithSharedTLS" (dict "Servers" .Services.Verifier "TLS" .ClientTLS) | indent 2 }}
 validator-committer:
@@ -11,5 +12,4 @@ validator-committer:
 dependency-graph:
   num-of-local-dep-constructors: 1
   waiting-txs-limit: 100_000
-  # Add monitoring configuration here if applicable
 per-channel-buffer-size-per-goroutine: 10

--- a/cmd/config/templates/loadgen_committer.yaml.tmpl
+++ b/cmd/config/templates/loadgen_committer.yaml.tmpl
@@ -1,30 +1,13 @@
 # Copyright IBM Corp. All Rights Reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
-#
-# This is a partial template. It contains only the sidecar client configurations.
-# It should be complemented by the common load generator configuration.
 
 sidecar-client:
   sidecar-client:
-    endpoint: {{ .Services.Sidecar.GrpcEndpoint }}
-    tls:
-      mode: {{ .ClientTLS.Mode }}
-      cert-path: {{ .ClientTLS.CertPath }}
-      key-path: {{ .ClientTLS.KeyPath }}
-      ca-cert-paths:
-        {{- range .ClientTLS.CACertPaths }}
-        - {{ . }}
-        {{- end }}
+{{ include "endpointWithTLS" (dict "Endpoint" .Services.Sidecar.GrpcEndpoint "TLS" .ClientTLS) | indent 4 }}
   orderer-servers:
     {{- range .Services.Orderer }}
     - endpoint: {{ .GrpcEndpoint }}
-      tls:
-        mode: {{ .GrpcTLS.Mode }}
-        cert-path: {{ .GrpcTLS.CertPath }}
-        key-path: {{ .GrpcTLS.KeyPath }}
-        ca-cert-paths:
-          {{- range .GrpcTLS.CACertPaths }}
-          - {{ . }}
-          {{- end }}
+{{ include "tlsConfig" .GrpcTLS | indent 6 }}
     {{- end }}
+{{ include "loadgenConfig" . | indent 0 }}

--- a/cmd/config/templates/loadgen_coordinator.yaml.tmpl
+++ b/cmd/config/templates/loadgen_coordinator.yaml.tmpl
@@ -1,17 +1,7 @@
 # Copyright IBM Corp. All Rights Reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
-#
-# This is a partial template. It contains only the coordinator client configurations.
-# It should be complimented by the common load generator configuration.
 
 coordinator-client:
-  endpoint: {{ .Services.Coordinator.GrpcEndpoint }}
-  tls:
-    mode: {{ .ClientTLS.Mode }}
-    key-path: {{ .ClientTLS.KeyPath }}
-    cert-path: {{ .ClientTLS.CertPath }}
-    ca-cert-paths:
-      {{- range .ClientTLS.CACertPaths }}
-      - {{ . }}
-      {{- end }}
+{{ include "endpointWithTLS" (dict "Endpoint" .Services.Coordinator.GrpcEndpoint "TLS" .ClientTLS) | indent 2 }}
+{{ include "loadgenConfig" . | indent 0 }}

--- a/cmd/config/templates/loadgen_distributed.yaml.tmpl
+++ b/cmd/config/templates/loadgen_distributed.yaml.tmpl
@@ -1,17 +1,7 @@
 # Copyright IBM Corp. All Rights Reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
-#
-# This is a partial template. It contains only the distributed load gen client configurations.
-# It should be complimented by the common load generator configuration.
 
 loadgen-client:
-  endpoint: {{ .Services.LoadGen.GrpcEndpoint }}
-  tls:
-    mode: {{ .ClientTLS.Mode }}
-    key-path: {{ .ClientTLS.KeyPath }}
-    cert-path: {{ .ClientTLS.CertPath }}
-    ca-cert-paths:
-      {{- range .ClientTLS.CACertPaths }}
-      - {{ . }}
-      {{- end }}
+{{ include "endpointWithTLS" (dict "Endpoint" .Services.LoadGen.GrpcEndpoint "TLS" .ClientTLS) | indent 2 }}
+{{ include "loadgenConfig" . | indent 0 }}

--- a/cmd/config/templates/loadgen_only_orderer.yaml.tmpl
+++ b/cmd/config/templates/loadgen_only_orderer.yaml.tmpl
@@ -1,28 +1,8 @@
 # Copyright IBM Corp. All Rights Reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
-#
-# This is a partial template. It contains only the orderer client configurations.
-# It should be complimented by the common load generator configuration.
 
 orderer-client:
-  orderer:
-    fault-tolerance-level: BFT
-    latest-known-config-block-path: "{{ .Policy.ArtifactsPath }}/config-block.pb.bin"
-    tls:
-      mode: {{ .ClientTLS.Mode }}
-      cert-path: {{ .ClientTLS.CertPath }}
-      key-path: {{ .ClientTLS.KeyPath }}
-      common-ca-cert-paths:
-        {{- range .ClientTLS.CACertPaths }}
-        - {{ . }}
-        {{- end }}
-    identity:
-      msp-id: peer-org-0
-      msp-dir: {{ .Policy.ArtifactsPath }}/peerOrganizations/peer-org-0/users/client@peer-org-0.com/msp
-      bccsp:
-        Default: SW
-        SW:
-          Security: 256
-          Hash: SHA2
+{{ include "ordererClientConfig" . | indent 2 }}
   broadcast-parallelism: 5
+{{ include "loadgenConfig" . | indent 0 }}

--- a/cmd/config/templates/loadgen_only_orderer.yaml.tmpl
+++ b/cmd/config/templates/loadgen_only_orderer.yaml.tmpl
@@ -3,6 +3,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 orderer-client:
-{{ include "ordererClientConfig" . | indent 2 }}
+{{ include "ordererDialConfig" . | indent 2 }}
   broadcast-parallelism: 5
 {{ include "loadgenConfig" . | indent 0 }}

--- a/cmd/config/templates/loadgen_orderer.yaml.tmpl
+++ b/cmd/config/templates/loadgen_orderer.yaml.tmpl
@@ -5,6 +5,6 @@
 orderer-client:
   sidecar-client:
 {{ include "endpointWithTLS" (dict "Endpoint" .Services.Sidecar.GrpcEndpoint "TLS" .ClientTLS) | indent 4 }}
-{{ include "ordererClientConfig" . | indent 2 }}
+{{ include "ordererDialConfig" . | indent 2 }}
   broadcast-parallelism: 5
 {{ include "loadgenConfig" . | indent 0 }}

--- a/cmd/config/templates/loadgen_orderer.yaml.tmpl
+++ b/cmd/config/templates/loadgen_orderer.yaml.tmpl
@@ -1,38 +1,10 @@
 # Copyright IBM Corp. All Rights Reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
-#
-# This is a partial template. It contains only the orderer client configurations.
-# It should be complimented by the common load generator configuration.
 
 orderer-client:
   sidecar-client:
-    endpoint: {{ .Services.Sidecar.GrpcEndpoint }}
-    tls:
-      mode: {{ .ClientTLS.Mode }}
-      cert-path: {{ .ClientTLS.CertPath }}
-      key-path: {{ .ClientTLS.KeyPath }}
-      ca-cert-paths:
-        {{- range .ClientTLS.CACertPaths }}
-        - {{ . }}
-        {{- end }}
-  orderer:
-    fault-tolerance-level: BFT
-    latest-known-config-block-path: "{{ .Policy.ArtifactsPath }}/config-block.pb.bin"
-    tls:
-      mode: {{ .ClientTLS.Mode }}
-      cert-path: {{ .ClientTLS.CertPath }}
-      key-path: {{ .ClientTLS.KeyPath }}
-      common-ca-cert-paths:
-        {{- range .ClientTLS.CACertPaths }}
-        - {{ . }}
-        {{- end }}
-    identity:
-      msp-id: peer-org-0
-      msp-dir: {{ .Policy.ArtifactsPath }}/peerOrganizations/peer-org-0/users/client@peer-org-0.com/msp
-      bccsp:
-        Default: SW
-        SW:
-          Security: 256
-          Hash: SHA2
+{{ include "endpointWithTLS" (dict "Endpoint" .Services.Sidecar.GrpcEndpoint "TLS" .ClientTLS) | indent 4 }}
+{{ include "ordererClientConfig" . | indent 2 }}
   broadcast-parallelism: 5
+{{ include "loadgenConfig" . | indent 0 }}

--- a/cmd/config/templates/loadgen_shared.yaml.tmpl
+++ b/cmd/config/templates/loadgen_shared.yaml.tmpl
@@ -1,30 +1,19 @@
 # Copyright IBM Corp. All Rights Reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
-#
-# This is a partial template. It contains only the common parts of the load generator's configurations.
-# It should be complimented by the client adapter configuration.
 
+{{- /*
+Shared template blocks for loadgen config templates.
+
+Templates:
+  loadgenConfig -- server, monitoring (with latency), load-profile, stream, generate, limit, and logging
+*/ -}}
+
+{{- /* {{ include "loadgenConfig" . | indent 0 }} */ -}}
+{{- define "loadgenConfig" }}
 server:
-  endpoint: {{ .ThisService.GrpcEndpoint | default "localhost:0" }}
-  tls:
-    mode: {{ .ThisService.GrpcTLS.Mode }}
-    key-path: {{ .ThisService.GrpcTLS.KeyPath }}
-    cert-path: {{ .ThisService.GrpcTLS.CertPath }}
-    ca-cert-paths:
-      {{- range .ThisService.GrpcTLS.CACertPaths }}
-      - {{ . }}
-      {{- end }}
-monitoring:
-  endpoint: {{ .ThisService.MetricsEndpoint | default "localhost:0" }}
-  tls:
-    mode: {{ .ThisService.MetricsTLS.Mode }}
-    key-path: {{ .ThisService.MetricsTLS.KeyPath }}
-    cert-path: {{ .ThisService.MetricsTLS.CertPath }}
-    ca-cert-paths:
-      {{- range .ThisService.MetricsTLS.CACertPaths }}
-      - {{ . }}
-      {{- end }}
+{{ include "endpointWithTLS" (dict "Endpoint" (.ThisService.GrpcEndpoint | default "localhost:0") "TLS" .ThisService.GrpcTLS) | indent 2 }}
+{{ include "monitoring" . | indent 0 }}
   latency:
     max-tracked-txs: 10_000
     sampler:
@@ -66,7 +55,6 @@ load-profile:
   workers: {{ .LoadGenWorkers }}
 
 stream:
-  # Low rate limit prevents overloading the machine in tests.
   rate-limit: 1_000
   gen-batch: 10
   buffers-size: 10
@@ -76,18 +64,9 @@ generate:
   namespaces: true
   load: true
 
-# The stopping condition for generating load according to the collected metrics.
-# Zero value indicate no limit.
-# The limit on the number of TXs is applied at block granularity. I.e., more TXs might be created than expected
-# if a block overshot.
-# The load generator stops when both requirements are met, i.e., one of them might overshoot.
-# For the orderer adapter, the blocks limit is ignored for broadcasting as we don't track submitted blocks.
-# For adapters that use concurrent submitters, we cannot enforce exact limits.
-# The sidecar and coordinator adapters are sequential, so they don't have these issues.
 limit:
   blocks: {{ .LoadGenBlockLimit }}
   transactions: {{ .LoadGenTXLimit }}
 
-logging:
-  logSpec: {{ .Logging.LogSpec }}
-  format: {{ .Logging.Format }}
+{{ include "logging" . | indent 0 }}
+{{- end }}

--- a/cmd/config/templates/loadgen_vc.yaml.tmpl
+++ b/cmd/config/templates/loadgen_vc.yaml.tmpl
@@ -1,20 +1,7 @@
 # Copyright IBM Corp. All Rights Reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
-#
-# This is a partial template. It contains only the VC client configurations.
-# It should be complimented by the common load generator configuration.
 
 vc-client:
-  endpoints:
-    {{- range .Services.VCService }}
-    - {{ .GrpcEndpoint }}
-    {{- end }}
-  tls:
-    mode: {{ .ClientTLS.Mode }}
-    key-path: {{ .ClientTLS.KeyPath }}
-    cert-path: {{ .ClientTLS.CertPath }}
-    ca-cert-paths:
-      {{- range .ClientTLS.CACertPaths }}
-      - {{ . }}
-      {{- end }}
+{{ include "endpointListWithSharedTLS" (dict "Servers" .Services.VCService "TLS" .ClientTLS) | indent 2 }}
+{{ include "loadgenConfig" . | indent 0 }}

--- a/cmd/config/templates/loadgen_verifier.yaml.tmpl
+++ b/cmd/config/templates/loadgen_verifier.yaml.tmpl
@@ -1,20 +1,7 @@
 # Copyright IBM Corp. All Rights Reserved.
 #
 # SPDX-License-Identifier: Apache-2.0
-#
-# This is a partial template. It contains only the VC client configurations.
-# It should be complimented by the common load generator configuration.
 
 verifier-client:
-  endpoints:
-    {{- range .Services.Verifier }}
-    - {{ .GrpcEndpoint }}
-    {{- end }}
-  tls:
-    mode: {{ .ClientTLS.Mode }}
-    key-path: {{ .ClientTLS.KeyPath }}
-    cert-path: {{ .ClientTLS.CertPath }}
-    ca-cert-paths:
-      {{- range .ClientTLS.CACertPaths }}
-      - {{ . }}
-      {{- end }}
+{{ include "endpointListWithSharedTLS" (dict "Servers" .Services.Verifier "TLS" .ClientTLS) | indent 2 }}
+{{ include "loadgenConfig" . | indent 0 }}

--- a/cmd/config/templates/mock-orderer.yaml.tmpl
+++ b/cmd/config/templates/mock-orderer.yaml.tmpl
@@ -5,20 +5,12 @@
 servers:
   {{- range .Services.Orderer }}
   - endpoint: {{ .GrpcEndpoint }}
-    tls:
-      mode: {{ .GrpcTLS.Mode }}
-      cert-path: {{ .GrpcTLS.CertPath }}
-      key-path: {{ .GrpcTLS.KeyPath }}
-      ca-cert-paths:
-        {{- range .GrpcTLS.CACertPaths }}
-        - {{ . }}
-        {{- end }}
+{{ include "tlsConfig" .GrpcTLS | indent 4 }}
   {{- end }}
+
 block-size: {{ .BlockSize }}
 block-timeout: {{ .BlockTimeout }}
 artifacts-path: {{ .Policy.ArtifactsPath }}
 send-genesis-block: true
 
-logging:
-  logSpec: {{ .Logging.LogSpec }}
-  format: {{ .Logging.Format }}
+{{ include "logging" . | indent 0 }}

--- a/cmd/config/templates/query.yaml.tmpl
+++ b/cmd/config/templates/query.yaml.tmpl
@@ -2,9 +2,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-# Configuration for the server
 {{ include "service" . | indent 0 }}
 {{ include "rateLimit" . | indent 2 }}
+
 {{ include "database" . | indent 0 }}
 
 max-request-keys: {{ .MaxRequestKeys }}

--- a/cmd/config/templates/query.yaml.tmpl
+++ b/cmd/config/templates/query.yaml.tmpl
@@ -3,12 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # Configuration for the server
-server:
-{{ include "endpointWithTLS" (dict "Endpoint" (.ThisService.GrpcEndpoint | default "localhost:0") "TLS" .ThisService.GrpcTLS) | indent 2 }}
+{{ include "service" . | indent 0 }}
 {{ include "rateLimit" . | indent 2 }}
 {{ include "database" . | indent 0 }}
 
 max-request-keys: {{ .MaxRequestKeys }}
-
-{{ include "monitoring" . | indent 0 }}
-{{ include "logging" . | indent 0 }}

--- a/cmd/config/templates/query.yaml.tmpl
+++ b/cmd/config/templates/query.yaml.tmpl
@@ -4,57 +4,11 @@
 #
 # Configuration for the server
 server:
-  endpoint: {{ .ThisService.GrpcEndpoint | default "localhost:0" }}
-  tls:
-    mode: {{ .ThisService.GrpcTLS.Mode }}
-    key-path: {{ .ThisService.GrpcTLS.KeyPath }}
-    cert-path: {{ .ThisService.GrpcTLS.CertPath }}
-    ca-cert-paths:
-      {{- range .ThisService.GrpcTLS.CACertPaths }}
-      - {{ . }}
-      {{- end }}
-  {{- if .RateLimit }}
-  # Rate limiting configuration for unary gRPC endpoints.
-  # Uses a token bucket algorithm to limit the number of requests per second.
-  rate-limit:
-    # Maximum number of requests per second allowed.
-    # Set to 0 to disable rate limiting.
-    requests-per-second: {{ .RateLimit.RequestsPerSecond }}
-    # Maximum number of requests allowed in a single burst.
-    # Must be greater than 0 and less than or equal to requests-per-second.
-    burst: {{ .RateLimit.Burst }}
-  {{- end }}
-monitoring:
-  endpoint: {{ .ThisService.MetricsEndpoint | default "localhost:0" }}
-  tls:
-    mode: {{ .ThisService.MetricsTLS.Mode }}
-    key-path: {{ .ThisService.MetricsTLS.KeyPath }}
-    cert-path: {{ .ThisService.MetricsTLS.CertPath }}
-    ca-cert-paths:
-      {{- range .ThisService.MetricsTLS.CACertPaths }}
-      - {{ . }}
-      {{- end }}
-
-database:
-  endpoints:
-    {{- range .DB.Endpoints }}
-    - {{ . }}
-    {{- end }}
-  username: {{ .DB.Username }}
-  # TODO: pass password via environment variable
-  password: {{ .DB.Password }}
-  database: {{ .DB.Name }}
-  load-balance: {{ .DB.LoadBalance }}
-  tls:
-    mode: {{ .DB.TLS.Mode }}
-    ca-cert-path: {{ .DB.TLS.CACertPath }}
-  max-connections: 10
-  min-connections: 5
-  retry:
-    max-elapsed-time: 1h
+{{ include "endpointWithTLS" (dict "Endpoint" (.ThisService.GrpcEndpoint | default "localhost:0") "TLS" .ThisService.GrpcTLS) | indent 2 }}
+{{ include "rateLimit" . | indent 2 }}
+{{ include "database" . | indent 0 }}
 
 max-request-keys: {{ .MaxRequestKeys }}
 
-logging:
-  logSpec: {{ .Logging.LogSpec }}
-  format: {{ .Logging.Format }}
+{{ include "monitoring" . | indent 0 }}
+{{ include "logging" . | indent 0 }}

--- a/cmd/config/templates/shared.yaml.tmpl
+++ b/cmd/config/templates/shared.yaml.tmpl
@@ -1,0 +1,118 @@
+# Copyright IBM Corp. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+{{- /*
+Shared template blocks used across all service and loadgen config templates.
+All defines are at 0-indent and must be called via: {{ include "name" . | indent N }}
+
+Templates:
+  tlsConfig                     -- TLS config block; accepts a TLS struct directly
+  endpointWithTLS               -- endpoint and TLS config; accepts dict with "Endpoint" and "TLS" keys
+  endpointListWithSharedTLS     -- list of endpoints with shared TLS; accepts dict with "Servers" and "TLS" keys
+  monitoring                    -- metrics/monitoring server config (endpoint + TLS)
+  logging                       -- log spec and format
+  rateLimit                     -- optional rate-limit config for gRPC endpoints
+  ordererClientConfig           -- orderer client-side TLS and identity config
+  database                      -- database connection config (endpoints, credentials, TLS, pooling)
+
+Go's template only accepts a single data argument. Some templates need multiple
+values (e.g., both an endpoint and a TLS config). "dict" creates an inline map so we
+can pass multiple values as one argument:
+  dict "Endpoint" .ThisService.GrpcEndpoint "TLS" .ThisService.GrpcTLS
+produces {"Endpoint": ..., "TLS": ...}, accessible inside the template as .Endpoint and .TLS.
+*/ -}}
+
+{{- /* {{ include "tlsConfig" .ClientTLS | indent 2 }} */ -}}
+{{- define "tlsConfig" }}
+tls:
+  mode: {{ .Mode }}
+  key-path: {{ .KeyPath }}
+  cert-path: {{ .CertPath }}
+  ca-cert-paths:
+    {{- range .CACertPaths }}
+    - {{ . }}
+    {{- end }}
+{{- end }}
+
+{{- /* {{ include "endpointWithTLS" (dict "Endpoint" .ThisService.GrpcEndpoint "TLS" .ThisService.GrpcTLS) | indent 2 }} */ -}}
+{{- define "endpointWithTLS" }}
+endpoint: {{ .Endpoint }}
+{{ include "tlsConfig" .TLS | indent 0 }}
+{{- end }}
+
+{{- /* {{ include "endpointListWithSharedTLS" (dict "Servers" .Services.Verifier "TLS" .ClientTLS) | indent 2 }} */ -}}
+{{- define "endpointListWithSharedTLS" }}
+endpoints:
+  {{- range .Servers }}
+  - {{ .GrpcEndpoint }}
+  {{- end }}
+{{ include "tlsConfig" .TLS | indent 0 }}
+{{- end }}
+
+{{- /* {{ include "monitoring" . | indent 0 }} */ -}}
+{{- define "monitoring" }}
+monitoring:
+{{ include "endpointWithTLS" (dict "Endpoint" (.ThisService.MetricsEndpoint | default "localhost:0") "TLS" .ThisService.MetricsTLS) | indent 2 }}
+{{- end }}
+
+{{- /* {{ include "logging" . | indent 0 }} */ -}}
+{{- define "logging" }}
+logging:
+  logSpec: {{ .Logging.LogSpec }}
+  format: {{ .Logging.Format }}
+{{- end }}
+
+{{- /* {{ include "rateLimit" . | indent 2 }} */ -}}
+{{- define "rateLimit" }}
+{{- if .RateLimit }}
+rate-limit:
+  requests-per-second: {{ .RateLimit.RequestsPerSecond }}
+  burst: {{ .RateLimit.Burst }}
+{{- end }}
+{{- end }}
+
+{{- /* {{ include "ordererClientConfig" . | indent 0 }} */ -}}
+{{- define "ordererClientConfig" }}
+orderer:
+  fault-tolerance-level: BFT
+  latest-known-config-block-path: "{{ .Policy.ArtifactsPath }}/config-block.pb.bin"
+  tls:
+    mode: {{ .ClientTLS.Mode }}
+    cert-path: {{ .ClientTLS.CertPath }}
+    key-path: {{ .ClientTLS.KeyPath }}
+    common-ca-cert-paths:
+      {{- range .ClientTLS.CACertPaths }}
+      - {{ . }}
+      {{- end }}
+  identity:
+    msp-id: peer-org-0
+    msp-dir: {{ .Policy.ArtifactsPath }}/peerOrganizations/peer-org-0/users/client@peer-org-0.com/msp
+    bccsp:
+      Default: SW
+      SW:
+        Security: 256
+        Hash: SHA2
+{{- end }}
+
+
+{{- /* {{ include "database" . | indent 0 }} */ -}}
+{{- define "database" }}
+database:
+  endpoints:
+    {{- range .DB.Endpoints }}
+    - {{ . }}
+    {{- end }}
+  username: {{ .DB.Username }}
+  # TODO: pass password via environment variable
+  password: {{ .DB.Password }}
+  database: {{ .DB.Name }}
+  load-balance: {{ .DB.LoadBalance }}
+  tls:
+    mode: {{ .DB.TLS.Mode }}
+    ca-cert-path: {{ .DB.TLS.CACertPath }}
+  max-connections: 10
+  min-connections: 5
+  retry:
+    max-elapsed-time: 1h
+{{- end }}

--- a/cmd/config/templates/shared.yaml.tmpl
+++ b/cmd/config/templates/shared.yaml.tmpl
@@ -113,7 +113,6 @@ database:
     - {{ . }}
     {{- end }}
   username: {{ .DB.Username }}
-  # TODO: pass password via environment variable
   password: {{ .DB.Password }}
   database: {{ .DB.Name }}
   load-balance: {{ .DB.LoadBalance }}

--- a/cmd/config/templates/shared.yaml.tmpl
+++ b/cmd/config/templates/shared.yaml.tmpl
@@ -13,7 +13,8 @@ Templates:
   monitoring                    -- metrics/monitoring server config (endpoint + TLS)
   logging                       -- log spec and format
   rateLimit                     -- optional rate-limit config for gRPC endpoints
-  ordererClientConfig           -- orderer client-side TLS and identity config
+  service                       -- combined logging + monitoring + server (endpoint + TLS)
+  ordererDialConfig             -- orderer dial/connection config (TLS + identity)
   database                      -- database connection config (endpoints, credentials, TLS, pooling)
 
 Go's template only accepts a single data argument. Some templates need multiple
@@ -63,6 +64,14 @@ logging:
   format: {{ .Logging.Format }}
 {{- end }}
 
+{{- /* {{ include "service" . | indent 0 }} */ -}}
+{{- define "service" }}
+{{ include "logging" . | indent 0 }}
+{{ include "monitoring" . | indent 0 }}
+server:
+{{ include "endpointWithTLS" (dict "Endpoint" (.ThisService.GrpcEndpoint | default "localhost:0") "TLS" .ThisService.GrpcTLS) | indent 2 }}
+{{- end }}
+
 {{- /* {{ include "rateLimit" . | indent 2 }} */ -}}
 {{- define "rateLimit" }}
 {{- if .RateLimit }}
@@ -72,8 +81,8 @@ rate-limit:
 {{- end }}
 {{- end }}
 
-{{- /* {{ include "ordererClientConfig" . | indent 0 }} */ -}}
-{{- define "ordererClientConfig" }}
+{{- /* {{ include "ordererDialConfig" . | indent 0 }} */ -}}
+{{- define "ordererDialConfig" }}
 orderer:
   fault-tolerance-level: BFT
   latest-known-config-block-path: "{{ .Policy.ArtifactsPath }}/config-block.pb.bin"

--- a/cmd/config/templates/sidecar.yaml.tmpl
+++ b/cmd/config/templates/sidecar.yaml.tmpl
@@ -11,10 +11,8 @@
       min-time: 60s
       permit-without-stream: false
 {{ include "rateLimit" . | indent 2 }}
-  # Maximum number of concurrent streaming RPCs (Deliver + Notification).
-  # Set to 0 for unlimited streams (default behavior if not specified).
-  # If not set here, uses the viper default of 10.
   max-concurrent-streams: {{ .MaxConcurrentStreams | default 0 }}
+
 {{ include "ordererDialConfig" . | indent 0 }}
 
 committer:

--- a/cmd/config/templates/sidecar.yaml.tmpl
+++ b/cmd/config/templates/sidecar.yaml.tmpl
@@ -2,8 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-server:
-{{ include "endpointWithTLS" (dict "Endpoint" (.ThisService.GrpcEndpoint | default "localhost:0") "TLS" .ThisService.GrpcTLS) | indent 2 }}
+{{ include "service" . | indent 0 }}
   keep-alive:
     params:
       time: 300s
@@ -16,8 +15,7 @@ server:
   # Set to 0 for unlimited streams (default behavior if not specified).
   # If not set here, uses the viper default of 10.
   max-concurrent-streams: {{ .MaxConcurrentStreams | default 0 }}
-
-{{ include "ordererClientConfig" . | indent 0 }}
+{{ include "ordererDialConfig" . | indent 0 }}
 
 committer:
 {{ include "endpointWithTLS" (dict "Endpoint" .Services.Coordinator.GrpcEndpoint "TLS" .ClientTLS) | indent 2 }}
@@ -32,6 +30,3 @@ notification:
 last-committed-block-set-interval: 5s
 waiting-txs-limit: 20_000_000
 channel-buffer-size: 100
-
-{{ include "monitoring" . | indent 0 }}
-{{ include "logging" . | indent 0 }}

--- a/cmd/config/templates/sidecar.yaml.tmpl
+++ b/cmd/config/templates/sidecar.yaml.tmpl
@@ -3,15 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 server:
-  endpoint: {{ .ThisService.GrpcEndpoint | default "localhost:0" }}
-  tls:
-    mode: {{ .ThisService.GrpcTLS.Mode }}
-    key-path: {{ .ThisService.GrpcTLS.KeyPath }}
-    cert-path: {{ .ThisService.GrpcTLS.CertPath }}
-    ca-cert-paths:
-      {{- range .ThisService.GrpcTLS.CACertPaths }}
-      - {{ . }}
-      {{- end }}
+{{ include "endpointWithTLS" (dict "Endpoint" (.ThisService.GrpcEndpoint | default "localhost:0") "TLS" .ThisService.GrpcTLS) | indent 2 }}
   keep-alive:
     params:
       time: 300s
@@ -19,61 +11,16 @@ server:
     enforcement-policy:
       min-time: 60s
       permit-without-stream: false
-  {{- if .RateLimit }}
-  # Rate limiting configuration for unary gRPC endpoints.
-  # Uses a token bucket algorithm to limit the number of requests per second.
-  rate-limit:
-    # Maximum number of requests per second allowed.
-    # Set to 0 to disable rate limiting.
-    requests-per-second: {{ .RateLimit.RequestsPerSecond }}
-    # Maximum number of requests allowed in a single burst.
-    # Must be greater than 0 and less than or equal to requests-per-second.
-    burst: {{ .RateLimit.Burst }}
-  {{- end }}
+{{ include "rateLimit" . | indent 2 }}
   # Maximum number of concurrent streaming RPCs (Deliver + Notification).
   # Set to 0 for unlimited streams (default behavior if not specified).
   # If not set here, uses the viper default of 10.
   max-concurrent-streams: {{ .MaxConcurrentStreams | default 0 }}
-monitoring:
-  endpoint: {{ .ThisService.MetricsEndpoint | default "localhost:0" }}
-  tls:
-    mode: {{ .ThisService.MetricsTLS.Mode }}
-    key-path: {{ .ThisService.MetricsTLS.KeyPath }}
-    cert-path: {{ .ThisService.MetricsTLS.CertPath }}
-    ca-cert-paths:
-      {{- range .ThisService.MetricsTLS.CACertPaths }}
-      - {{ . }}
-      {{- end }}
 
-orderer:
-  fault-tolerance-level: BFT
-  latest-known-config-block-path: "{{ .Policy.ArtifactsPath }}/config-block.pb.bin"
-  tls:
-    mode: {{ .ClientTLS.Mode }}
-    cert-path: {{ .ClientTLS.CertPath }}
-    key-path: {{ .ClientTLS.KeyPath }}
-    common-ca-cert-paths:
-      {{- range .ClientTLS.CACertPaths }}
-      - {{ . }}
-      {{- end }}
-  identity:
-    msp-id: peer-org-0
-    msp-dir: {{ .Policy.ArtifactsPath }}/peerOrganizations/peer-org-0/users/client@peer-org-0.com/msp
-    bccsp:
-      Default: SW
-      SW:
-        Security: 256
-        Hash: SHA2
+{{ include "ordererClientConfig" . | indent 0 }}
+
 committer:
-  endpoint: {{ .Services.Coordinator.GrpcEndpoint }}
-  tls:
-    mode: {{ .ClientTLS.Mode }}
-    cert-path: {{ .ClientTLS.CertPath }}
-    key-path: {{ .ClientTLS.KeyPath }}
-    ca-cert-paths:
-      {{- range .ClientTLS.CACertPaths }}
-      - {{ . }}
-      {{- end }}
+{{ include "endpointWithTLS" (dict "Endpoint" .Services.Coordinator.GrpcEndpoint "TLS" .ClientTLS) | indent 2 }}
 
 ledger:
   path: {{ .LedgerPath }}
@@ -86,6 +33,5 @@ last-committed-block-set-interval: 5s
 waiting-txs-limit: 20_000_000
 channel-buffer-size: 100
 
-logging:
-  logSpec: {{ .Logging.LogSpec }}
-  format: {{ .Logging.Format }}
+{{ include "monitoring" . | indent 0 }}
+{{ include "logging" . | indent 0 }}

--- a/cmd/config/templates/vc.yaml.tmpl
+++ b/cmd/config/templates/vc.yaml.tmpl
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 {{ include "service" . | indent 0 }}
+
 {{ include "database" . | indent 0 }}
 
 resource-limits:

--- a/cmd/config/templates/vc.yaml.tmpl
+++ b/cmd/config/templates/vc.yaml.tmpl
@@ -2,8 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-server:
-{{ include "endpointWithTLS" (dict "Endpoint" (.ThisService.GrpcEndpoint | default "localhost:0") "TLS" .ThisService.GrpcTLS) | indent 2 }}
+{{ include "service" . | indent 0 }}
 {{ include "database" . | indent 0 }}
 
 resource-limits:
@@ -12,6 +11,3 @@ resource-limits:
   max-workers-for-committer: 20
   min-transaction-batch-size: {{ .VCMinTransactionBatchSize | default 1 }}
   timeout-for-min-transaction-batch-size: {{ .VCTimeoutForMinTransactionBatchSize | default "2s" }}
-
-{{ include "monitoring" . | indent 0 }}
-{{ include "logging" . | indent 0 }}

--- a/cmd/config/templates/vc.yaml.tmpl
+++ b/cmd/config/templates/vc.yaml.tmpl
@@ -3,43 +3,8 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 server:
-  endpoint: {{ .ThisService.GrpcEndpoint | default "localhost:0" }}
-  tls:
-    mode: {{ .ThisService.GrpcTLS.Mode }}
-    key-path: {{ .ThisService.GrpcTLS.KeyPath }}
-    cert-path: {{ .ThisService.GrpcTLS.CertPath }}
-    ca-cert-paths:
-      {{- range .ThisService.GrpcTLS.CACertPaths }}
-      - {{ . }}
-      {{- end }}
-monitoring:
-  endpoint: {{ .ThisService.MetricsEndpoint | default "localhost:0" }}
-  tls:
-    mode: {{ .ThisService.MetricsTLS.Mode }}
-    key-path: {{ .ThisService.MetricsTLS.KeyPath }}
-    cert-path: {{ .ThisService.MetricsTLS.CertPath }}
-    ca-cert-paths:
-      {{- range .ThisService.MetricsTLS.CACertPaths }}
-      - {{ . }}
-      {{- end }}
-
-database:
-  endpoints:
-    {{- range .DB.Endpoints }}
-    - {{ . }}
-    {{- end }}
-  username: {{ .DB.Username }}
-  # TODO: pass password via environment variable
-  password: {{ .DB.Password }}
-  database: {{ .DB.Name }}
-  load-balance: {{ .DB.LoadBalance }}
-  tls:
-    mode: {{ .DB.TLS.Mode }}
-    ca-cert-path: {{ .DB.TLS.CACertPath }}
-  max-connections: 10
-  min-connections: 5
-  retry:
-    max-elapsed-time: 1h
+{{ include "endpointWithTLS" (dict "Endpoint" (.ThisService.GrpcEndpoint | default "localhost:0") "TLS" .ThisService.GrpcTLS) | indent 2 }}
+{{ include "database" . | indent 0 }}
 
 resource-limits:
   max-workers-for-preparer: 1
@@ -48,6 +13,5 @@ resource-limits:
   min-transaction-batch-size: {{ .VCMinTransactionBatchSize | default 1 }}
   timeout-for-min-transaction-batch-size: {{ .VCTimeoutForMinTransactionBatchSize | default "2s" }}
 
-logging:
-  logSpec: {{ .Logging.LogSpec }}
-  format: {{ .Logging.Format }}
+{{ include "monitoring" . | indent 0 }}
+{{ include "logging" . | indent 0 }}

--- a/cmd/config/templates/verifier.yaml.tmpl
+++ b/cmd/config/templates/verifier.yaml.tmpl
@@ -3,25 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 server:
-  endpoint: {{ .ThisService.GrpcEndpoint | default "localhost:0" }}
-  tls:
-    mode: {{ .ThisService.GrpcTLS.Mode }}
-    key-path: {{ .ThisService.GrpcTLS.KeyPath }}
-    cert-path: {{ .ThisService.GrpcTLS.CertPath }}
-    ca-cert-paths:
-      {{- range .ThisService.GrpcTLS.CACertPaths }}
-      - {{ . }}
-      {{- end }}
-monitoring:
-  endpoint: {{ .ThisService.MetricsEndpoint | default "localhost:0" }}
-  tls:
-    mode: {{ .ThisService.MetricsTLS.Mode }}
-    key-path: {{ .ThisService.MetricsTLS.KeyPath }}
-    cert-path: {{ .ThisService.MetricsTLS.CertPath }}
-    ca-cert-paths:
-      {{- range .ThisService.MetricsTLS.CACertPaths }}
-      - {{ . }}
-      {{- end }}
+{{ include "endpointWithTLS" (dict "Endpoint" (.ThisService.GrpcEndpoint | default "localhost:0") "TLS" .ThisService.GrpcTLS) | indent 2 }}
 
 parallel-executor:
   parallelism: 40
@@ -29,6 +11,5 @@ parallel-executor:
   batch-size-cutoff: {{ .VerifierBatchSizeCutoff | default 50 }}
   channel-buffer-size: 50
 
-logging:
-  logSpec: {{ .Logging.LogSpec }}
-  format: {{ .Logging.Format }}
+{{ include "monitoring" . | indent 0 }}
+{{ include "logging" . | indent 0 }}

--- a/cmd/config/templates/verifier.yaml.tmpl
+++ b/cmd/config/templates/verifier.yaml.tmpl
@@ -2,14 +2,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-server:
-{{ include "endpointWithTLS" (dict "Endpoint" (.ThisService.GrpcEndpoint | default "localhost:0") "TLS" .ThisService.GrpcTLS) | indent 2 }}
-
+{{ include "service" . | indent 0 }}
 parallel-executor:
   parallelism: 40
   batch-time-cutoff: {{ .VerifierBatchTimeCutoff | default "10ms" }}
   batch-size-cutoff: {{ .VerifierBatchSizeCutoff | default 50 }}
   channel-buffer-size: 50
-
-{{ include "monitoring" . | indent 0 }}
-{{ include "logging" . | indent 0 }}

--- a/cmd/config/templates/verifier.yaml.tmpl
+++ b/cmd/config/templates/verifier.yaml.tmpl
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 {{ include "service" . | indent 0 }}
+
 parallel-executor:
   parallelism: 40
   batch-time-cutoff: {{ .VerifierBatchTimeCutoff | default "10ms" }}


### PR DESCRIPTION
#### Type of change

- Improvement (improvement to code, performance, etc)
 
#### Description

The config templates had identical blocks (TLS, endpoint, monitoring,
logging, database) copy-pasted across 14 files. While these blocks
don't change often, when they do, every copy must be updated in sync —
a tedious and error-prone process. More importantly, reading any single
template required wading through boilerplate to find the service-specific
config that actually differs.

This refactoring extracts shared patterns into named template blocks.
Each service template now reads as a concise list of composed blocks
plus its unique config, making the service-specific parts immediately
visible. When a shared pattern does need to change, it's updated in
one place.

#### Additional details (Optional)

- Extract shared template blocks into shared.yaml.tmpl:
  tlsConfig, endpointWithTLS, endpointListWithIndividualTLS,
  endpointListWithSharedTLS, monitoring, logging, rateLimit,
  ordererClientConfig, and database
- Extract loadgen-specific shared block into loadgen_shared.yaml.tmpl:
  loadgenConfig
- Add custom "include" template function to enable piping template
  output through sprig's "indent" for correct YAML nesting at any level
- Restructure loadgen templates: replace string concatenation with
  define/template composition, each loadgen variant is now a standalone
  main template referencing shared blocks
- Switch from html/template to text/template (correct for YAML generation)

#### Related issues

 - resolves #326 
