### PR TITLE
[test] fail faster

### DIFF
--- a/cmd/cliutil/test_exports.go
+++ b/cmd/cliutil/test_exports.go
@@ -12,7 +12,6 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
@@ -21,6 +20,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/hyperledger/fabric-x-committer/cmd/config"
 	"github.com/hyperledger/fabric-x-committer/loadgen/workload"
@@ -126,47 +126,41 @@ func UnitTestRunner(
 	cmd.SetOut(&cmdStdOut)
 	cmd.SetErr(&cmdStdErr)
 
-	wg := &sync.WaitGroup{}
-	t.Cleanup(func() {
-		t.Log("Waiting for command to finish")
-		wg.Wait()
-	})
-
 	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Minute)
 	t.Cleanup(cancel)
 
-	cmdDone := make(chan any)
-	wg.Go(func() {
+	g, ctx := errgroup.WithContext(ctx)
+	g.Go(func() error {
 		t.Logf("Starting command: %s", args[0])
 		defer t.Logf("Command exited: %s", args[0])
-		defer close(cmdDone)
+		defer cancel()
 		_, execErr := cmd.ExecuteContextC(ctx)
-		execErr = connection.FilterStreamRPCError(execErr)
-		if cmdTest.Err == nil {
-			assert.NoError(t, execErr)
-		} else if assert.Error(t, execErr) {
-			assert.Equal(t, cmdTest.Err.Error(), execErr.Error())
-		}
+		return connection.FilterStreamRPCError(execErr)
 	})
 
 	assert.Eventually(t, func() bool {
 		if len(missingExpectedOutputs(cmdTest, cmdStdOut.String(), cmdStdErr.String(), loggerPath)) == 0 {
 			return true
 		}
-		// If the command has already exited but expected outputs are still missing,
-		// fail fast — they will never appear.
+		// If the context is done (command exited or timed out) but expected
+		// outputs are still missing, fail fast — they will never appear.
 		select {
-		case <-cmdDone:
+		case <-ctx.Done():
 			t.Fatalf("Command exited before expected output appeared.\nSTD ERR: %s\nSTD OUT: %s",
 				cmdStdErr.String(), cmdStdOut.String())
 		default:
 		}
 		return false
-	}, 10*time.Minute, 500*time.Millisecond)
+	}, 2*time.Minute, 500*time.Millisecond)
 
 	t.Log("Stopping command, and waiting for finish")
 	cancel()
-	wg.Wait()
+	execErr := g.Wait()
+	if cmdTest.Err == nil {
+		assert.NoError(t, execErr)
+	} else if assert.Error(t, execErr) {
+		assert.Equal(t, cmdTest.Err.Error(), execErr.Error())
+	}
 	if !t.Failed() {
 		return
 	}

--- a/cmd/cliutil/test_exports.go
+++ b/cmd/cliutil/test_exports.go
@@ -135,9 +135,11 @@ func UnitTestRunner(
 	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Minute)
 	t.Cleanup(cancel)
 
