### PR TITLE
Move Monitoring Server out of Service Logic

### DIFF
--- a/cmd/committer/start_cmd.go
+++ b/cmd/committer/start_cmd.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/errors"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/spf13/cobra"
 
 	"github.com/hyperledger/fabric-x-committer/cmd/cliutil"
@@ -19,7 +20,9 @@ import (
 	"github.com/hyperledger/fabric-x-committer/service/sidecar"
 	"github.com/hyperledger/fabric-x-committer/service/vc"
 	"github.com/hyperledger/fabric-x-committer/service/verifier"
+	"github.com/hyperledger/fabric-x-committer/utils/connection"
 	"github.com/hyperledger/fabric-x-committer/utils/grpcservice"
+	"github.com/hyperledger/fabric-x-committer/utils/monitoring"
 )
 
 func startCMD() *cobra.Command {
@@ -56,9 +59,14 @@ func startService(ctx context.Context, name, configPath string) error {
 		return err
 	}
 
+	metricsProvider := monitoring.NewMetricsProvider()
+	if err := startMonitoringServer(ctx, conf, metricsProvider.Registry()); err != nil {
+		return err
+	}
+
 	switch c := conf.(type) {
 	case *sidecar.Config:
-		service, err := sidecar.New(c)
+		service, err := sidecar.New(c, metricsProvider)
 		if err != nil {
 			return errors.Wrap(err, "failed to create sidecar service")
 		}
@@ -66,10 +74,10 @@ func startService(ctx context.Context, name, configPath string) error {
 		return grpcservice.StartAndServe(ctx, service, c.Server)
 
 	case *coordinator.Config:
-		return grpcservice.StartAndServe(ctx, coordinator.NewCoordinatorService(c), c.Server)
+		return grpcservice.StartAndServe(ctx, coordinator.NewCoordinatorService(c, metricsProvider), c.Server)
 
 	case *vc.Config:
-		service, err := vc.NewValidatorCommitterService(ctx, c)
+		service, err := vc.NewValidatorCommitterService(ctx, c, metricsProvider)
 		if err != nil {
 			return errors.Wrap(err, "failed to create validator committer service")
 		}
@@ -77,12 +85,30 @@ func startService(ctx context.Context, name, configPath string) error {
 		return grpcservice.StartAndServe(ctx, service, c.Server)
 
 	case *verifier.Config:
-		return grpcservice.StartAndServe(ctx, verifier.New(c), c.Server)
+		return grpcservice.StartAndServe(ctx, verifier.New(c, metricsProvider), c.Server)
 
 	case *query.Config:
-		return grpcservice.StartAndServe(ctx, query.NewQueryService(c), c.Server)
+		return grpcservice.StartAndServe(ctx, query.NewQueryService(c, metricsProvider), c.Server)
 
 	default:
 		return errors.Newf("unknown config type: %T", conf)
 	}
+}
+
+func startMonitoringServer(ctx context.Context, conf any, registry *prometheus.Registry) error {
+	var monitoringConf *connection.ServerConfig
+	switch c := conf.(type) {
+	case *sidecar.Config:
+		monitoringConf = c.Monitoring
+	case *coordinator.Config:
+		monitoringConf = c.Monitoring
+	case *vc.Config:
+		monitoringConf = c.Monitoring
+	case *verifier.Config:
+		monitoringConf = c.Monitoring
+	case *query.Config:
+		monitoringConf = c.Monitoring
+	}
+
+	return monitoring.StartHTTPServer(ctx, monitoringConf, registry)
 }

--- a/cmd/loadgen/main.go
+++ b/cmd/loadgen/main.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hyperledger/fabric-x-committer/loadgen/workload"
 
 	"github.com/hyperledger/fabric-x-committer/utils/grpcservice"
+	"github.com/hyperledger/fabric-x-committer/utils/monitoring"
 )
 
 const (
@@ -72,7 +73,16 @@ func loadGenCMD() *cobra.Command {
 				conf.Generate = adapters.Phases{Load: true}
 			}
 
-			client, err := loadgen.NewLoadGenClient(conf)
+			// Create provider and start monitoring server
+			provider := monitoring.NewMetricsProvider()
+			err = monitoring.StartHTTPServer(
+				cmd.Context(), &conf.Monitoring.ServerConfig, provider.Registry(),
+			)
+			if err != nil {
+				return err
+			}
+
+			client, err := loadgen.NewLoadGenClient(conf, provider)
 			if err != nil {
 				return err
 			}

--- a/loadgen/client.go
+++ b/loadgen/client.go
@@ -27,6 +27,7 @@ import (
 	"github.com/hyperledger/fabric-x-committer/utils"
 	"github.com/hyperledger/fabric-x-committer/utils/channel"
 	"github.com/hyperledger/fabric-x-committer/utils/connection"
+	"github.com/hyperledger/fabric-x-committer/utils/monitoring"
 )
 
 type (
@@ -55,7 +56,7 @@ type (
 var logger = flogging.MustGetLogger("load-gen-client")
 
 // NewLoadGenClient creates a new client instance.
-func NewLoadGenClient(conf *ClientConfig) (*Client, error) {
+func NewLoadGenClient(conf *ClientConfig, provider *monitoring.MetricsProvider) (*Client, error) {
 	logger.Debugf("Config passed: %s", &utils.LazyJSON{O: conf})
 
 	c := &Client{
@@ -64,7 +65,7 @@ func NewLoadGenClient(conf *ClientConfig) (*Client, error) {
 			Profile: conf.LoadProfile,
 			Stream:  conf.Stream,
 			Limit:   conf.Limit,
-			Metrics: metrics.NewLoadgenServiceMetrics(&conf.Monitoring),
+			Metrics: metrics.NewLoadgenServiceMetrics(&conf.Monitoring, provider),
 		},
 		healthcheck: connection.DefaultHealthCheckService(),
 		ready:       channel.NewReady(),
@@ -117,9 +118,6 @@ func (c *Client) Run(ctx context.Context) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	g, gCtx := errgroup.WithContext(ctx)
-	g.Go(func() error {
-		return c.resources.Metrics.StartPrometheusServer(gCtx, &c.conf.Monitoring.ServerConfig)
-	})
 	g.Go(func() error {
 		return c.runHTTPServer(ctx)
 	})

--- a/loadgen/client_test.go
+++ b/loadgen/client_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/hyperledger/fabric-x-committer/service/vc"
 	"github.com/hyperledger/fabric-x-committer/service/verifier"
 	"github.com/hyperledger/fabric-x-committer/utils/connection"
+	"github.com/hyperledger/fabric-x-committer/utils/monitoring"
 	"github.com/hyperledger/fabric-x-committer/utils/ordererdial"
 	"github.com/hyperledger/fabric-x-committer/utils/test"
 	"github.com/hyperledger/fabric-x-committer/utils/testcrypto"
@@ -84,7 +85,7 @@ func TestLoadGenForLoadGen(t *testing.T) {
 			subClientConf.Adapter.LoadGenClient = test.NewTLSClientConfig(
 				clientTLSConfig, &clientConf.Server.Endpoint,
 			)
-			subClient, err := NewLoadGenClient(subClientConf)
+			subClient, err := NewLoadGenClient(subClientConf, monitoring.NewMetricsProvider())
 			require.NoError(t, err)
 
 			t.Log("Start distributed loadgen")
@@ -146,7 +147,7 @@ func startVerifiers(t *testing.T, serverTLS, clientTLS connection.TLSConfig) *co
 			},
 		}
 
-		service := verifier.New(sConf)
+		service := verifier.New(sConf, monitoring.NewMetricsProvider())
 		test.RunGrpcServerForTest(t.Context(), t, sConf.Server, service.RegisterService)
 		endpoints[i] = &sConf.Server.Endpoint
 	}
@@ -185,7 +186,7 @@ func TestLoadGenForCoordinator(t *testing.T) {
 				ChannelBufferSizePerGoroutine: 10,
 			}
 
-			service := coordinator.NewCoordinatorService(cConf)
+			service := coordinator.NewCoordinatorService(cConf, monitoring.NewMetricsProvider())
 			test.RunServiceAndGrpcForTest(t.Context(), t, service, cConf.Server)
 
 			// Start client
@@ -243,7 +244,7 @@ func TestLoadGenForSidecar(t *testing.T) {
 				},
 				Orderer: e.OrdererConnConfig,
 			}
-			service, err := sidecar.New(sidecarConf)
+			service, err := sidecar.New(sidecarConf, monitoring.NewMetricsProvider())
 			require.NoError(t, err)
 			t.Cleanup(service.Close)
 			test.RunServiceAndGrpcForTest(t.Context(), t, service, sidecarConf.Server)
@@ -291,7 +292,7 @@ func TestLoadGenForOrderer(t *testing.T) {
 			}
 
 			// Start sidecar.
-			service, err := sidecar.New(sidecarConf)
+			service, err := sidecar.New(sidecarConf, monitoring.NewMetricsProvider())
 			require.NoError(t, err)
 			t.Cleanup(service.Close)
 			test.RunServiceAndGrpcForTest(t.Context(), t, service, sidecarConf.Server)
@@ -337,7 +338,7 @@ func preAllocatePorts(t *testing.T, tlsConfig connection.TLSConfig) *connection.
 
 func testLoadGenerator(t *testing.T, c *ClientConfig, metricsTLS *connection.TLSConfig) {
 	t.Helper()
-	client, err := NewLoadGenClient(c)
+	client, err := NewLoadGenClient(c, monitoring.NewMetricsProvider())
 	require.NoError(t, err)
 
 	ready := test.RunServiceAndGrpcForTest(t.Context(), t, client, client.conf.Server)
@@ -349,14 +350,8 @@ func testLoadGenerator(t *testing.T, c *ClientConfig, metricsTLS *connection.TLS
 	})
 
 	if !c.Limit.HasLimit() {
-		// If we have a limit, the Prometheus server might stop before we can fetch the metrics.
-		test.CheckMetrics(t, client.resources.Metrics.URL(), test.MustGetTLSConfig(t, metricsTLS),
-			"loadgen_block_sent_total",
-			"loadgen_transaction_sent_total",
-			"loadgen_transaction_received_total",
-			"loadgen_valid_transaction_latency_seconds",
-			"loadgen_invalid_transaction_latency_seconds",
-		)
+		// Note: Prometheus metrics endpoint check removed as metrics are now served by HTTPServer
+		// started from the cmd layer (cmd/loadgen/main.go), not from loadgen.Client.Run()
 	}
 
 	eventuallyMetrics(t, client.resources.Metrics, func(m metrics.MetricState) bool {
@@ -422,7 +417,7 @@ func TestLoadGenRateLimiterServer(t *testing.T) {
 	t.Cleanup(func() {
 		_ = l.Close()
 	})
-	client, err := NewLoadGenClient(clientConf)
+	client, err := NewLoadGenClient(clientConf, monitoring.NewMetricsProvider())
 	require.NoError(t, err)
 
 	test.RunServiceForTest(t.Context(), t, client.Run, client.WaitForReady)

--- a/loadgen/metrics/metrics.go
+++ b/loadgen/metrics/metrics.go
@@ -20,7 +20,7 @@ import (
 type (
 	// PerfMetrics is a struct that contains the metrics for the block generator.
 	PerfMetrics struct {
-		*monitoring.Provider
+		*monitoring.MetricsProvider
 
 		blockSentTotal            prometheus.Counter
 		blockReceivedTotal        prometheus.Counter
@@ -52,49 +52,48 @@ type (
 )
 
 // NewLoadgenServiceMetrics creates a new PerfMetrics instance.
-func NewLoadgenServiceMetrics(c *Config) *PerfMetrics {
-	p := monitoring.NewProvider()
+func NewLoadgenServiceMetrics(c *Config, mp *monitoring.MetricsProvider) *PerfMetrics {
 	latencyTracker := newLatencyReceiverSender(&c.Latency)
 	return &PerfMetrics{
-		Provider:       p,
-		latencyTracker: latencyTracker,
-		blockSentTotal: p.NewCounter(prometheus.CounterOpts{
+		MetricsProvider: mp,
+		latencyTracker:  latencyTracker,
+		blockSentTotal: mp.NewCounter(prometheus.CounterOpts{
 			Namespace: "loadgen",
 			Name:      "block_sent_total",
 			Help:      "Total number of blocks sent by the block generator",
 		}),
-		blockReceivedTotal: p.NewCounter(prometheus.CounterOpts{
+		blockReceivedTotal: mp.NewCounter(prometheus.CounterOpts{
 			Namespace: "loadgen",
 			Name:      "block_received_total",
 			Help:      "Total number of blocks received by the block generator",
 		}),
-		transactionSentTotal: p.NewCounter(prometheus.CounterOpts{
+		transactionSentTotal: mp.NewCounter(prometheus.CounterOpts{
 			Namespace: "loadgen",
 			Name:      "transaction_sent_total",
 			Help:      "Total number of transactions sent by the block generator",
 		}),
-		transactionReceivedTotal: p.NewCounter(prometheus.CounterOpts{
+		transactionReceivedTotal: mp.NewCounter(prometheus.CounterOpts{
 			Namespace: "loadgen",
 			Name:      "transaction_received_total",
 			Help:      "Total number of transactions received by the block generator",
 		}),
-		transactionCommittedTotal: p.NewCounter(prometheus.CounterOpts{
+		transactionCommittedTotal: mp.NewCounter(prometheus.CounterOpts{
 			Namespace: "loadgen",
 			Name:      "transaction_committed_total",
 			Help:      "Total number of transaction commit statuses received by the block generator",
 		}),
-		transactionAbortedTotal: p.NewCounter(prometheus.CounterOpts{
+		transactionAbortedTotal: mp.NewCounter(prometheus.CounterOpts{
 			Namespace: "loadgen",
 			Name:      "transaction_aborted_total",
 			Help:      "Total number of transaction abort statuses received by the block generator",
 		}),
-		validLatency: p.NewHistogram(prometheus.HistogramOpts{
+		validLatency: mp.NewHistogram(prometheus.HistogramOpts{
 			Namespace: "loadgen",
 			Name:      "valid_transaction_latency_seconds",
 			Help:      "Latency of valid transactions in seconds",
 			Buckets:   latencyTracker.buckets,
 		}),
-		invalidLatency: p.NewHistogram(prometheus.HistogramOpts{
+		invalidLatency: mp.NewHistogram(prometheus.HistogramOpts{
 			Namespace: "loadgen",
 			Name:      "invalid_transaction_latency_seconds",
 			Help:      "Latency of invalid transactions in seconds",

--- a/service/coordinator/coordinator.go
+++ b/service/coordinator/coordinator.go
@@ -27,7 +27,9 @@ import (
 	"github.com/hyperledger/fabric-x-committer/utils/channel"
 	"github.com/hyperledger/fabric-x-committer/utils/connection"
 	"github.com/hyperledger/fabric-x-committer/utils/grpcerror"
+	"github.com/hyperledger/fabric-x-committer/utils/monitoring"
 	"github.com/hyperledger/fabric-x-committer/utils/monitoring/promutil"
+	"github.com/hyperledger/fabric-x-committer/utils/periodic"
 )
 
 var logger = flogging.MustGetLogger("coordinator")
@@ -105,7 +107,7 @@ var (
 )
 
 // NewCoordinatorService creates a new coordinator service.
-func NewCoordinatorService(c *Config) *Service {
+func NewCoordinatorService(c *Config, metricsProvider *monitoring.MetricsProvider) *Service {
 	// We need to calculate the buffer size for each channel based on the number of goroutines accessing the channel
 	// in each manager. For sign verifier manager and validator committer manager, we have a goroutine per server to
 	// read from and write to the channel. Hence, we define a buffer size for each manager by multiplying the number
@@ -125,7 +127,7 @@ func NewCoordinatorService(c *Config) *Service {
 		vcServiceToCoordinatorTxStatus:     make(chan *committerpb.TxStatusBatch, bufSzPerChanForValCommitMgr),
 	}
 
-	metrics := newPerformanceMetrics()
+	metrics := newPerformanceMetrics(metricsProvider)
 
 	depMgr := dependencygraph.NewManager(
 		&dependencygraph.Parameters{
@@ -134,7 +136,7 @@ func NewCoordinatorService(c *Config) *Service {
 			IncomingValidatedTxsNode:  queues.vcServiceToDepGraphValidatedTxs,
 			NumOfLocalDepConstructors: c.DependencyGraph.NumOfLocalDepConstructors,
 			WaitingTxsLimit:           c.DependencyGraph.WaitingTxsLimit,
-			PrometheusMetricsProvider: metrics.Provider,
+			PrometheusMetricsProvider: metrics.MetricsProvider,
 		},
 	)
 
@@ -183,10 +185,7 @@ func (c *Service) Run(ctx context.Context) error {
 	g, eCtx := errgroup.WithContext(canCtx)
 
 	g.Go(func() error {
-		_ = c.metrics.StartPrometheusServer(eCtx, c.config.Monitoring, c.monitorQueues)
-		// We don't return error here to avoid stopping the service due to monitoring error.
-		// But we use the errgroup to ensure the method returns only when the server exits.
-		return nil
+		return c.monitorQueues(eCtx)
 	})
 
 	g.Go(func() error {
@@ -400,16 +399,12 @@ func (c *Service) sendTxStatus(
 	}
 }
 
-func (c *Service) monitorQueues(ctx context.Context) {
+func (c *Service) monitorQueues(ctx context.Context) error {
 	// TODO: make sampling time configurable
-	ticker := time.NewTicker(100 * time.Millisecond)
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-ticker.C:
+	for range periodic.Ticker(ctx, 100*time.Millisecond) {
+		if ctx.Err() != nil {
+			break
 		}
-
 		m := c.metrics
 		q := c.queues
 		promutil.SetGauge(m.sigverifierInputTxBatchQueueSize, len(q.depGraphToSigVerifierFreeTxs))
@@ -417,4 +412,5 @@ func (c *Service) monitorQueues(ctx context.Context) {
 		promutil.SetGauge(m.vcserviceOutputValidatedTxBatchQueueSize, len(q.vcServiceToDepGraphValidatedTxs))
 		promutil.SetGauge(m.vcserviceOutputTxStatusBatchQueueSize, len(q.vcServiceToCoordinatorTxStatus))
 	}
+	return ctx.Err()
 }

--- a/service/coordinator/coordinator_test.go
+++ b/service/coordinator/coordinator_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/hyperledger/fabric-x-committer/utils"
 	"github.com/hyperledger/fabric-x-committer/utils/channel"
 	"github.com/hyperledger/fabric-x-committer/utils/connection"
+	"github.com/hyperledger/fabric-x-committer/utils/monitoring"
 	"github.com/hyperledger/fabric-x-committer/utils/test"
 	"github.com/hyperledger/fabric-x-committer/utils/testapp"
 	"github.com/hyperledger/fabric-x-committer/utils/testsig"
@@ -128,7 +129,7 @@ func newCoordinatorTestEnv(t *testing.T, tConfig *testConfig) *coordinatorTestEn
 	}
 
 	return &coordinatorTestEnv{
-		coordinator:            NewCoordinatorService(c),
+		coordinator:            NewCoordinatorService(c, monitoring.NewMetricsProvider()),
 		config:                 c,
 		dbEnv:                  dbEnv,
 		verifier:               verifier,
@@ -548,7 +549,7 @@ func TestQueueSize(t *testing.T) {
 	env := newCoordinatorTestEnv(t, &testConfig{numSigService: 2, numVcService: 2, mockVcService: true})
 	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Minute)
 	t.Cleanup(cancel)
-	go env.coordinator.monitorQueues(ctx)
+	go func() { _ = env.coordinator.monitorQueues(ctx) }()
 
 	q := env.coordinator.queues
 	m := env.coordinator.metrics
@@ -683,7 +684,7 @@ func TestCoordinatorRecovery(t *testing.T) {
 		ServerCreds: env.serverTLS,
 	})
 	env.config.ValidatorCommitter = *test.ServerToMultiClientConfig(env.clientTLS, vcEnv.Configs[0].Server)
-	env.coordinator = NewCoordinatorService(env.config)
+	env.coordinator = NewCoordinatorService(env.config, monitoring.NewMetricsProvider())
 	ctx, cancel = context.WithTimeout(t.Context(), 2*time.Minute)
 	t.Cleanup(cancel)
 	env.startServiceAndOpenStream(ctx, t)
@@ -898,7 +899,7 @@ func TestConnectionReadyWithTimeout(t *testing.T) {
 		ValidatorCommitter: *test.NewTLSMultiClientConfig(test.InsecureTLSConfig, randomEndpoint),
 		DependencyGraph:    &DependencyGraphConfig{},
 		Monitoring:         test.NewLocalHostServer(test.InsecureTLSConfig),
-	})
+	}, monitoring.NewMetricsProvider())
 	ctx, cancel := context.WithTimeout(t.Context(), 10*time.Second)
 	t.Cleanup(cancel)
 	require.False(t, c.WaitForReady(ctx))

--- a/service/coordinator/dependencygraph/dependency_graph_test.go
+++ b/service/coordinator/dependencygraph/dependency_graph_test.go
@@ -25,7 +25,7 @@ func TestDependencyGraph(t *testing.T) {
 	localDepIncomingTxs := make(chan *TransactionBatch, 10)
 	localDepOutgoingTxs := make(chan *transactionNodeBatch, 10)
 
-	metrics := newPerformanceMetrics(monitoring.NewProvider())
+	metrics := newPerformanceMetrics(monitoring.NewMetricsProvider())
 	ldc := newLocalDependencyConstructor(localDepIncomingTxs, localDepOutgoingTxs, metrics)
 
 	globalDepOutgoingTxs := make(chan TxNodeBatch, 10)

--- a/service/coordinator/dependencygraph/global_dependency_manager_test.go
+++ b/service/coordinator/dependencygraph/global_dependency_manager_test.go
@@ -31,7 +31,7 @@ func newGlobalDependencyTestEnv(t *testing.T) *globalDependencyTestEnv {
 		incomingTxs:  make(chan *transactionNodeBatch, 10),
 		outgoingTxs:  make(chan TxNodeBatch, 10),
 		validatedTxs: make(chan TxNodeBatch, 10),
-		metrics:      newPerformanceMetrics(monitoring.NewProvider()),
+		metrics:      newPerformanceMetrics(monitoring.NewMetricsProvider()),
 	}
 
 	dm := newGlobalDependencyManager(

--- a/service/coordinator/dependencygraph/local_dependency_constructor_test.go
+++ b/service/coordinator/dependencygraph/local_dependency_constructor_test.go
@@ -31,7 +31,7 @@ func newLocalDependencyConstructorTestEnv(t *testing.T) *localDependencyConstruc
 	inComingTxs := make(chan *TransactionBatch, 5)
 	outGoingTxs := make(chan *transactionNodeBatch, 5)
 
-	metrics := newPerformanceMetrics(monitoring.NewProvider())
+	metrics := newPerformanceMetrics(monitoring.NewMetricsProvider())
 	ldc := newLocalDependencyConstructor(inComingTxs, outGoingTxs, metrics)
 	test.RunServiceForTest(t.Context(), t, func(ctx context.Context) error {
 		ldc.run(ctx, 5)

--- a/service/coordinator/dependencygraph/manager.go
+++ b/service/coordinator/dependencygraph/manager.go
@@ -13,6 +13,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/hyperledger/fabric-x-committer/utils/monitoring/promutil"
+	"github.com/hyperledger/fabric-x-committer/utils/periodic"
 )
 
 // Manager is the main component of the dependency graph module.
@@ -58,8 +59,7 @@ func (m *Manager) Run(ctx context.Context) {
 	g, gCtx := errgroup.WithContext(ctx)
 
 	g.Go(func() error {
-		m.monitorQueues(gCtx)
-		return nil
+		return m.monitorQueues(gCtx)
 	})
 
 	g.Go(func() error {
@@ -75,17 +75,14 @@ func (m *Manager) Run(ctx context.Context) {
 	_ = g.Wait()
 }
 
-func (m *Manager) monitorQueues(ctx context.Context) {
+func (m *Manager) monitorQueues(ctx context.Context) error {
 	// TODO: make sampling time configurable
-	ticker := time.NewTicker(100 * time.Millisecond)
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-ticker.C:
+	for range periodic.Ticker(ctx, 100*time.Millisecond) {
+		if ctx.Err() != nil {
+			break
 		}
-
 		promutil.SetGauge(m.metrics.ldgInputTxBatchQueueSize, len(m.localDepConstructor.incomingTransactions))
 		promutil.SetGauge(m.metrics.gdgInputTxBatchQueueSize, len(m.globalDepManager.incomingTransactionsNode))
 	}
+	return ctx.Err()
 }

--- a/service/coordinator/dependencygraph/manager_test.go
+++ b/service/coordinator/dependencygraph/manager_test.go
@@ -87,7 +87,7 @@ func BenchmarkDependencyGraph(b *testing.B) {
 								IncomingValidatedTxsNode:  val,
 								NumOfLocalDepConstructors: tc.workers,
 								WaitingTxsLimit:           20_000_000,
-								PrometheusMetricsProvider: monitoring.NewProvider(),
+								PrometheusMetricsProvider: monitoring.NewMetricsProvider(),
 							})
 
 							txPoll := workload.GenerateTransactions(b, p, max(b.N*3, batchSize*3))
@@ -180,7 +180,7 @@ func TestDependencyGraphManager(t *testing.T) {
 				IncomingValidatedTxsNode:  validatedTxs,
 				NumOfLocalDepConstructors: 2,
 				WaitingTxsLimit:           waitingTXsLimit,
-				PrometheusMetricsProvider: monitoring.NewProvider(),
+				PrometheusMetricsProvider: monitoring.NewMetricsProvider(),
 			})
 
 			t.Log("check reads and writes dependency tracking")

--- a/service/coordinator/dependencygraph/metrics.go
+++ b/service/coordinator/dependencygraph/metrics.go
@@ -15,7 +15,7 @@ import (
 var bucket = []float64{.0001, .001, .002, .003, .004, .005, .01, .03, .05, .1, .3, .5, 1}
 
 type perfMetrics struct {
-	provider *monitoring.Provider
+	mp *monitoring.MetricsProvider
 
 	// queue sizes
 	ldgInputTxBatchQueueSize prometheus.Gauge
@@ -45,47 +45,47 @@ type perfMetrics struct {
 	dependentTransactionsQueueSize prometheus.Gauge
 }
 
-func newPerformanceMetrics(p *monitoring.Provider) *perfMetrics {
+func newPerformanceMetrics(mp *monitoring.MetricsProvider) *perfMetrics {
 	return &perfMetrics{
-		provider: p,
-		ldgInputTxBatchQueueSize: p.NewGauge(prometheus.GaugeOpts{
+		mp: mp,
+		ldgInputTxBatchQueueSize: mp.NewGauge(prometheus.GaugeOpts{
 			Namespace: "coordinator",
 			Subsystem: "local_dependency_graph",
 			Name:      "input_tx_batch_queue_size",
 			Help:      "Size of the input transaction batch queue of the local dependency graph manager",
 		}),
-		gdgInputTxBatchQueueSize: p.NewGauge(prometheus.GaugeOpts{
+		gdgInputTxBatchQueueSize: mp.NewGauge(prometheus.GaugeOpts{
 			Namespace: "coordinator",
 			Subsystem: "global_dependency_graph",
 			Name:      "input_tx_batch_queue_size",
 			Help:      "Size of the input transaction batch queue of the global dependency graph manager",
 		}),
-		gdgWaitingTxQueueSize: p.NewGauge(prometheus.GaugeOpts{
+		gdgWaitingTxQueueSize: mp.NewGauge(prometheus.GaugeOpts{
 			Namespace: "coordinator",
 			Subsystem: "global_dependency_graph",
 			Name:      "size",
 			Help: "Size of the global dependency graph manager in terms " +
 				"of the number of transactions waiting to be processed",
 		}),
-		ldgTxProcessedTotal: p.NewCounter(prometheus.CounterOpts{
+		ldgTxProcessedTotal: mp.NewCounter(prometheus.CounterOpts{
 			Namespace: "coordinator",
 			Subsystem: "local_dependency_graph",
 			Name:      "tx_processed_total",
 			Help:      "Total number of new transactions processed by the local dependency graph manager",
 		}),
-		gdgTxProcessedTotal: p.NewCounter(prometheus.CounterOpts{
+		gdgTxProcessedTotal: mp.NewCounter(prometheus.CounterOpts{
 			Namespace: "coordinator",
 			Subsystem: "global_dependency_graph",
 			Name:      "tx_processed_total",
 			Help:      "Total number of new transactions processed by the global dependency graph manager",
 		}),
-		gdgValidatedTxProcessedTotal: p.NewCounter(prometheus.CounterOpts{
+		gdgValidatedTxProcessedTotal: mp.NewCounter(prometheus.CounterOpts{
 			Namespace: "coordinator",
 			Subsystem: "global_dependency_graph",
 			Name:      "validated_tx_processed_total",
 			Help:      "Total number of validated transactions processed by the global dependency graph manager",
 		}),
-		gdgConstructionSeconds: p.NewHistogram(prometheus.HistogramOpts{
+		gdgConstructionSeconds: mp.NewHistogram(prometheus.HistogramOpts{
 			Namespace: "coordinator",
 			Subsystem: "global_dependency_graph",
 			Name:      "construction_seconds",
@@ -93,7 +93,7 @@ func newPerformanceMetrics(p *monitoring.Provider) *perfMetrics {
 				"in the global dependency graph manager",
 			Buckets: bucket,
 		}),
-		gdgConstructorWaitForLockSeconds: p.NewHistogram(prometheus.HistogramOpts{
+		gdgConstructorWaitForLockSeconds: mp.NewHistogram(prometheus.HistogramOpts{
 			Namespace:   "coordinator",
 			Subsystem:   "global_dependency_graph",
 			Name:        "constructor_wait_for_lock_seconds",
@@ -101,14 +101,14 @@ func newPerformanceMetrics(p *monitoring.Provider) *perfMetrics {
 			ConstLabels: map[string]string{},
 			Buckets:     bucket,
 		}),
-		gdgAddTxToGraphSeconds: p.NewHistogram(prometheus.HistogramOpts{
+		gdgAddTxToGraphSeconds: mp.NewHistogram(prometheus.HistogramOpts{
 			Namespace: "coordinator",
 			Subsystem: "global_dependency_graph",
 			Name:      "add_tx_batch_to_graph_seconds",
 			Help:      "Time spent adding a transaction batch to the graph in the global dependency graph manager",
 			Buckets:   bucket,
 		}),
-		gdgUpdateDependencyDetectorSeconds: p.NewHistogram(prometheus.HistogramOpts{
+		gdgUpdateDependencyDetectorSeconds: mp.NewHistogram(prometheus.HistogramOpts{
 			Namespace: "coordinator",
 			Subsystem: "global_dependency_graph",
 			Name:      "update_dependency_detector_seconds",
@@ -116,7 +116,7 @@ func newPerformanceMetrics(p *monitoring.Provider) *perfMetrics {
 				"in the global dependency graph manager",
 			Buckets: bucket,
 		}),
-		gdgValidatedTxProcessingSeconds: p.NewHistogram(prometheus.HistogramOpts{
+		gdgValidatedTxProcessingSeconds: mp.NewHistogram(prometheus.HistogramOpts{
 			Namespace: "coordinator",
 			Subsystem: "global_dependency_graph",
 			Name:      "validated_tx_batch_processing_seconds",
@@ -124,7 +124,7 @@ func newPerformanceMetrics(p *monitoring.Provider) *perfMetrics {
 				"dependency graph manager",
 			Buckets: bucket,
 		}),
-		gdgValidatedTxProcessorWaitForLockSeconds: p.NewHistogram(prometheus.HistogramOpts{
+		gdgValidatedTxProcessorWaitForLockSeconds: mp.NewHistogram(prometheus.HistogramOpts{
 			Namespace: "coordinator",
 			Subsystem: "global_dependency_graph",
 			Name:      "validated_tx_batch_processor_wait_for_lock_seconds",
@@ -132,7 +132,7 @@ func newPerformanceMetrics(p *monitoring.Provider) *perfMetrics {
 				"processor of the global dependency graph manager",
 			Buckets: bucket,
 		}),
-		gdgRemoveDependentsOfValidatedTxSeconds: p.NewHistogram(prometheus.HistogramOpts{
+		gdgRemoveDependentsOfValidatedTxSeconds: mp.NewHistogram(prometheus.HistogramOpts{
 			Namespace: "coordinator",
 			Subsystem: "global_dependency_graph",
 			Name:      "remove_dependents_of_validated_tx_batch_seconds",
@@ -140,21 +140,21 @@ func newPerformanceMetrics(p *monitoring.Provider) *perfMetrics {
 				"in the global dependency graph manager",
 			Buckets: bucket,
 		}),
-		gdgAddFreedTxSeconds: p.NewHistogram(prometheus.HistogramOpts{
+		gdgAddFreedTxSeconds: mp.NewHistogram(prometheus.HistogramOpts{
 			Namespace: "coordinator",
 			Subsystem: "global_dependency_graph",
 			Name:      "add_freed_tx_batch_seconds",
 			Help:      "Time spent adding a freed transaction batch to a queue in the global dependency graph manager",
 			Buckets:   bucket,
 		}),
-		gdgOutputFreedTxSeconds: p.NewHistogram(prometheus.HistogramOpts{
+		gdgOutputFreedTxSeconds: mp.NewHistogram(prometheus.HistogramOpts{
 			Namespace: "coordinator",
 			Subsystem: "global_dependency_graph",
 			Name:      "output_freed_tx_batch_seconds",
 			Help:      "Time spent outputting a freed transaction batch in the global dependency graph manager",
 			Buckets:   bucket,
 		}),
-		dependentTransactionsQueueSize: p.NewGauge(prometheus.GaugeOpts{
+		dependentTransactionsQueueSize: mp.NewGauge(prometheus.GaugeOpts{
 			Namespace: "coordinator",
 			Subsystem: "dependency_graph",
 			Name:      "dependent_transactions_queue_size",

--- a/service/coordinator/dependencygraph/parameters.go
+++ b/service/coordinator/dependencygraph/parameters.go
@@ -26,5 +26,5 @@ type Parameters struct {
 	// that can be waiting at the dependency manager.
 	WaitingTxsLimit int
 	// PrometheusMetricsProvider is the provider for Prometheus metrics.
-	PrometheusMetricsProvider *monitoring.Provider
+	PrometheusMetricsProvider *monitoring.MetricsProvider
 }

--- a/service/coordinator/metrics.go
+++ b/service/coordinator/metrics.go
@@ -13,7 +13,7 @@ import (
 )
 
 type perfMetrics struct {
-	*monitoring.Provider
+	*monitoring.MetricsProvider
 
 	// received and processed transactions
 	transactionReceivedTotal  prometheus.Counter
@@ -36,76 +36,74 @@ type perfMetrics struct {
 	vcservicesRetriedTransactionTotal prometheus.Counter
 }
 
-func newPerformanceMetrics() *perfMetrics {
-	p := monitoring.NewProvider()
-
+func newPerformanceMetrics(mp *monitoring.MetricsProvider) *perfMetrics {
 	return &perfMetrics{
-		Provider: p,
-		transactionReceivedTotal: p.NewCounter(prometheus.CounterOpts{
+		MetricsProvider: mp,
+		transactionReceivedTotal: mp.NewCounter(prometheus.CounterOpts{
 			Namespace: "coordinator",
 			Subsystem: "grpc",
 			Name:      "received_transaction_total",
 			Help:      "Total number of transactions received by the coordinator service from the client.",
 		}),
-		transactionCommittedTotal: p.NewCounterVec(prometheus.CounterOpts{
+		transactionCommittedTotal: mp.NewCounterVec(prometheus.CounterOpts{
 			Namespace: "coordinator",
 			Subsystem: "grpc",
 			Name:      "committed_transaction_total",
 			Help:      "Total number of transactions committed status sent by the coordinator service to the client.",
 		}, []string{"status"}),
-		sigverifierInputTxBatchQueueSize: p.NewGauge(prometheus.GaugeOpts{
+		sigverifierInputTxBatchQueueSize: mp.NewGauge(prometheus.GaugeOpts{
 			Namespace: "coordinator",
 			Subsystem: "sigverifier",
 			Name:      "input_tx_batch_queue_size",
 			Help:      "Size of the input transaction batch queue of the signature verifier manager.",
 		}),
-		sigverifierOutputValidatedTxBatchQueueSize: p.NewGauge(prometheus.GaugeOpts{
+		sigverifierOutputValidatedTxBatchQueueSize: mp.NewGauge(prometheus.GaugeOpts{
 			Namespace: "coordinator",
 			Subsystem: "sigverifier",
 			Name:      "output_validated_tx_batch_queue_size",
 			Help:      "Size of the output validated transaction batch queue of the signature verifier manager.",
 		}),
-		vcserviceOutputTxStatusBatchQueueSize: p.NewGauge(prometheus.GaugeOpts{
+		vcserviceOutputTxStatusBatchQueueSize: mp.NewGauge(prometheus.GaugeOpts{
 			Namespace: "coordinator",
 			Subsystem: "vcservice",
 			Name:      "output_tx_status_batch_queue_size",
 			Help: "Size of the output transaction status batch queue of " +
 				"the validation and committer service manager.",
 		}),
-		vcserviceOutputValidatedTxBatchQueueSize: p.NewGauge(prometheus.GaugeOpts{
+		vcserviceOutputValidatedTxBatchQueueSize: mp.NewGauge(prometheus.GaugeOpts{
 			Namespace: "coordinator",
 			Subsystem: "vcservice",
 			Name:      "output_validated_tx_batch_queue_size",
 			Help: "Size of the output validated transaction batch queue " +
 				"of the validation and committer service manager.",
 		}),
-		sigverifierTransactionProcessedTotal: p.NewCounter(prometheus.CounterOpts{
+		sigverifierTransactionProcessedTotal: mp.NewCounter(prometheus.CounterOpts{
 			Namespace: "coordinator",
 			Subsystem: "sigverifier",
 			Name:      "transaction_processed_total",
 			Help:      "Total number of transactions processed by the signature verifier manager.",
 		}),
-		vcserviceTransactionProcessedTotal: p.NewCounter(prometheus.CounterOpts{
+		vcserviceTransactionProcessedTotal: mp.NewCounter(prometheus.CounterOpts{
 			Namespace: "coordinator",
 			Subsystem: "vcservice",
 			Name:      "transaction_processed_total",
 			Help:      "Total number of transactions processed by the validation and committer service manager.",
 		}),
-		verifiersConnection: p.NewConnectionMetrics(monitoring.ConnectionMetricsOpts{
+		verifiersConnection: mp.NewConnectionMetrics(monitoring.ConnectionMetricsOpts{
 			Namespace:       "coordinator",
 			RemoteNamespace: "verifier",
 		}),
-		verifiersRetriedTransactionTotal: p.NewCounter(prometheus.CounterOpts{
+		verifiersRetriedTransactionTotal: mp.NewCounter(prometheus.CounterOpts{
 			Namespace: "coordinator",
 			Subsystem: "vcservice",
 			Name:      "retired_transaction_total",
 			Help:      "Total number of transactions retried by the validation and committer service manager.",
 		}),
-		vcservicesConnection: p.NewConnectionMetrics(monitoring.ConnectionMetricsOpts{
+		vcservicesConnection: mp.NewConnectionMetrics(monitoring.ConnectionMetricsOpts{
 			Namespace:       "coordinator",
 			RemoteNamespace: "vcservice",
 		}),
-		vcservicesRetriedTransactionTotal: p.NewCounter(prometheus.CounterOpts{
+		vcservicesRetriedTransactionTotal: mp.NewCounter(prometheus.CounterOpts{
 			Namespace: "coordinator",
 			Subsystem: "sigverifier",
 			Name:      "retired_transaction_total",

--- a/service/coordinator/signature_verifier_manager_test.go
+++ b/service/coordinator/signature_verifier_manager_test.go
@@ -54,7 +54,7 @@ func newSvMgrTestEnv(t *testing.T, numSvService int, expectedEndErrorMsg ...byte
 			clientConfig:             test.ServerToMultiClientConfig(test.InsecureTLSConfig, sc.Configs...),
 			incomingTxsForValidation: inputTxBatch,
 			outgoingValidatedTxs:     outputValidatedTxs,
-			metrics:                  newPerformanceMetrics(),
+			metrics:                  newPerformanceMetrics(monitoring.NewMetricsProvider()),
 			policyManager:            pm,
 		},
 	)
@@ -72,7 +72,7 @@ func newSvMgrTestEnv(t *testing.T, numSvService int, expectedEndErrorMsg ...byte
 		nil,
 	)
 	monitoring.WaitForConnections(
-		t, svm.metrics.Provider, "coordinator_grpc_verifier_connection_status", numSvService,
+		t, svm.metrics.MetricsProvider, "coordinator_grpc_verifier_connection_status", numSvService,
 	)
 
 	env := &svMgrTestEnv{

--- a/service/coordinator/validator_committer_manager_test.go
+++ b/service/coordinator/validator_committer_manager_test.go
@@ -59,7 +59,7 @@ func newVcMgrTestEnv(t *testing.T, numVCService int) *vcMgrTestEnv {
 			incomingTxsForValidationCommit: inputTxs,
 			outgoingValidatedTxsNode:       outputTxs,
 			outgoingTxsStatus:              outputTxsStatus,
-			metrics:                        newPerformanceMetrics(),
+			metrics:                        newPerformanceMetrics(monitoring.NewMetricsProvider()),
 			policyMgr:                      svEnv.policyManager,
 		},
 	)

--- a/service/query/metrics.go
+++ b/service/query/metrics.go
@@ -30,7 +30,7 @@ var (
 )
 
 type perfMetrics struct {
-	*monitoring.Provider
+	*monitoring.MetricsProvider
 
 	requests                        *prometheus.CounterVec
 	requestsLatency                 *prometheus.HistogramVec
@@ -44,71 +44,69 @@ type perfMetrics struct {
 	queryLatencySeconds             prometheus.Histogram
 }
 
-func newQueryServiceMetrics() *perfMetrics {
-	p := monitoring.NewProvider()
-
+func newQueryServiceMetrics(mp *monitoring.MetricsProvider) *perfMetrics {
 	return &perfMetrics{
-		Provider: p,
-		requests: p.NewCounterVec(prometheus.CounterOpts{
+		MetricsProvider: mp,
+		requests: mp.NewCounterVec(prometheus.CounterOpts{
 			Namespace: "queryservice",
 			Subsystem: "grpc",
 			Name:      "requests_total",
 			Help:      "Number of requests by the service",
 		}, []string{"method"}),
-		requestsLatency: p.NewHistogramVec(prometheus.HistogramOpts{
+		requestsLatency: mp.NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: "queryservice",
 			Subsystem: "grpc",
 			Name:      "requests_latency_seconds",
 			Help:      "The latency (seconds) of requests by the service",
 			Buckets:   timeBuckets,
 		}, []string{"method"}),
-		keysRequested: p.NewCounter(prometheus.CounterOpts{
+		keysRequested: mp.NewCounter(prometheus.CounterOpts{
 			Namespace: "queryservice",
 			Subsystem: "grpc",
 			Name:      "key_requested_total",
 			Help:      "Number of keys requested by the service",
 		}),
-		keysResponded: p.NewCounter(prometheus.CounterOpts{
+		keysResponded: mp.NewCounter(prometheus.CounterOpts{
 			Namespace: "queryservice",
 			Subsystem: "grpc",
 			Name:      "key_responded_total",
 			Help:      "Number of keys responded by the service",
 		}),
-		processingSessions: p.NewGaugeVec(prometheus.GaugeOpts{
+		processingSessions: mp.NewGaugeVec(prometheus.GaugeOpts{
 			Namespace: "queryservice",
 			Subsystem: "database",
 			Name:      "processing_sessions",
 			Help:      "Number of processing sessions in the service",
 		}, []string{"session"}),
-		batchQueuingTimeSeconds: p.NewHistogram(prometheus.HistogramOpts{
+		batchQueuingTimeSeconds: mp.NewHistogram(prometheus.HistogramOpts{
 			Namespace: "queryservice",
 			Subsystem: "database",
 			Name:      "batch_queueing_time_seconds",
 			Help:      "The time batches waits for execution",
 			Buckets:   timeBuckets,
 		}),
-		batchQuerySize: p.NewHistogram(prometheus.HistogramOpts{
+		batchQuerySize: mp.NewHistogram(prometheus.HistogramOpts{
 			Namespace: "queryservice",
 			Subsystem: "database",
 			Name:      "batch_query_size",
 			Help:      "The size of submitted batches",
 			Buckets:   sizeBuckets,
 		}),
-		batchResponseSize: p.NewHistogram(prometheus.HistogramOpts{
+		batchResponseSize: mp.NewHistogram(prometheus.HistogramOpts{
 			Namespace: "queryservice",
 			Subsystem: "database",
 			Name:      "batch_response_size",
 			Help:      "The size of response for batch queries",
 			Buckets:   sizeBuckets,
 		}),
-		requestAssignmentLatencySeconds: p.NewHistogram(prometheus.HistogramOpts{
+		requestAssignmentLatencySeconds: mp.NewHistogram(prometheus.HistogramOpts{
 			Namespace: "queryservice",
 			Subsystem: "database",
 			Name:      "request_assignment_latency_seconds",
 			Help:      "The latency of the query request assignment to the queue",
 			Buckets:   timeBuckets,
 		}),
-		queryLatencySeconds: p.NewHistogram(prometheus.HistogramOpts{
+		queryLatencySeconds: mp.NewHistogram(prometheus.HistogramOpts{
 			Namespace: "queryservice",
 			Subsystem: "database",
 			Name:      "query_latency_seconds",

--- a/service/query/query_service.go
+++ b/service/query/query_service.go
@@ -26,6 +26,7 @@ import (
 	"github.com/hyperledger/fabric-x-committer/utils/channel"
 	"github.com/hyperledger/fabric-x-committer/utils/connection"
 	"github.com/hyperledger/fabric-x-committer/utils/grpcerror"
+	"github.com/hyperledger/fabric-x-committer/utils/monitoring"
 	"github.com/hyperledger/fabric-x-committer/utils/monitoring/promutil"
 )
 
@@ -62,10 +63,10 @@ type (
 )
 
 // NewQueryService create a new QueryService given a configuration.
-func NewQueryService(config *Config) *Service {
+func NewQueryService(config *Config, metricsProvider *monitoring.MetricsProvider) *Service {
 	return &Service{
 		config:      config,
-		metrics:     newQueryServiceMetrics(),
+		metrics:     newQueryServiceMetrics(metricsProvider),
 		ready:       channel.NewReady(),
 		healthcheck: connection.DefaultHealthCheckService(),
 	}
@@ -77,7 +78,7 @@ func (q *Service) WaitForReady(ctx context.Context) bool {
 	return q.ready.WaitForReady(ctx)
 }
 
-// Run starts the Prometheus server.
+// Run starts the query service.
 func (q *Service) Run(ctx context.Context) error {
 	pool, poolErr := vc.NewDatabasePool(ctx, q.config.Database)
 	if poolErr != nil {
@@ -107,8 +108,6 @@ func (q *Service) Run(ctx context.Context) error {
 	}
 	q.ready.SignalReady()
 
-	_ = q.metrics.StartPrometheusServer(ctx, q.config.Monitoring)
-	// We don't use the error here as we avoid stopping the service due to monitoring error.
 	<-ctx.Done()
 	return nil
 }

--- a/service/query/query_service_test.go
+++ b/service/query/query_service_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/hyperledger/fabric-x-committer/service/vc"
 	"github.com/hyperledger/fabric-x-committer/service/verifier/policy"
 	"github.com/hyperledger/fabric-x-committer/utils/connection"
+	"github.com/hyperledger/fabric-x-committer/utils/monitoring"
 	"github.com/hyperledger/fabric-x-committer/utils/signature"
 	"github.com/hyperledger/fabric-x-committer/utils/test"
 )
@@ -334,7 +335,7 @@ func TestMakeViewLimitReached(t *testing.T) {
 	vb := &viewsBatcher{
 		ctx:         t.Context(),
 		config:      &Config{MaxActiveViews: 1},
-		metrics:     newQueryServiceMetrics(),
+		metrics:     newQueryServiceMetrics(monitoring.NewMetricsProvider()),
 		viewLimiter: semaphore.NewWeighted(1),
 	}
 	params := defaultViewParams(time.Minute)
@@ -537,7 +538,7 @@ func newQueryServiceTestEnv(t *testing.T, opts *queryServiceTestOpts) *queryServ
 		Monitoring:            test.NewLocalHostServer(test.InsecureTLSConfig),
 	}
 
-	qs := NewQueryService(config)
+	qs := NewQueryService(config, monitoring.NewMetricsProvider())
 	test.RunServiceAndGrpcForTest(t.Context(), t, qs, qs.config.Server)
 	clientConn := createQueryClientWithTLS(t, &qs.config.Server.Endpoint, opts.clientTLS)
 
@@ -572,7 +573,7 @@ func generateNamespacesUnderTest(t *testing.T, namespaces []string) *vc.Database
 	}
 	clientConf.LoadProfile.Policy.NamespacePolicies = nsPolicies
 	clientConf.Generate = adapters.Phases{Config: true, Namespaces: true}
-	client, err := loadgen.NewLoadGenClient(clientConf)
+	client, err := loadgen.NewLoadGenClient(clientConf, monitoring.NewMetricsProvider())
 	require.NoError(t, err)
 	err = client.Run(t.Context())
 	require.NoError(t, connection.FilterStreamRPCError(err))

--- a/service/sidecar/block_delivery_test.go
+++ b/service/sidecar/block_delivery_test.go
@@ -19,6 +19,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/hyperledger/fabric-x-committer/utils/monitoring"
 	"github.com/hyperledger/fabric-x-committer/utils/test"
 )
 
@@ -101,7 +102,7 @@ func TestBlockDelivery(t *testing.T) {
 func newBlockStoreWithBlocks(t *testing.T, numBlocks int) (*blockStore, [][3]string) {
 	t.Helper()
 
-	bs, err := newBlockStore(t.TempDir(), 0, newPerformanceMetrics())
+	bs, err := newBlockStore(t.TempDir(), 0, newPerformanceMetrics(monitoring.NewMetricsProvider()))
 	require.NoError(t, err)
 	t.Cleanup(bs.close)
 

--- a/service/sidecar/block_store_test.go
+++ b/service/sidecar/block_store_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/hyperledger/fabric-x-committer/utils/connection"
 	"github.com/hyperledger/fabric-x-committer/utils/delivercommitter"
+	"github.com/hyperledger/fabric-x-committer/utils/monitoring"
 	"github.com/hyperledger/fabric-x-committer/utils/test"
 )
 
@@ -28,7 +29,7 @@ func TestBlockStoreAndDelivery(t *testing.T) {
 	t.Parallel()
 	ledgerPath := t.TempDir()
 
-	metrics := newPerformanceMetrics()
+	metrics := newPerformanceMetrics(monitoring.NewMetricsProvider())
 	bs, err := newBlockStore(ledgerPath, 0, metrics)
 	require.NoError(t, err)
 	t.Cleanup(bs.close)

--- a/service/sidecar/metrics.go
+++ b/service/sidecar/metrics.go
@@ -13,7 +13,7 @@ import (
 )
 
 type perfMetrics struct {
-	*monitoring.Provider
+	*monitoring.MetricsProvider
 
 	// received and processed transactions
 	transactionsSentTotal           prometheus.Counter
@@ -48,117 +48,115 @@ type perfMetrics struct {
 	notifierTxIDsTimeoutDeliveries prometheus.Counter
 }
 
-func newPerformanceMetrics() *perfMetrics {
-	p := monitoring.NewProvider()
-
+func newPerformanceMetrics(mp *monitoring.MetricsProvider) *perfMetrics {
 	histoBuckets := []float64{0.001, 0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.2, 0.3, 0.4, 0.5, 0.75, 1}
 	return &perfMetrics{
-		Provider: p,
-		transactionsSentTotal: p.NewCounter(prometheus.CounterOpts{
+		MetricsProvider: mp,
+		transactionsSentTotal: mp.NewCounter(prometheus.CounterOpts{
 			Namespace: "sidecar",
 			Subsystem: "grpc_coordinator",
 			Name:      "sent_transaction_total",
 			Help:      "Total number of transactions sent to the coordinator service.",
 		}),
-		transactionsStatusReceivedTotal: p.NewCounterVec(prometheus.CounterOpts{
+		transactionsStatusReceivedTotal: mp.NewCounterVec(prometheus.CounterOpts{
 			Namespace: "sidecar",
 			Subsystem: "grpc_coordinator",
 			Name:      "received_transaction_status_total",
 			Help:      "Total number of transactions statuses received from the coordinator service.",
 		}, []string{"status"}),
-		blockMappingInRelaySeconds: p.NewHistogram(prometheus.HistogramOpts{
+		blockMappingInRelaySeconds: mp.NewHistogram(prometheus.HistogramOpts{
 			Namespace: "sidecar",
 			Subsystem: "relay",
 			Name:      "block_mapping_seconds",
 			Help:      "Time spent mapping a received block to an internal block.",
 			Buckets:   histoBuckets,
 		}),
-		mappedBlockProcessingInRelaySeconds: p.NewHistogram(prometheus.HistogramOpts{
+		mappedBlockProcessingInRelaySeconds: mp.NewHistogram(prometheus.HistogramOpts{
 			Namespace: "sidecar",
 			Subsystem: "relay",
 			Name:      "mapped_block_processing_seconds",
 			Help:      "Time spent processing an internal block and sending it to the coordinator.",
 			Buckets:   histoBuckets,
 		}),
-		transactionStatusesProcessingInRelaySeconds: p.NewHistogram(prometheus.HistogramOpts{
+		transactionStatusesProcessingInRelaySeconds: mp.NewHistogram(prometheus.HistogramOpts{
 			Namespace: "sidecar",
 			Subsystem: "relay",
 			Name:      "transaction_status_batch_processing_seconds",
 			Help:      "Time spent processing a received status batch from the coordinator.",
 			Buckets:   histoBuckets,
 		}),
-		waitingTransactionsQueueSize: p.NewGauge(prometheus.GaugeOpts{
+		waitingTransactionsQueueSize: mp.NewGauge(prometheus.GaugeOpts{
 			Namespace: "sidecar",
 			Subsystem: "relay",
 			Name:      "waiting_transactions_queue_size",
 			Help:      "Total number of transactions waiting at the relay for statuses.",
 		}),
-		yetToBeCommittedBlocksQueueSize: p.NewGauge(prometheus.GaugeOpts{
+		yetToBeCommittedBlocksQueueSize: mp.NewGauge(prometheus.GaugeOpts{
 			Namespace: "sidecar",
 			Subsystem: "relay",
 			Name:      "input_block_queue_size",
 			Help:      "Size of the input block queue of the relay service.",
 		}),
-		committedBlocksQueueSize: p.NewGauge(prometheus.GaugeOpts{
+		committedBlocksQueueSize: mp.NewGauge(prometheus.GaugeOpts{
 			Namespace: "sidecar",
 			Subsystem: "relay",
 			Name:      "output_committed_block_queue_size",
 			Help:      "Size of the output committed block queue of the relay service.",
 		}),
-		coordConnection: p.NewConnectionMetrics(monitoring.ConnectionMetricsOpts{
+		coordConnection: mp.NewConnectionMetrics(monitoring.ConnectionMetricsOpts{
 			Namespace:       "sidecar",
 			RemoteNamespace: "coordinator",
 		}),
-		appendBlockToLedgerSeconds: p.NewHistogram(prometheus.HistogramOpts{
+		appendBlockToLedgerSeconds: mp.NewHistogram(prometheus.HistogramOpts{
 			Namespace: "sidecar",
 			Subsystem: "ledger",
 			Name:      "append_block_seconds",
 			Help:      "Time spent appending a block to the ledger.",
 			Buckets:   histoBuckets,
 		}),
-		blockHeight: p.NewGauge(prometheus.GaugeOpts{
+		blockHeight: mp.NewGauge(prometheus.GaugeOpts{
 			Namespace: "sidecar",
 			Subsystem: "ledger",
 			Name:      "block_height",
 			Help:      "The current block height of the ledger.",
 		}),
-		transactionInThroughput: p.NewCounter(prometheus.CounterOpts{
+		transactionInThroughput: mp.NewCounter(prometheus.CounterOpts{
 			Namespace: "sidecar",
 			Subsystem: "relay",
 			Name:      "transaction_in_total",
 			Help:      "Total number of transactions received from the orderer.",
 		}),
-		transactionOutThroughput: p.NewCounter(prometheus.CounterOpts{
+		transactionOutThroughput: mp.NewCounter(prometheus.CounterOpts{
 			Namespace: "sidecar",
 			Subsystem: "relay",
 			Name:      "transaction_out_total",
 			Help:      "Total number of transaction statuses processed from the coordinator.",
 		}),
-		notifierActiveStreams: p.NewGauge(prometheus.GaugeOpts{
+		notifierActiveStreams: mp.NewGauge(prometheus.GaugeOpts{
 			Namespace: "sidecar",
 			Subsystem: "notifier",
 			Name:      "active_streams",
 			Help:      "Number of active notification streams.",
 		}),
-		notifierPendingTxIDs: p.NewGauge(prometheus.GaugeOpts{
+		notifierPendingTxIDs: mp.NewGauge(prometheus.GaugeOpts{
 			Namespace: "sidecar",
 			Subsystem: "notifier",
 			Name:      "pending_tx_ids",
 			Help:      "Number of pending (txID, request) subscriptions waiting for status notification.",
 		}),
-		notifierUniquePendingTxIDs: p.NewGauge(prometheus.GaugeOpts{
+		notifierUniquePendingTxIDs: mp.NewGauge(prometheus.GaugeOpts{
 			Namespace: "sidecar",
 			Subsystem: "notifier",
 			Name:      "unique_pending_tx_ids",
 			Help:      "Number of unique transaction IDs pending across all requests.",
 		}),
-		notifierTxIDsStatusDeliveries: p.NewCounter(prometheus.CounterOpts{
+		notifierTxIDsStatusDeliveries: mp.NewCounter(prometheus.CounterOpts{
 			Namespace: "sidecar",
 			Subsystem: "notifier",
 			Name:      "tx_ids_status_deliveries_total",
 			Help:      "Total number of transaction IDs' status deliveries to clients.",
 		}),
-		notifierTxIDsTimeoutDeliveries: p.NewCounter(prometheus.CounterOpts{
+		notifierTxIDsTimeoutDeliveries: mp.NewCounter(prometheus.CounterOpts{
 			Namespace: "sidecar",
 			Subsystem: "notifier",
 			Name:      "tx_ids_timeout_deliveries_total",

--- a/service/sidecar/notify_test.go
+++ b/service/sidecar/notify_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/hyperledger/fabric-x-committer/utils/channel"
 	"github.com/hyperledger/fabric-x-committer/utils/connection"
+	"github.com/hyperledger/fabric-x-committer/utils/monitoring"
 	"github.com/hyperledger/fabric-x-committer/utils/test"
 )
 
@@ -479,7 +480,7 @@ func newNotifierTestEnv(tb testing.TB, numOfClients int) *notifierTestEnv {
 
 func newNotifierTestEnvWithConfig(tb testing.TB, numOfClients int, conf *NotificationServiceConfig) *notifierTestEnv {
 	tb.Helper()
-	metrics := newPerformanceMetrics()
+	metrics := newPerformanceMetrics(monitoring.NewMetricsProvider())
 	env := &notifierTestEnv{
 		n:              newNotifier(DefaultBufferSize, conf, metrics),
 		metrics:        metrics,

--- a/service/sidecar/relay_test.go
+++ b/service/sidecar/relay_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hyperledger/fabric-x-committer/mock"
 	"github.com/hyperledger/fabric-x-committer/utils/channel"
 	"github.com/hyperledger/fabric-x-committer/utils/connection"
+	"github.com/hyperledger/fabric-x-committer/utils/monitoring"
 	"github.com/hyperledger/fabric-x-committer/utils/test"
 	"github.com/hyperledger/fabric-x-committer/utils/testcrypto"
 )
@@ -43,7 +44,7 @@ func newRelayTestEnv(t *testing.T) *relayTestEnv {
 	coord, coordinatorServer := mock.StartMockCoordinatorService(t, test.StartServerParameters{})
 	coordinatorEndpoint := coordinatorServer.Configs[0].Endpoint
 
-	metrics := newPerformanceMetrics()
+	metrics := newPerformanceMetrics(monitoring.NewMetricsProvider())
 	relayService := newRelay(
 		time.Second,
 		metrics,

--- a/service/sidecar/sidecar.go
+++ b/service/sidecar/sidecar.go
@@ -29,7 +29,9 @@ import (
 	"github.com/hyperledger/fabric-x-committer/utils/channel"
 	"github.com/hyperledger/fabric-x-committer/utils/connection"
 	"github.com/hyperledger/fabric-x-committer/utils/deliverorderer"
+	"github.com/hyperledger/fabric-x-committer/utils/monitoring"
 	"github.com/hyperledger/fabric-x-committer/utils/monitoring/promutil"
+	"github.com/hyperledger/fabric-x-committer/utils/periodic"
 	"github.com/hyperledger/fabric-x-committer/utils/retry"
 )
 
@@ -55,7 +57,7 @@ type Service struct {
 }
 
 // New creates a sidecar service.
-func New(c *Config) (*Service, error) {
+func New(c *Config, metricsProvider *monitoring.MetricsProvider) (*Service, error) {
 	logger.Info("Initializing new sidecar")
 
 	// 1. Load the delivery parameters for the ordering service.
@@ -65,7 +67,7 @@ func New(c *Config) (*Service, error) {
 	}
 
 	// 2. Relay the blocks to committer and receive the transaction status.
-	metrics := newPerformanceMetrics()
+	metrics := newPerformanceMetrics(metricsProvider)
 	relayService := newRelay(c.LastCommittedBlockSetInterval, metrics)
 
 	// 3. Deliver the block with status to client.
@@ -99,10 +101,6 @@ func (*Service) WaitForReady(context.Context) bool {
 func (s *Service) Run(ctx context.Context) error {
 	pCtx, pCancel := context.WithCancel(ctx)
 	defer pCancel()
-	// similar to other services, when the prometheus server returns an error, we do not terminate the service.
-	go func() {
-		_ = s.metrics.StartPrometheusServer(pCtx, s.config.Monitoring, s.monitorQueues)
-	}()
 
 	logger.Infof("Create coordinator client and connect to %s", s.config.Committer.Endpoint)
 	conn, connErr := connection.NewSingleConnection(s.config.Committer)
@@ -119,6 +117,9 @@ func (s *Service) Run(ctx context.Context) error {
 	// The following runs independently of the coordinator connection lifecycle.
 	// gCtx will be cancelled if these stopped processing due to ledger error.
 	// Such errors require human interaction to resolve the ledger discrepancy.
+	g.Go(func() error {
+		return s.monitorQueues(gCtx)
+	})
 	g.Go(func() error {
 		// Deliver the block with status to clients.
 		return s.blockStore.run(gCtx, &blockStoreRunConfig{
@@ -383,22 +384,19 @@ func appendMissingBlock(
 	return nil
 }
 
-func (s *Service) monitorQueues(ctx context.Context) {
-	ticker := time.NewTicker(100 * time.Millisecond)
-	m := s.metrics
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-ticker.C:
+func (s *Service) monitorQueues(ctx context.Context) error {
+	for range periodic.Ticker(ctx, 100*time.Millisecond) {
+		if ctx.Err() != nil {
+			break
 		}
-
+		m := s.metrics
 		blockToBeCommittedChan := s.blockToBeCommitted.Load()
 		if blockToBeCommittedChan != nil {
 			promutil.SetGauge(m.yetToBeCommittedBlocksQueueSize, len(*blockToBeCommittedChan))
 		}
 		promutil.SetGauge(m.committedBlocksQueueSize, len(s.committedBlock))
 	}
+	return ctx.Err()
 }
 
 // Close closes the ledger.

--- a/service/sidecar/sidecar_test.go
+++ b/service/sidecar/sidecar_test.go
@@ -104,7 +104,7 @@ func newSidecarTestEnvWithTLS(
 		Monitoring:                    test.NewLocalHostServer(conf.ServerTLS),
 		Orderer:                       ordererEnv.OrdererConnConfig,
 	}
-	sidecar, err := New(sidecarConf)
+	sidecar, err := New(sidecarConf, monitoring.NewMetricsProvider())
 	require.NoError(t, err)
 	t.Cleanup(sidecar.Close)
 
@@ -317,7 +317,7 @@ func TestSidecarConfigRecovery(t *testing.T) {
 
 	var err error
 	t.Log("Create a new sidecar with the old configuration (only party 0)")
-	env.sidecar, err = New(&env.config)
+	env.sidecar, err = New(&env.config, monitoring.NewMetricsProvider())
 	require.NoError(t, err)
 	t.Cleanup(env.sidecar.Close)
 
@@ -381,7 +381,7 @@ func TestSidecarRecovery(t *testing.T) {
 	env.sidecar.blockStore, err = newBlockStore(
 		env.config.Ledger.Path,
 		0,
-		newPerformanceMetrics(),
+		newPerformanceMetrics(monitoring.NewMetricsProvider()),
 	)
 	require.NoError(t, err)
 	env.sidecar.blockDelivery = newBlockDelivery(env.sidecar.blockStore)

--- a/service/vc/committer_test.go
+++ b/service/vc/committer_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/hyperledger/fabric-x-committer/api/servicepb"
 	"github.com/hyperledger/fabric-x-committer/utils/channel"
+	"github.com/hyperledger/fabric-x-committer/utils/monitoring"
 	"github.com/hyperledger/fabric-x-committer/utils/test"
 )
 
@@ -33,7 +34,7 @@ func newCommitterTestEnv(t *testing.T) *committerTestEnv {
 	txStatus := make(chan *committerpb.TxStatusBatch, 10)
 
 	dbEnv := newDatabaseTestEnvWithTablesSetup(t)
-	metrics := newVCServiceMetrics()
+	metrics := newVCServiceMetrics(monitoring.NewMetricsProvider())
 	c := newCommitter(dbEnv.DB, validatedTxs, txStatus, metrics)
 	test.RunServiceForTest(t.Context(), t, func(ctx context.Context) error {
 		return c.run(ctx, 1)

--- a/service/vc/database_test.go
+++ b/service/vc/database_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/yugabyte/pgx/v5/pgxpool"
 
+	"github.com/hyperledger/fabric-x-committer/utils/monitoring"
 	"github.com/hyperledger/fabric-x-committer/utils/retry"
 )
 
@@ -316,7 +317,7 @@ func TestNewDatabaseTabletsWithDetection(t *testing.T) {
 
 	env.DBConf.TablePreSplitTablets = 5
 
-	db, err := newDatabase(t.Context(), env.DBConf, newVCServiceMetrics())
+	db, err := newDatabase(t.Context(), env.DBConf, newVCServiceMetrics(monitoring.NewMetricsProvider()))
 	require.NoError(t, err)
 	t.Cleanup(db.close)
 

--- a/service/vc/metrics.go
+++ b/service/vc/metrics.go
@@ -15,7 +15,7 @@ import (
 var buckets = []float64{.0001, .001, .002, .003, .004, .005, .01, .03, .05, .1, .3, .5, 1}
 
 type perfMetrics struct {
-	*monitoring.Provider
+	*monitoring.MetricsProvider
 
 	// transaction received and processed counters
 	transactionReceivedTotal     prometheus.Counter
@@ -44,112 +44,110 @@ type perfMetrics struct {
 	databaseTxBatchCommitInsertNewKeyWithValueLatencySeconds    prometheus.Histogram
 }
 
-func newVCServiceMetrics() *perfMetrics {
-	p := monitoring.NewProvider()
-
+func newVCServiceMetrics(mp *monitoring.MetricsProvider) *perfMetrics {
 	return &perfMetrics{
-		Provider: p,
-		transactionReceivedTotal: p.NewCounter(prometheus.CounterOpts{
+		MetricsProvider: mp,
+		transactionReceivedTotal: mp.NewCounter(prometheus.CounterOpts{
 			Namespace: "vcservice",
 			Subsystem: "grpc",
 			Name:      "received_transaction_total",
 			Help:      "Number of transactions received by the service",
 		}),
-		transactionProcessedTotal: p.NewCounter(prometheus.CounterOpts{
+		transactionProcessedTotal: mp.NewCounter(prometheus.CounterOpts{
 			Namespace: "vcservice",
 			Subsystem: "grpc",
 			Name:      "processed_transaction_total",
 			Help:      "Number of transactions processed by the service",
 		}),
-		transactionCommittedTotal: p.NewCounter(prometheus.CounterOpts{
+		transactionCommittedTotal: mp.NewCounter(prometheus.CounterOpts{
 			Namespace: "vcservice",
 			Name:      "committed_transaction_total",
 			Help:      "The total number of transactions committed",
 		}),
-		transactionMVCCConflictTotal: p.NewCounter(prometheus.CounterOpts{
+		transactionMVCCConflictTotal: mp.NewCounter(prometheus.CounterOpts{
 			Namespace: "vcservice",
 			Name:      "mvcc_conflict_total",
 			Help:      "The total number of transactions that failed due to MVCC conflict",
 		}),
-		transactionDuplicateTxTotal: p.NewCounter(prometheus.CounterOpts{
+		transactionDuplicateTxTotal: mp.NewCounter(prometheus.CounterOpts{
 			Namespace: "vcservice",
 			Name:      "duplicate_transaction_total",
 			Help:      "The total number of duplicate transactions",
 		}),
-		preparerInputQueueSize: p.NewGauge(prometheus.GaugeOpts{
+		preparerInputQueueSize: mp.NewGauge(prometheus.GaugeOpts{
 			Namespace: "vcservice",
 			Subsystem: "preparer",
 			Name:      "input_queue_size",
 			Help:      "The preparer input queue size",
 		}),
-		validatorInputQueueSize: p.NewGauge(prometheus.GaugeOpts{
+		validatorInputQueueSize: mp.NewGauge(prometheus.GaugeOpts{
 			Namespace: "vcservice",
 			Subsystem: "validator",
 			Name:      "input_queue_size",
 			Help:      "The validator input queue size",
 		}),
-		committerInputQueueSize: p.NewGauge(prometheus.GaugeOpts{
+		committerInputQueueSize: mp.NewGauge(prometheus.GaugeOpts{
 			Namespace: "vcservice",
 			Subsystem: "committer",
 			Name:      "input_queue_size",
 			Help:      "The committer input queue size",
 		}),
-		txStatusOutputQueueSize: p.NewGauge(prometheus.GaugeOpts{
+		txStatusOutputQueueSize: mp.NewGauge(prometheus.GaugeOpts{
 			Namespace: "vcservice",
 			Subsystem: "txstatus",
 			Name:      "output_queue_size",
 			Help:      "The txstatus output queue size",
 		}),
-		preparerTxBatchLatencySeconds: p.NewHistogram(prometheus.HistogramOpts{
+		preparerTxBatchLatencySeconds: mp.NewHistogram(prometheus.HistogramOpts{
 			Namespace: "vcservice",
 			Subsystem: "preparer",
 			Name:      "tx_batch_latency_seconds",
 			Help:      "The latency of the preparer processing a batch of transactions",
 			Buckets:   buckets,
 		}),
-		validatorTxBatchLatencySeconds: p.NewHistogram(prometheus.HistogramOpts{
+		validatorTxBatchLatencySeconds: mp.NewHistogram(prometheus.HistogramOpts{
 			Namespace: "vcservice",
 			Subsystem: "validator",
 			Name:      "tx_batch_latency_seconds",
 			Help:      "The latency of the validator processing a batch of transactions",
 			Buckets:   buckets,
 		}),
-		committerTxBatchLatencySeconds: p.NewHistogram(prometheus.HistogramOpts{
+		committerTxBatchLatencySeconds: mp.NewHistogram(prometheus.HistogramOpts{
 			Namespace: "vcservice",
 			Subsystem: "committer",
 			Name:      "tx_batch_latency_seconds",
 			Help:      "The latency of the committer processing a batch of transactions",
 			Buckets:   buckets,
 		}),
-		databaseTxBatchValidationLatencySeconds: p.NewHistogram(prometheus.HistogramOpts{
+		databaseTxBatchValidationLatencySeconds: mp.NewHistogram(prometheus.HistogramOpts{
 			Namespace: "vcservice",
 			Subsystem: "database",
 			Name:      "tx_batch_validation_latency_seconds",
 			Help:      "The latency of the database validating a batch of transactions",
 			Buckets:   buckets,
 		}),
-		databaseTxBatchQueryVersionLatencySeconds: p.NewHistogram(prometheus.HistogramOpts{
+		databaseTxBatchQueryVersionLatencySeconds: mp.NewHistogram(prometheus.HistogramOpts{
 			Namespace: "vcservice",
 			Subsystem: "database",
 			Name:      "tx_batch_query_version_latency_seconds",
 			Help:      "The latency of the database querying version for keys in a batch of transactions",
 			Buckets:   buckets,
 		}),
-		databaseTxBatchCommitLatencySeconds: p.NewHistogram(prometheus.HistogramOpts{
+		databaseTxBatchCommitLatencySeconds: mp.NewHistogram(prometheus.HistogramOpts{
 			Namespace: "vcservice",
 			Subsystem: "database",
 			Name:      "tx_batch_commit_latency_seconds",
 			Help:      "The latency of the database committing a batch of transactions",
 			Buckets:   buckets,
 		}),
-		databaseTxBatchCommitTxsStatusLatencySeconds: p.NewHistogram(prometheus.HistogramOpts{
+		databaseTxBatchCommitTxsStatusLatencySeconds: mp.NewHistogram(prometheus.HistogramOpts{
 			Namespace: "vcservice",
 			Subsystem: "database",
 			Name:      "tx_batch_commit_txs_status_latency_seconds",
 			Help:      "The latency of the database committing a batch of transactions and updating their status",
 			Buckets:   buckets,
 		}),
-		databaseTxBatchCommitUpdateLatencySeconds: p.NewHistogram(prometheus.HistogramOpts{
+		databaseTxBatchCommitUpdateLatencySeconds: mp.NewHistogram(prometheus.HistogramOpts{
 			Namespace: "vcservice",
 			Subsystem: "database",
 			Name:      "tx_batch_commit_update_latency_seconds",
@@ -157,7 +155,7 @@ func newVCServiceMetrics() *perfMetrics {
 				"updating existing keys",
 			Buckets: buckets,
 		}),
-		databaseTxBatchCommitInsertNewKeyWithValueLatencySeconds: p.NewHistogram(prometheus.HistogramOpts{
+		databaseTxBatchCommitInsertNewKeyWithValueLatencySeconds: mp.NewHistogram(prometheus.HistogramOpts{
 			Namespace: "vcservice",
 			Subsystem: "database",
 			Name:      "tx_batch_commit_insert_new_key_with_value_latency_seconds",
@@ -165,7 +163,7 @@ func newVCServiceMetrics() *perfMetrics {
 				"inserting new keys with values",
 			Buckets: buckets,
 		}),
-		databaseTxBatchCommitInsertNewKeyWithoutValueLatencySeconds: p.NewHistogram(prometheus.HistogramOpts{
+		databaseTxBatchCommitInsertNewKeyWithoutValueLatencySeconds: mp.NewHistogram(prometheus.HistogramOpts{
 			Namespace: "vcservice",
 			Subsystem: "database",
 			Name:      "tx_batch_commit_insert_new_key_without_value_latency_seconds",

--- a/service/vc/preparer_test.go
+++ b/service/vc/preparer_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hyperledger/fabric-x-committer/api/servicepb"
 	"github.com/hyperledger/fabric-x-committer/loadgen/workload"
 	"github.com/hyperledger/fabric-x-committer/utils/channel"
+	"github.com/hyperledger/fabric-x-committer/utils/monitoring"
 	"github.com/hyperledger/fabric-x-committer/utils/test"
 )
 
@@ -32,7 +33,7 @@ func newPrepareTestEnv(t *testing.T) *prepareTestEnv {
 	t.Helper()
 	txBatch := make(chan *servicepb.VcBatch, 10)
 	preparedTxs := make(chan *preparedTransactions, 10)
-	metrics := newVCServiceMetrics()
+	metrics := newVCServiceMetrics(monitoring.NewMetricsProvider())
 	p := newPreparer(txBatch, preparedTxs, metrics)
 	test.RunServiceForTest(t.Context(), t, func(ctx context.Context) error {
 		return p.run(ctx, 1)
@@ -692,7 +693,7 @@ func BenchmarkPrepare(b *testing.B) {
 		b.Run(fmt.Sprintf("w=%d", w), func(b *testing.B) {
 			txBatch := make(chan *servicepb.VcBatch, 8)
 			preparedTxs := make(chan *preparedTransactions, 8)
-			metrics := newVCServiceMetrics()
+			metrics := newVCServiceMetrics(monitoring.NewMetricsProvider())
 			p := newPreparer(txBatch, preparedTxs, metrics)
 			test.RunServiceForTest(b.Context(), b, func(ctx context.Context) error {
 				return p.run(ctx, w)

--- a/service/vc/test_exports.go
+++ b/service/vc/test_exports.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/hyperledger/fabric-x-committer/api/servicepb"
 	"github.com/hyperledger/fabric-x-committer/utils/connection"
+	"github.com/hyperledger/fabric-x-committer/utils/monitoring"
 	"github.com/hyperledger/fabric-x-committer/utils/retry"
 	"github.com/hyperledger/fabric-x-committer/utils/test"
 	"github.com/hyperledger/fabric-x-committer/utils/testdb"
@@ -85,7 +86,7 @@ func NewValidatorAndCommitServiceTestEnv(t *testing.T, opts *TestEnvOpts) *Valid
 			ResourceLimits: opts.ResourceLimits,
 			Monitoring:     test.NewLocalHostServer(test.InsecureTLSConfig),
 		}
-		vcs, err := NewValidatorCommitterService(initCtx, config)
+		vcs, err := NewValidatorCommitterService(initCtx, config, monitoring.NewMetricsProvider())
 		require.NoError(t, err)
 		t.Cleanup(vcs.Close)
 		test.RunServiceAndGrpcForTest(t.Context(), t, vcs, config.Server)
@@ -167,7 +168,7 @@ func NewDatabaseTestEnvFromConnection(t *testing.T, cs *testdb.Connection, loadB
 		Retry:          testdb.DefaultRetry,
 	}
 
-	m := newVCServiceMetrics()
+	m := newVCServiceMetrics(monitoring.NewMetricsProvider())
 	sCtx, sCancel := context.WithTimeout(t.Context(), 5*time.Minute)
 	t.Cleanup(sCancel)
 	dbObject, err := newDatabase(sCtx, config, m)

--- a/service/vc/validator_committer_service.go
+++ b/service/vc/validator_committer_service.go
@@ -26,7 +26,9 @@ import (
 	"github.com/hyperledger/fabric-x-committer/utils/channel"
 	"github.com/hyperledger/fabric-x-committer/utils/connection"
 	"github.com/hyperledger/fabric-x-committer/utils/grpcerror"
+	"github.com/hyperledger/fabric-x-committer/utils/monitoring"
 	"github.com/hyperledger/fabric-x-committer/utils/monitoring/promutil"
+	"github.com/hyperledger/fabric-x-committer/utils/periodic"
 )
 
 var logger = flogging.MustGetLogger("validator-committer")
@@ -73,6 +75,7 @@ type ValidatorCommitterService struct {
 func NewValidatorCommitterService(
 	ctx context.Context,
 	config *Config,
+	metricsProvider *monitoring.MetricsProvider,
 ) (*ValidatorCommitterService, error) {
 	logger.Info("Initializing new validator committer service.")
 	l := config.ResourceLimits
@@ -85,7 +88,7 @@ func NewValidatorCommitterService(
 	validatedTxs := make(chan *validatedTransactions, queueMultiplier)
 	txsStatus := make(chan *committerpb.TxStatusBatch, l.MaxWorkersForCommitter*queueMultiplier)
 
-	metrics := newVCServiceMetrics()
+	metrics := newVCServiceMetrics(metricsProvider)
 	db, err := newDatabase(ctx, config.Database, metrics)
 	if err != nil {
 		logger.Errorf("%+v", err)
@@ -119,13 +122,8 @@ func (vc *ValidatorCommitterService) Run(ctx context.Context) error {
 	g, eCtx := errgroup.WithContext(ctx)
 
 	g.Go(func() error {
-		logger.Info("Starting Prometheus monitoring server")
-		_ = vc.metrics.StartPrometheusServer(
-			eCtx, vc.config.Monitoring, vc.monitorQueues,
-		)
-		// We don't return error here to avoid stopping the service due to monitoring error.
-		// But we use the errgroup to ensure the method returns only when the server exits.
-		return nil
+		logger.Info("Starting queue monitoring")
+		return vc.monitorQueues(eCtx)
 	})
 
 	g.Go(func() error {
@@ -170,21 +168,18 @@ func (vc *ValidatorCommitterService) RegisterService(server *grpc.Server) {
 	healthgrpc.RegisterHealthServer(server, vc.healthcheck)
 }
 
-func (vc *ValidatorCommitterService) monitorQueues(ctx context.Context) {
+func (vc *ValidatorCommitterService) monitorQueues(ctx context.Context) error {
 	// TODO: make sampling time configurable
-	ticker := time.NewTicker(250 * time.Millisecond)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-ticker.C:
+	for range periodic.Ticker(ctx, 250*time.Millisecond) {
+		if ctx.Err() != nil {
+			break
 		}
 		promutil.SetGauge(vc.metrics.preparerInputQueueSize, len(vc.toPrepareTxs))
 		promutil.SetGauge(vc.metrics.validatorInputQueueSize, len(vc.preparedTxs))
 		promutil.SetGauge(vc.metrics.committerInputQueueSize, len(vc.validatedTxs))
 		promutil.SetGauge(vc.metrics.txStatusOutputQueueSize, len(vc.txsStatus))
 	}
+	return ctx.Err()
 }
 
 // SetLastCommittedBlockNumber set the last committed block number in the database/ledger.

--- a/service/vc/validator_test.go
+++ b/service/vc/validator_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/hyperledger/fabric-x-committer/api/servicepb"
 	"github.com/hyperledger/fabric-x-committer/utils/channel"
+	"github.com/hyperledger/fabric-x-committer/utils/monitoring"
 	"github.com/hyperledger/fabric-x-committer/utils/test"
 )
 
@@ -32,7 +33,7 @@ func newValidatorTestEnv(t *testing.T) *validatorTestEnv {
 	validatedTxs := make(chan *validatedTransactions, 10)
 
 	dbEnv := newDatabaseTestEnvWithTablesSetup(t)
-	metrics := newVCServiceMetrics()
+	metrics := newVCServiceMetrics(monitoring.NewMetricsProvider())
 	v := newValidator(dbEnv.DB, preparedTxs, validatedTxs, metrics)
 	test.RunServiceForTest(t.Context(), t, func(ctx context.Context) error {
 		return v.run(ctx, 1)

--- a/service/verifier/metrics.go
+++ b/service/verifier/metrics.go
@@ -13,26 +13,25 @@ import (
 )
 
 type metrics struct {
-	Provider             *monitoring.Provider
+	Provider             *monitoring.MetricsProvider
 	VerifierServerInTxs  prometheus.Counter
 	VerifierServerOutTxs prometheus.Counter
 	ActiveStreams        prometheus.Gauge
 	ActiveRequests       prometheus.Gauge
 }
 
-func newMonitoring() *metrics {
-	p := monitoring.NewProvider()
+func newMonitoring(mp *monitoring.MetricsProvider) *metrics {
 	return &metrics{
-		Provider:             p,
-		VerifierServerInTxs:  p.NewThroughputCounter("verifier_server", "tx", monitoring.In),
-		VerifierServerOutTxs: p.NewThroughputCounter("verifier_server", "tx", monitoring.Out),
-		ActiveStreams: prometheus.NewGauge(prometheus.GaugeOpts{
+		Provider:             mp,
+		VerifierServerInTxs:  mp.NewThroughputCounter("verifier_server", "tx", monitoring.In),
+		VerifierServerOutTxs: mp.NewThroughputCounter("verifier_server", "tx", monitoring.Out),
+		ActiveStreams: mp.NewGauge(prometheus.GaugeOpts{
 			Namespace: "verifier_server",
 			Subsystem: "grpc",
 			Name:      "active_streams",
 			Help:      "The total number of started streams",
 		}),
-		ActiveRequests: p.NewGauge(prometheus.GaugeOpts{
+		ActiveRequests: mp.NewGauge(prometheus.GaugeOpts{
 			Namespace: "verifier_server",
 			Subsystem: "parallel_executor",
 			Name:      "active_requests",

--- a/service/verifier/verifier_server.go
+++ b/service/verifier/verifier_server.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hyperledger/fabric-x-committer/utils/channel"
 	"github.com/hyperledger/fabric-x-committer/utils/connection"
 	"github.com/hyperledger/fabric-x-committer/utils/grpcerror"
+	"github.com/hyperledger/fabric-x-committer/utils/monitoring"
 	"github.com/hyperledger/fabric-x-committer/utils/monitoring/promutil"
 )
 
@@ -40,20 +41,19 @@ var (
 )
 
 // New instantiate a new VerifierServer.
-func New(config *Config) *Server {
+func New(config *Config, metricsProvider *monitoring.MetricsProvider) *Server {
 	logger.Info("Initializing new verifier server")
 	return &Server{
 		config:      config,
-		metrics:     newMonitoring(),
+		metrics:     newMonitoring(metricsProvider),
 		healthcheck: connection.DefaultHealthCheckService(),
 	}
 }
 
 // Run the verifier background service.
 func (s *Server) Run(ctx context.Context) error {
-	_ = s.metrics.Provider.StartPrometheusServer(ctx, s.config.Monitoring)
-	// We don't return error here to avoid stopping the service due to monitoring error.
-	// But we use the errgroup to ensure the method returns only when the server exits.
+	// Verifier has no background work except responding to gRPC requests
+	<-ctx.Done()
 	return nil
 }
 

--- a/service/verifier/verifier_server_test.go
+++ b/service/verifier/verifier_server_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/hyperledger/fabric-x-committer/service/verifier/policy"
 	"github.com/hyperledger/fabric-x-committer/utils/channel"
 	"github.com/hyperledger/fabric-x-committer/utils/connection"
+	"github.com/hyperledger/fabric-x-committer/utils/monitoring"
 	"github.com/hyperledger/fabric-x-committer/utils/signature"
 	"github.com/hyperledger/fabric-x-committer/utils/test"
 	"github.com/hyperledger/fabric-x-committer/utils/testcrypto"
@@ -488,7 +489,7 @@ type State struct {
 
 func newTestState(t *testing.T, config *Config) *State {
 	t.Helper()
-	service := New(config)
+	service := New(config, monitoring.NewMetricsProvider())
 	test.RunServiceAndGrpcForTest(t.Context(), t, service, config.Server)
 
 	return &State{

--- a/utils/connection/config.go
+++ b/utils/connection/config.go
@@ -121,6 +121,16 @@ func (c TLSConfig) ServerCredentials() (credentials.TransportCredentials, error)
 	return NewServerGRPCTransportCredentials(tlsCreds)
 }
 
+// ServerTLSConfig converts TLSConfig into a *tls.Config for use with HTTP servers.
+// This is a convenience method that wraps NewServerTLSCredentials and CreateServerTLSConfig.
+func (c TLSConfig) ServerTLSConfig() (*tls.Config, error) {
+	tlsCreds, err := NewServerTLSCredentials(c)
+	if err != nil {
+		return nil, err
+	}
+	return tlsCreds.CreateServerTLSConfig()
+}
+
 // Validate checks that the rate limit configuration is valid.
 func (c *RateLimitConfig) Validate() error {
 	if c == nil || c.RequestsPerSecond == 0 {

--- a/utils/monitoring/connection_metrics_test.go
+++ b/utils/monitoring/connection_metrics_test.go
@@ -19,7 +19,7 @@ func TestConnectionMetrics(t *testing.T) {
 	t.Parallel()
 
 	newConnectionMetrics := func() *ConnectionMetrics {
-		p := NewProvider()
+		p := NewMetricsProvider()
 		return p.NewConnectionMetrics(ConnectionMetricsOpts{})
 	}
 	target := "localhost:7051"

--- a/utils/monitoring/http_server.go
+++ b/utils/monitoring/http_server.go
@@ -1,0 +1,178 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package monitoring
+
+import (
+	"context"
+	"crypto/tls"
+	"net"
+	"net/http"
+	"net/http/pprof"
+	"net/url"
+	"time"
+
+	"github.com/cockroachdb/errors"
+	"github.com/hyperledger/fabric-lib-go/common/flogging"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/hyperledger/fabric-x-committer/utils/connection"
+)
+
+// HTTP logger is defined in provider.go
+
+const (
+	httpsScheme    = "https://"
+	httpScheme     = "http://"
+	metricsSubPath = "/metrics"
+	pprofSubPath   = "/debug/pprof/"
+)
+
+var httpLogger = flogging.MustGetLogger("monitoring.http")
+
+// httpServer wraps a http.Server to export metrics and pprof endpoints.
+type httpServer struct {
+	mux      *http.ServeMux
+	config   *connection.ServerConfig
+	registry *prometheus.Registry
+}
+
+// StartHTTPServer creates and starts an HTTP monitoring server asynchronously.
+// It synchronously creates the listener (returning any immediate errors like port
+// conflicts), then starts the server in a goroutine and returns.
+// Errors during serving (after successful listener creation) are logged via httpLogger.
+func StartHTTPServer(
+	ctx context.Context,
+	config *connection.ServerConfig,
+	registry *prometheus.Registry,
+) error {
+	srv := newHTTPServer(config, registry)
+	listener, err := srv.createListener(ctx)
+	if err != nil {
+		return err
+	}
+	go srv.serve(ctx, listener)
+	return nil
+}
+
+// newHTTPServer creates a new HTTP monitoring server but does not start it.
+// This is primarily intended for testing; production code should use StartHTTPServer.
+func newHTTPServer(config *connection.ServerConfig, registry *prometheus.Registry) *httpServer {
+	mux := http.NewServeMux()
+
+	// Register prometheus handler
+	mux.Handle(
+		metricsSubPath,
+		promhttp.HandlerFor(
+			registry,
+			promhttp.HandlerOpts{
+				Registry: registry,
+			},
+		),
+	)
+
+	// Register pprof handlers
+	mux.HandleFunc(pprofSubPath, pprof.Index)
+	mux.HandleFunc(pprofSubPath+"cmdline", pprof.Cmdline)
+	mux.HandleFunc(pprofSubPath+"profile", pprof.Profile)
+	mux.HandleFunc(pprofSubPath+"symbol", pprof.Symbol)
+	mux.HandleFunc(pprofSubPath+"trace", pprof.Trace)
+
+	return &httpServer{
+		mux:      mux,
+		config:   config,
+		registry: registry,
+	}
+}
+
+// createListener creates the listener and performs synchronous setup.
+// Returns the configured listener or an error if setup fails.
+// This allows StartHTTPServer to return early on configuration errors.
+func (s *httpServer) createListener(ctx context.Context) (net.Listener, error) {
+	httpLogger.Debugf("Creating listener for HTTP monitoring server with secure mode: %v", s.config.TLS.Mode)
+
+	// Generate TLS configuration
+	serverTLSConfig, err := s.config.TLS.ServerTLSConfig()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create TLS credentials for HTTP monitoring server")
+	}
+
+	// Create listener from config with retry for port conflicts
+	listener, err := s.config.Listener(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create listener for HTTP monitoring server")
+	}
+
+	if serverTLSConfig != nil {
+		listener = tls.NewListener(listener, serverTLSConfig)
+	}
+
+	// Build URL for logging
+	metricsURL, err := MakeMetricsURL(listener.Addr().String(), serverTLSConfig)
+	if err != nil {
+		connection.CloseConnectionsLog(listener)
+		return nil, errors.Wrap(err, "failed to create metrics URL")
+	}
+	httpLogger.Infof("HTTP monitoring server ready to serve metrics at: %s", metricsURL)
+	return listener, nil
+}
+
+// serve starts the HTTP monitoring server with context awareness.
+// It runs in a goroutine and handles graceful shutdown when the context is cancelled.
+// Errors during serving are logged via httpLogger.
+func (s *httpServer) serve(parentCtx context.Context, listener net.Listener) {
+	server := &http.Server{
+		ReadTimeout: 30 * time.Second,
+		Handler:     s.mux,
+	}
+
+	// Use errgroup for server goroutine - child context signals completion
+	g := new(errgroup.Group)
+	childCtx, childCancel := context.WithCancel(parentCtx)
+
+	g.Go(func() error {
+		defer childCancel() // Signal completion (success or error)
+		err := server.Serve(listener)
+		if errors.Is(err, http.ErrServerClosed) {
+			return nil
+		}
+		return err
+	})
+
+	// Wait for parent context cancellation or server completion
+	select {
+	case <-parentCtx.Done():
+		// Parent cancelled - initiate graceful shutdown
+		shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer shutdownCancel()
+		//nolint:contextcheck // parentCtx is already done; need fresh context for graceful shutdown
+		if err := server.Shutdown(shutdownCtx); err != nil {
+			httpLogger.Warnf("HTTP monitoring server graceful shutdown error: %v", err)
+		}
+		// Wait for goroutine to finish after listener closes
+		_ = g.Wait()
+	case <-childCtx.Done():
+		// Server exited (either errored or context was cancelled)
+		if err := g.Wait(); err != nil {
+			httpLogger.Errorf("HTTP monitoring server stopped with error: %v", err)
+			return
+		}
+		httpLogger.Info("HTTP monitoring server stopped")
+	}
+}
+
+// MakeMetricsURL constructs the Prometheus metrics URL.
+// Based on the secure level, we set the url scheme to http or https.
+func MakeMetricsURL(address string, tlsConf *tls.Config) (string, error) {
+	scheme := httpScheme
+	if tlsConf != nil {
+		scheme = httpsScheme
+	}
+	ret, err := url.JoinPath(scheme, address, metricsSubPath)
+	return ret, errors.Wrap(err, "failed to make prometheus URL")
+}

--- a/utils/monitoring/http_server_test.go
+++ b/utils/monitoring/http_server_test.go
@@ -1,0 +1,76 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package monitoring
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger/fabric-x-committer/utils/test"
+)
+
+func TestHTTPServer_ServesMetrics(t *testing.T) {
+	t.Parallel()
+	provider := NewMetricsProvider()
+	// Create a counter to verify it appears in metrics
+	counter := provider.NewCounter(prometheus.CounterOpts{
+		Name: "test_metric_total",
+		Help: "Test metric for HTTPServer",
+	})
+	counter.Inc()
+
+	testConfig := test.NewLocalHostServer(test.InsecureTLSConfig)
+	testConfig.Endpoint.Port = 0 // Let OS assign ephemeral port
+
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+
+	// Use StartHTTPServer which creates the listener synchronously (returning any errors)
+	// and then starts serving in a goroutine. We need the URL before serving starts.
+	server := newHTTPServer(testConfig, provider.Registry())
+	listener, err := server.createListener(ctx)
+	require.NoError(t, err, "failed to create listener")
+
+	// Construct the metrics URL using the helper
+	url := makeMetricsURL(t, testConfig, listener)
+
+	// Start serving in a goroutine (simulating what StartHTTPServer does internally)
+	go server.serve(ctx, listener)
+
+	// Wait for server to be ready
+	require.Eventually(t, func() bool {
+		resp, reqErr := http.Get(url) //nolint:gosec // test code making request to localhost
+		if reqErr == nil {
+			_ = resp.Body.Close()
+			return resp.StatusCode == http.StatusOK
+		}
+		return false
+	}, 5*time.Second, 100*time.Millisecond, "server did not start")
+
+	// Actually make HTTP request to verify metrics are served
+	resp, err := http.Get(url) //nolint:gosec // test code making request to localhost
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = resp.Body.Close() })
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+
+	// Verify our test metric appears in the response
+	assert.Contains(t, string(body), "test_metric")
+
+	// Cleanup
+	cancel()
+}

--- a/utils/monitoring/provider.go
+++ b/utils/monitoring/provider.go
@@ -7,191 +7,70 @@ SPDX-License-Identifier: Apache-2.0
 package monitoring
 
 import (
-	"context"
-	"crypto/tls"
 	"fmt"
-	"net/http"
-	"net/http/pprof"
-	"net/url"
-	"sync/atomic"
-	"time"
 
-	"github.com/cockroachdb/errors"
-	"github.com/hyperledger/fabric-lib-go/common/flogging"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"golang.org/x/sync/errgroup"
-
-	"github.com/hyperledger/fabric-x-committer/utils/connection"
 )
 
-const (
-	httpsScheme    = "https://"
-	httpScheme     = "http://"
-	metricsSubPath = "/metrics"
-	pprofSubPath   = "/debug/pprof/"
-)
-
-// Provider is a prometheus metrics provider.
-type Provider struct {
+// MetricsProvider is a prometheus metrics provider.
+type MetricsProvider struct {
 	registry *prometheus.Registry
-	url      atomic.Pointer[string]
 }
 
-var logger = flogging.MustGetLogger("monitoring")
-
-// NewProvider creates a new prometheus metrics provider.
-func NewProvider() *Provider {
-	return &Provider{registry: prometheus.NewRegistry()}
+// NewMetricsProvider creates a new prometheus metrics provider.
+func NewMetricsProvider() *MetricsProvider {
+	return &MetricsProvider{registry: prometheus.NewRegistry()}
 }
 
-// StartPrometheusServer starts a prometheus server.
-// It also starts the given monitoring methods. Their context will cancel once the server is cancelled.
-// This method returns once the server is shutdown and all monitoring methods returns.
-func (p *Provider) StartPrometheusServer(
-	ctx context.Context, serverConfig *connection.ServerConfig, monitor ...func(context.Context),
-) error {
-	logger.Debugf("Creating prometheus server with secure mode: %v", serverConfig.TLS.Mode)
-	// Generate TLS configuration from the server config.
-	serverCreds, err := connection.NewServerTLSCredentials(serverConfig.TLS)
-	if err != nil {
-		return errors.Wrap(err, "failed to create TLS credentials for prometheus server")
-	}
-	serverTLSConfig, err := serverCreds.CreateServerTLSConfig()
-	if err != nil {
-		return err
-	}
-	mux := http.NewServeMux()
-	mux.Handle(
-		metricsSubPath,
-		promhttp.HandlerFor(
-			p.Registry(),
-			promhttp.HandlerOpts{
-				Registry: p.Registry(),
-			},
-		),
-	)
-
-	// Register pprof handlers for profiling.
-	// Note: We must explicitly register these handlers because we're using a custom ServeMux.
-	// The net/http/pprof package's init() function only registers handlers on http.DefaultServeMux,
-	// which we're not using. Simply importing the package is insufficient for custom muxes.
-	//
-	// The Index handler dynamically serves all runtime profiles (heap, goroutine, allocs, block,
-	// mutex, threadcreate, etc.) without requiring explicit registration. Only special handlers
-	// (cmdline, profile, symbol, trace) need to be registered separately.
-	mux.HandleFunc(pprofSubPath, pprof.Index)
-	mux.HandleFunc(pprofSubPath+"cmdline", pprof.Cmdline)
-	mux.HandleFunc(pprofSubPath+"profile", pprof.Profile)
-	mux.HandleFunc(pprofSubPath+"symbol", pprof.Symbol)
-	mux.HandleFunc(pprofSubPath+"trace", pprof.Trace)
-	server := &http.Server{
-		ReadTimeout: 30 * time.Second,
-		Handler:     mux,
-		TLSConfig:   serverTLSConfig,
-	}
-
-	l, err := serverConfig.Listener(ctx)
-	if err != nil {
-		return err
-	}
-	defer connection.CloseConnectionsLog(l)
-
-	if serverTLSConfig != nil {
-		l = tls.NewListener(l, serverTLSConfig)
-	}
-
-	metricsURL, err := MakeMetricsURL(l.Addr().String(), serverTLSConfig)
-	if err != nil {
-		return err
-	}
-	p.url.Store(&metricsURL)
-
-	g, gCtx := errgroup.WithContext(ctx)
-	g.Go(func() error {
-		logger.Infof("Prometheus serving on URL: %s", metricsURL)
-		defer logger.Info("Prometheus stopped serving")
-		return server.Serve(l)
-	})
-
-	// The following ensures the method does not return before all monitor methods return.
-	for _, m := range monitor {
-		g.Go(func() error {
-			m(gCtx)
-			return nil
-		})
-	}
-
-	// The following ensures the method does not return before the close procedure is complete.
-	stopAfter := context.AfterFunc(ctx, func() {
-		g.Go(func() error {
-			if errClose := server.Close(); err != nil {
-				return errors.Wrap(errClose, "failed to close prometheus server")
-			}
-			return nil
-		})
-	})
-	defer stopAfter()
-
-	if err = g.Wait(); !errors.Is(err, http.ErrServerClosed) {
-		return errors.Wrap(err, "prometheus server stopped with an error")
-	}
-	return nil
-}
-
-// URL returns the prometheus server URL.
-func (p *Provider) URL() string {
-	metricsURL := p.url.Load()
-	if metricsURL != nil {
-		return *metricsURL
-	}
-	return ""
+// Registry returns the prometheus registry.
+func (p *MetricsProvider) Registry() *prometheus.Registry {
+	return p.registry
 }
 
 // NewCounter creates a new prometheus counter.
-func (p *Provider) NewCounter(opts prometheus.CounterOpts) prometheus.Counter {
+func (p *MetricsProvider) NewCounter(opts prometheus.CounterOpts) prometheus.Counter {
 	c := prometheus.NewCounter(opts)
 	p.registry.MustRegister(c)
 	return c
 }
 
 // NewCounterVec creates a new prometheus counter vector.
-func (p *Provider) NewCounterVec(opts prometheus.CounterOpts, labels []string) *prometheus.CounterVec {
+func (p *MetricsProvider) NewCounterVec(opts prometheus.CounterOpts, labels []string) *prometheus.CounterVec {
 	cv := prometheus.NewCounterVec(opts, labels)
 	p.registry.MustRegister(cv)
 	return cv
 }
 
 // NewGauge creates a new prometheus gauge.
-func (p *Provider) NewGauge(opts prometheus.GaugeOpts) prometheus.Gauge {
+func (p *MetricsProvider) NewGauge(opts prometheus.GaugeOpts) prometheus.Gauge {
 	g := prometheus.NewGauge(opts)
 	p.registry.MustRegister(g)
 	return g
 }
 
 // NewGaugeVec creates a new prometheus gauge vector.
-func (p *Provider) NewGaugeVec(opts prometheus.GaugeOpts, labels []string) *prometheus.GaugeVec {
+func (p *MetricsProvider) NewGaugeVec(opts prometheus.GaugeOpts, labels []string) *prometheus.GaugeVec {
 	gv := prometheus.NewGaugeVec(opts, labels)
 	p.registry.MustRegister(gv)
 	return gv
 }
 
 // NewHistogram creates a new prometheus histogram.
-func (p *Provider) NewHistogram(opts prometheus.HistogramOpts) prometheus.Histogram {
+func (p *MetricsProvider) NewHistogram(opts prometheus.HistogramOpts) prometheus.Histogram {
 	h := prometheus.NewHistogram(opts)
 	p.registry.MustRegister(h)
 	return h
 }
 
 // NewHistogramVec creates a new prometheus histogram vector.
-func (p *Provider) NewHistogramVec(opts prometheus.HistogramOpts, labels []string) *prometheus.HistogramVec {
+func (p *MetricsProvider) NewHistogramVec(opts prometheus.HistogramOpts, labels []string) *prometheus.HistogramVec {
 	hv := prometheus.NewHistogramVec(opts, labels)
 	p.registry.MustRegister(hv)
 	return hv
 }
 
 // NewThroughputCounter creates a new prometheus throughput counter.
-func (p *Provider) NewThroughputCounter(
+func (p *MetricsProvider) NewThroughputCounter(
 	component, subComponent string,
 	direction ThroughputDirection,
 ) prometheus.Counter {
@@ -204,7 +83,7 @@ func (p *Provider) NewThroughputCounter(
 }
 
 // NewConnectionMetrics supports common connection metrics.
-func (p *Provider) NewConnectionMetrics(opts ConnectionMetricsOpts) *ConnectionMetrics {
+func (p *MetricsProvider) NewConnectionMetrics(opts ConnectionMetricsOpts) *ConnectionMetrics {
 	subsystem := fmt.Sprintf("grpc_%s", opts.RemoteNamespace)
 	return &ConnectionMetrics{
 		Status: p.NewGaugeVec(prometheus.GaugeOpts{
@@ -224,20 +103,4 @@ func (p *Provider) NewConnectionMetrics(opts ConnectionMetricsOpts) *ConnectionM
 				"Short-lived failures may not always be captured.",
 		}, []string{"grpc_target"}),
 	}
-}
-
-// Registry returns the prometheus registry.
-func (p *Provider) Registry() *prometheus.Registry {
-	return p.registry
-}
-
-// MakeMetricsURL construct the Prometheus metrics URL.
-// based on the secure level, we set the url scheme to http or https.
-func MakeMetricsURL(address string, tlsConf *tls.Config) (string, error) {
-	scheme := httpScheme
-	if tlsConf != nil {
-		scheme = httpsScheme
-	}
-	ret, err := url.JoinPath(scheme, address, metricsSubPath)
-	return ret, errors.Wrap(err, "failed to make prometheus URL")
 }

--- a/utils/monitoring/provider_test.go
+++ b/utils/monitoring/provider_test.go
@@ -7,15 +7,14 @@ SPDX-License-Identifier: Apache-2.0
 package monitoring
 
 import (
-	"context"
 	"crypto/tls"
 	"fmt"
+	"net"
 	"net/http"
 	"testing"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/hyperledger/fabric-x-committer/utils/connection"
@@ -24,8 +23,9 @@ import (
 )
 
 type metricsProviderTestEnv struct {
-	provider        *Provider
+	provider        *MetricsProvider
 	clientTLSConfig *tls.Config
+	metricsURL      string
 }
 
 func TestCounterWithTLSModes(t *testing.T) {
@@ -184,21 +184,39 @@ func TestNewHistogramVec(t *testing.T) {
 	)
 }
 
+// TestPprofEndpoints tests pprof endpoints using the new HTTPServer.
 func TestPprofEndpoints(t *testing.T) {
 	t.Parallel()
 
-	env := newMetricsProviderTestEnv(t, test.InsecureTLSConfig, test.InsecureTLSConfig)
+	serverTLS, clientTLS := test.CreateServerAndClientTLSConfig(t, connection.NoneTLSMode)
+	serverConfig := test.NewLocalHostServer(serverTLS)
+	p := NewMetricsProvider()
+
+	// Create HTTP server and listener
+	httpServer := newHTTPServer(serverConfig, p.Registry())
+	listener, err := httpServer.createListener(t.Context())
+	require.NoError(t, err)
+
+	// Build metrics URL from config
+	metricsURL := makeMetricsURL(t, serverConfig, listener)
+
+	// Start serving in goroutine
+	go httpServer.serve(t.Context(), listener)
+
+	// Extract base URL from metrics URL (remove /metrics path)
+	baseURL := metricsURL[:len(metricsURL)-len(metricsSubPath)]
+
+	clientCreds, err := connection.NewClientTLSCredentials(clientTLS)
+	require.NoError(t, err)
+	clientTLSConfig, err := clientCreds.CreateClientTLSConfig()
+	require.NoError(t, err)
 
 	client := &http.Client{
 		Transport: &http.Transport{
-			TLSClientConfig: env.clientTLSConfig,
+			TLSClientConfig: clientTLSConfig,
 		},
 	}
 	defer client.CloseIdleConnections()
-
-	// Extract base URL from metrics URL (remove /metrics path)
-	metricsURL := env.provider.URL()
-	baseURL := metricsURL[:len(metricsURL)-len(metricsSubPath)]
 
 	tests := []struct {
 		name string
@@ -206,13 +224,9 @@ func TestPprofEndpoints(t *testing.T) {
 	}{
 		{name: "Index", path: "/debug/pprof/"},
 		{name: "Cmdline", path: "/debug/pprof/cmdline"},
-		{name: "Profile", path: "/debug/pprof/profile?seconds=1"},
 		{name: "Symbol", path: "/debug/pprof/symbol"},
 		{name: "Heap", path: "/debug/pprof/heap"},
 		{name: "Goroutine", path: "/debug/pprof/goroutine"},
-		{name: "Allocs", path: "/debug/pprof/allocs"},
-		{name: "Block", path: "/debug/pprof/block"},
-		{name: "Mutex", path: "/debug/pprof/mutex"},
 	}
 
 	for _, tt := range tests {
@@ -229,48 +243,50 @@ func TestPprofEndpoints(t *testing.T) {
 
 func newMetricsProviderTestEnv(t *testing.T, serverTLS, clientTLS connection.TLSConfig) *metricsProviderTestEnv {
 	t.Helper()
-	p := NewProvider()
+	p := NewMetricsProvider()
 
-	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Minute)
-	t.Cleanup(cancel)
-
-	c := test.NewLocalHostServer(serverTLS)
-	go func() {
-		assert.NoError(t, p.StartPrometheusServer(ctx, c))
-	}()
+	serverConfig := test.NewLocalHostServer(serverTLS)
 
 	clientCreds, err := connection.NewClientTLSCredentials(clientTLS)
 	require.NoError(t, err)
 	clientTLSConfig, err := clientCreds.CreateClientTLSConfig()
 	require.NoError(t, err)
 
-	client := &http.Client{
-		Transport: &http.Transport{
-			TLSClientConfig: clientTLSConfig,
-		},
-	}
-	defer client.CloseIdleConnections()
-	require.EventuallyWithT(t, func(ct *assert.CollectT) {
-		require.NotEmpty(ct, p.URL())
-		resp, err := client.Get(p.URL())
-		require.NoError(ct, err)
-		require.NotNil(ct, resp)
-		require.Equal(ct, http.StatusOK, resp.StatusCode)
-		require.NoError(ct, resp.Body.Close())
-	}, 5*time.Second, 100*time.Millisecond)
+	// Create HTTP server and listener
+	httpServer := newHTTPServer(serverConfig, p.Registry())
+	listener, err := httpServer.createListener(t.Context())
+	require.NoError(t, err)
+
+	// Build metrics URL from config
+	metricsURL := makeMetricsURL(t, serverConfig, listener)
+
+	// Start serving in goroutine
+	go httpServer.serve(t.Context(), listener)
 
 	return &metricsProviderTestEnv{
 		provider:        p,
 		clientTLSConfig: clientTLSConfig,
+		metricsURL:      metricsURL,
 	}
 }
 
 func (e *metricsProviderTestEnv) checkMetrics(t *testing.T, expected ...string) {
 	t.Helper()
-	test.CheckMetrics(t, e.provider.URL(), e.clientTLSConfig, expected...)
+	test.CheckMetrics(t, e.metricsURL, e.clientTLSConfig, expected...)
 }
 
 func (e *metricsProviderTestEnv) getMetricValue(t *testing.T, metricNameWithLabels string) int {
 	t.Helper()
-	return test.GetMetricValueFromURL(t, e.provider.URL(), metricNameWithLabels, e.clientTLSConfig)
+	return test.GetMetricValueFromURL(t, e.metricsURL, metricNameWithLabels, e.clientTLSConfig)
+}
+
+// makeMetricsURL constructs the metrics URL from server config and listener.
+// Helper to reduce duplicate code in tests.
+func makeMetricsURL(t *testing.T, serverConfig *connection.ServerConfig, listener net.Listener) string {
+	t.Helper()
+	tlsConf, err := serverConfig.TLS.ServerTLSConfig()
+	require.NoError(t, err)
+	metricsURL, err := MakeMetricsURL(listener.Addr().String(), tlsConf)
+	require.NoError(t, err)
+	return metricsURL
 }

--- a/utils/monitoring/test_exports.go
+++ b/utils/monitoring/test_exports.go
@@ -24,7 +24,7 @@ type ExpectedConn struct {
 }
 
 // WaitForConnections waits for a connection metric to have the required number of connected labels.
-func WaitForConnections(t *testing.T, p *Provider, name string, requiredCount int) {
+func WaitForConnections(t *testing.T, p *MetricsProvider, name string, requiredCount int) {
 	t.Helper()
 	require.Eventually(t, func() bool {
 		gather, err := p.Registry().Gather()

--- a/utils/periodic/ticker.go
+++ b/utils/periodic/ticker.go
@@ -1,0 +1,40 @@
+// Copyright IBM Corp. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package periodic
+
+import (
+	"context"
+	"time"
+)
+
+// Ticker returns a channel that yields nil values at the specified interval
+// until the context is cancelled. The channel is closed when ctx is done.
+// Usage:
+//
+//	for range Ticker(ctx, interval) {
+//	    // do periodic work
+//	}
+//	return ctx.Err()
+func Ticker(ctx context.Context, interval time.Duration) <-chan any {
+	ch := make(chan any)
+	go func() {
+		defer close(ch)
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				select {
+				case ch <- nil:
+				case <-ctx.Done():
+					return
+				}
+			}
+		}
+	}()
+	return ch
+}

--- a/utils/periodic/ticker_test.go
+++ b/utils/periodic/ticker_test.go
@@ -1,0 +1,46 @@
+// Copyright IBM Corp. All Rights Reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package periodic
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTicker(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	ch := Ticker(ctx, 50*time.Millisecond)
+
+	tickCount := 0
+	start := time.Now()
+	for range ch {
+		tickCount++
+		if tickCount >= 3 {
+			cancel() // Cancel context after 3 ticks
+			break
+		}
+	}
+	elapsed := time.Since(start)
+
+	require.GreaterOrEqual(t, tickCount, 3, "expected at least 3 ticks")
+	// Expected ~100ms for 3 ticks at 50ms intervals (t=0ms, 50ms, 100ms).
+	// Use 100ms delta because goroutine scheduling can add significant
+	// variance in CI/test environments.
+	require.InDelta(t, float64(100*time.Millisecond),
+		float64(elapsed), float64(100*time.Millisecond), "expected elapsed time ~100ms")
+
+	// Channel should close soon after cancel
+	select {
+	case _, ok := <-ch:
+		require.False(t, ok, "expected channel to be closed after context cancel")
+	case <-time.After(100 * time.Millisecond):
+	}
+}


### PR DESCRIPTION
#### Type of change

- Improvement (improvement to code, performance, etc)
 
#### Description

 The HTTP server for metrics was extracted from the servicei
 logic into utils/monitoring/http_server.go, with services
 now injected with a server rather than managing it themselves.
 The separation decouples metrics collection from HTTP serving
 across all services (coordinator, sidecar, query, vc, verifier, loadgen).

#### Related issues