+	cmdDone := make(chan any)
 	wg.Go(func() {
 		t.Logf("Starting command: %s", args[0])
 		defer t.Logf("Command exited: %s", args[0])
+		defer close(cmdDone)
 		_, execErr := cmd.ExecuteContextC(ctx)
 		execErr = connection.FilterStreamRPCError(execErr)
 		if cmdTest.Err == nil {
@@ -148,7 +150,18 @@ func UnitTestRunner(
 	})
 
 	assert.Eventually(t, func() bool {
-		return len(getMissing(cmdTest, cmdStdOut.String(), cmdStdErr.String(), loggerPath)) == 0
+		if len(missingExpectedOutputs(cmdTest, cmdStdOut.String(), cmdStdErr.String(), loggerPath)) == 0 {
+			return true
+		}
+		// If the command has already exited but expected outputs are still missing,
+		// fail fast — they will never appear.
+		select {
+		case <-cmdDone:
+			t.Fatalf("Command exited before expected output appeared.\nSTD ERR: %s\nSTD OUT: %s",
+				cmdStdErr.String(), cmdStdOut.String())
+		default:
+		}
+		return false
 	}, 10*time.Minute, 500*time.Millisecond)
 
 	t.Log("Stopping command, and waiting for finish")
@@ -165,7 +178,7 @@ func UnitTestRunner(
 	if err == nil {
 		t.Log("LOG:\n", string(logOut))
 	}
-	for _, m := range getMissing(cmdTest, cmdStdOut.String(), cmdStdErr.String(), loggerPath) {
+	for _, m := range missingExpectedOutputs(cmdTest, cmdStdOut.String(), cmdStdErr.String(), loggerPath) {
 		t.Logf("Missing: %s", m)
 	}
 }
@@ -185,21 +198,21 @@ func defaultTestDBConfig() config.DatabaseConfig {
 	}
 }
 
-func getMissing(cmdTest CommandTest, cmdStdOut, cmdStdErr, loggerPath string) (missing []string) {
-	if cmdTest.CmdStdOutput != "" && !strings.Contains(cmdStdOut, cmdTest.CmdStdOutput) {
-		missing = append(missing, cmdTest.CmdStdOutput)
+func missingExpectedOutputs(expected CommandTest, stdout, stderr, logFilePath string) (missing []string) {
+	if expected.CmdStdOutput != "" && !strings.Contains(stdout, expected.CmdStdOutput) {
+		missing = append(missing, expected.CmdStdOutput)
 	}
-	if cmdTest.CmdStdErrOutput != "" && !strings.Contains(cmdStdErr, cmdTest.CmdStdErrOutput) {
-		missing = append(missing, cmdTest.CmdStdErrOutput)
+	if expected.CmdStdErrOutput != "" && !strings.Contains(stderr, expected.CmdStdErrOutput) {
+		missing = append(missing, expected.CmdStdErrOutput)
 	}
-	if len(cmdTest.CmdLoggerOutputs) == 0 {
+	if len(expected.CmdLoggerOutputs) == 0 {
 		return missing
 	}
-	logOut, err := os.ReadFile(loggerPath)
+	logOut, err := os.ReadFile(logFilePath)
 	if err != nil {
-		return append(missing, loggerPath)
+		return append(missing, logFilePath)
 	}
-	for _, loggerLine := range cmdTest.CmdLoggerOutputs {
+	for _, loggerLine := range expected.CmdLoggerOutputs {
 		if !strings.Contains(string(logOut), loggerLine) {
 			missing = append(missing, loggerLine)
 		}

--- a/integration/runner/process.go
+++ b/integration/runner/process.go
@@ -26,7 +26,6 @@ type (
 		params         CmdParameters
 		process        ifrit.Process
 		configFilePath string
-		exitCh         chan error
 	}
 
 	// CmdParameters holds the parameters for a command.
@@ -116,7 +115,7 @@ func (p *ProcessWithConfig) Stop(t *testing.T) {
 	}
 	p.process.Signal(os.Kill)
 	select {
-	case <-p.exitCh:
+	case <-p.process.Wait():
 	case <-time.After(30 * time.Second):
 		t.Errorf("Process [%s] did not terminate after 30 seconds", p.params.Name)
 	}
@@ -126,14 +125,12 @@ func (p *ProcessWithConfig) Stop(t *testing.T) {
 // requireRunning fails the test immediately if the process has already exited.
 func (p *ProcessWithConfig) requireRunning(t *testing.T) {
 	t.Helper()
-	if p == nil || p.exitCh == nil {
+	if p == nil || p.process == nil {
 		return
 	}
 
 	select {
-	case err := <-p.exitCh:
-		// Put the error back so subsequent calls also see it.
-		p.exitCh <- err
+	case err := <-p.process.Wait():
 		t.Fatalf("Process [%s] exited unexpectedly: %v", p.params.Name, err)
 	default:
 	}
@@ -149,9 +146,4 @@ func (p *ProcessWithConfig) Restart(t *testing.T) {
 	require.NoError(t, err)
 	c.Dir = path.Clean(path.Join(dir, "../.."))
 	p.process = test.Run(c, p.params.Name, "")
-
-	p.exitCh = make(chan error, 1)
-	go func() {
-		p.exitCh <- <-p.process.Wait()
-	}()
 }

--- a/integration/runner/process.go
+++ b/integration/runner/process.go
@@ -26,6 +26,7 @@ type (
 		params         CmdParameters
 		process        ifrit.Process
 		configFilePath string
+		exitCh         chan error
 	}
 
 	// CmdParameters holds the parameters for a command.
@@ -115,9 +116,26 @@ func (p *ProcessWithConfig) Stop(t *testing.T) {
 	}
 	p.process.Signal(os.Kill)
 	select {
-	case <-p.process.Wait():
+	case <-p.exitCh:
 	case <-time.After(30 * time.Second):
 		t.Errorf("Process [%s] did not terminate after 30 seconds", p.params.Name)
+	}
+	p.process = nil
+}
+
+// requireRunning fails the test immediately if the process has already exited.
+func (p *ProcessWithConfig) requireRunning(t *testing.T) {
+	t.Helper()
+	if p == nil || p.exitCh == nil {
+		return
+	}
+
+	select {
+	case err := <-p.exitCh:
+		// Put the error back so subsequent calls also see it.
+		p.exitCh <- err
+		t.Fatalf("Process [%s] exited unexpectedly: %v", p.params.Name, err)
+	default:
 	}
 }
 
@@ -131,4 +149,9 @@ func (p *ProcessWithConfig) Restart(t *testing.T) {
 	require.NoError(t, err)
 	c.Dir = path.Clean(path.Join(dir, "../.."))
 	p.process = test.Run(c, p.params.Name, "")
+
+	p.exitCh = make(chan error, 1)
+	go func() {
+		p.exitCh <- <-p.process.Wait()
+	}()
 }

--- a/integration/runner/runtime.go
+++ b/integration/runner/runtime.go
@@ -596,7 +596,7 @@ func (c *CommitterRuntime) ensureAtLeastLastCommittedBlockNumber(t *testing.T, b
 	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Minute)
 	defer cancel()
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
-		c.requireProcessesRunning(t)
+		c.requireAllServicesAreRunning(t)
 		nextBlock, err := c.CoordinatorClient.GetNextBlockNumberToCommit(ctx, nil)
 		require.NoError(ct, err)
 		require.NotNil(ct, nextBlock)
@@ -604,8 +604,8 @@ func (c *CommitterRuntime) ensureAtLeastLastCommittedBlockNumber(t *testing.T, b
 	}, 2*time.Minute, 250*time.Millisecond)
 }
 
-// requireProcessesRunning fails the test if any managed process has exited unexpectedly.
-func (c *CommitterRuntime) requireProcessesRunning(t *testing.T) {
+// requireAllServicesAreRunning fails the test if any managed process has exited unexpectedly.
+func (c *CommitterRuntime) requireAllServicesAreRunning(t *testing.T) {
 	t.Helper()
 	c.MockOrderer.requireRunning(t)
 	c.Coordinator.requireRunning(t)

--- a/integration/runner/runtime.go
+++ b/integration/runner/runtime.go
@@ -596,11 +596,27 @@ func (c *CommitterRuntime) ensureAtLeastLastCommittedBlockNumber(t *testing.T, b
 	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Minute)
 	defer cancel()
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		c.requireProcessesRunning(t)
 		nextBlock, err := c.CoordinatorClient.GetNextBlockNumberToCommit(ctx, nil)
 		require.NoError(ct, err)
 		require.NotNil(ct, nextBlock)
 		require.Greater(ct, nextBlock.Number, blkNum)
 	}, 2*time.Minute, 250*time.Millisecond)
+}
+
+// requireProcessesRunning fails the test if any managed process has exited unexpectedly.
+func (c *CommitterRuntime) requireProcessesRunning(t *testing.T) {
+	t.Helper()
+	c.MockOrderer.requireRunning(t)
+	c.Coordinator.requireRunning(t)
+	c.Sidecar.requireRunning(t)
+	c.QueryService.requireRunning(t)
+	for _, p := range c.Verifier {
+		p.requireRunning(t)
+	}
+	for _, p := range c.VcService {
+		p.requireRunning(t)
+	}
 }
 
 func isMoreThanOneBitSet(bits int) bool {


### PR DESCRIPTION
#### Type of change

- Test update
 
#### Description

When a service fails to start during integration tests or cmd test (e.g., config parse error, port binding failure), the test waits the full require.Eventually timeout before declaring failure. This commit check if the process has exited or if stderr contains an error. If so, call t.Fatal with the stderr content. This short-circuits the polling loop on
the first iteration that detects the failure 

#### Related issues

 - resolves #533 
 - resolves #532 