### PR TITLE
[mock-orderer] Add dynamic root CAs rotation

### DIFF
--- a/cmd/cliutil/dynamic_tls.go
+++ b/cmd/cliutil/dynamic_tls.go
@@ -1,0 +1,27 @@
+package cliutil
+
+import (
+	"github.com/cockroachdb/errors"
+
+	"github.com/hyperledger/fabric-x-committer/utils/connection"
+)
+
+// NewDynamicTLS returns the TLS interfaces separately to avoid the Go
+// nil-interface trap: a nil *DynamicTLS assigned to an interface becomes a
+// non-nil interface wrapping a nil pointer, which passes != nil checks but
+// panics on method calls. Returning interfaces directly ensures that when
+// TLS is disabled, callers receive true nil values.
+func NewDynamicTLS(
+	serverConfig *connection.ServerConfig,
+) (connection.TLSCertUpdater, connection.TLSConfigProvider, error) {
+	if serverConfig == nil || serverConfig.TLS.Mode != connection.MutualTLSMode {
+		return nil, nil, nil
+	}
+
+	dynamicTLS, err := connection.NewDynamicTLSFromConfig(serverConfig.TLS)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "failed to create dynamic TLS config")
+	}
+
+	return dynamicTLS, dynamicTLS, nil
+}

--- a/cmd/cliutil/dynamic_tls.go
+++ b/cmd/cliutil/dynamic_tls.go
@@ -1,3 +1,9 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
 package cliutil
 
 import (

--- a/cmd/committer/start_cmd.go
+++ b/cmd/committer/start_cmd.go
@@ -19,7 +19,6 @@ import (
 	"github.com/hyperledger/fabric-x-committer/service/sidecar"
 	"github.com/hyperledger/fabric-x-committer/service/vc"
 	"github.com/hyperledger/fabric-x-committer/service/verifier"
-	"github.com/hyperledger/fabric-x-committer/utils/connection"
 	"github.com/hyperledger/fabric-x-committer/utils/grpcservice"
 )
 
@@ -59,7 +58,7 @@ func startService(ctx context.Context, name, configPath string) error {
 
 	switch c := conf.(type) {
 	case *sidecar.Config:
-		tlsUpdater, tlsProvider, err := newDynamicTLS(c.Server)
+		tlsUpdater, tlsProvider, err := cliutil.NewDynamicTLS(c.Server)
 		if err != nil {
 			return err
 		}
@@ -85,7 +84,7 @@ func startService(ctx context.Context, name, configPath string) error {
 		return grpcservice.StartAndServe(ctx, verifier.New(c), nil, c.Server)
 
 	case *query.Config:
-		tlsUpdater, tlsProvider, err := newDynamicTLS(c.Server)
+		tlsUpdater, tlsProvider, err := cliutil.NewDynamicTLS(c.Server)
 		if err != nil {
 			return err
 		}
@@ -94,24 +93,4 @@ func startService(ctx context.Context, name, configPath string) error {
 	default:
 		return errors.Newf("unknown config type: %T", conf)
 	}
-}
-
-// newDynamicTLS returns the TLS interfaces separately to avoid the Go
-// nil-interface trap: a nil *DynamicTLS assigned to an interface becomes a
-// non-nil interface wrapping a nil pointer, which passes != nil checks but
-// panics on method calls. Returning interfaces directly ensures that when
-// TLS is disabled, callers receive true nil values.
-func newDynamicTLS(
-	serverConfig *connection.ServerConfig,
-) (connection.TLSCertUpdater, connection.TLSConfigProvider, error) {
-	if serverConfig == nil || serverConfig.TLS.Mode != connection.MutualTLSMode {
-		return nil, nil, nil
-	}
-
-	dynamicTLS, err := connection.NewDynamicTLSFromConfig(serverConfig.TLS)
-	if err != nil {
-		return nil, nil, errors.Wrap(err, "failed to create dynamic TLS config")
-	}
-
-	return dynamicTLS, dynamicTLS, nil
 }

--- a/cmd/config/samples/mock-orderer.yaml
+++ b/cmd/config/samples/mock-orderer.yaml
@@ -17,11 +17,9 @@ server:
     # Path to the server's TLS private key file.
     key-path: /root/artifacts/ordererOrganizations/orderer-org-0/orderers/orderer-0-org-0/tls/server.key
     # List of paths to CA certificate files for verifying client certificates (required for mtls).
-    # TODO: Remove peer's CA-Certs as these will be loaded from the config block.
     ca-cert-paths:
       - /root/artifacts/ordererOrganizations/orderer-org-0/msp/tlscacerts/tlsorderer-org-0-CA-cert.pem
-      - /root/artifacts/peerOrganizations/peer-org-0/msp/tlscacerts/tlspeer-org-0-CA-cert.pem
-      - /root/artifacts/peerOrganizations/peer-org-1/msp/tlscacerts/tlspeer-org-1-CA-cert.pem
+      # Peer organization CAs are loaded automatically from config block
 
 # Maximum number of transactions to include in each block. Blocks are cut when
 # this size is reached or when the block-timeout expires, whichever comes first.

--- a/cmd/mock/main.go
+++ b/cmd/mock/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hyperledger/fabric-x-committer/cmd/cliutil"
 	"github.com/hyperledger/fabric-x-committer/cmd/config"
 	"github.com/hyperledger/fabric-x-committer/mock"
+	"github.com/hyperledger/fabric-x-committer/utils/connection"
 	"github.com/hyperledger/fabric-x-committer/utils/grpcservice"
 )
 
@@ -76,15 +77,31 @@ func startMockOrderer() *cobra.Command {
 			cmd.Printf("Starting %v\n", mockOrdererName)
 			defer cmd.Printf("%v ended\n", mockOrdererName)
 
-			service, err := mock.NewMockOrderer(conf)
-			if err != nil {
-				return errors.Wrap(err, "failed to create mock ordering service")
-			}
 			serverConfigs := conf.ServerConfigs
 			if conf.Server != nil && !conf.Server.Endpoint.Empty() {
 				serverConfigs = append(serverConfigs, conf.Server)
 			}
-			return grpcservice.StartAndServe(cmd.Context(), service, nil, serverConfigs...)
+
+			// Create dynamic TLS for the first server config (or use Server if available).
+			// This enables dynamic CA rotation from config blocks.
+			var serverConfig *connection.ServerConfig
+			if conf.Server != nil {
+				serverConfig = conf.Server
+			} else if len(serverConfigs) > 0 {
+				serverConfig = serverConfigs[0]
+			}
+
+			tlsUpdater, tlsProvider, err := cliutil.NewDynamicTLS(serverConfig)
+			if err != nil {
+				return err
+			}
+
+			service, err := mock.NewMockOrderer(conf, tlsUpdater)
+			if err != nil {
+				return errors.Wrap(err, "failed to create mock ordering service")
+			}
+
+			return grpcservice.StartAndServe(cmd.Context(), service, tlsProvider, serverConfigs...)
 		},
 	}
 	cliutil.SetDefaultFlags(cmd, &configPath)

--- a/loadgen/adapters/sidecar.go
+++ b/loadgen/adapters/sidecar.go
@@ -44,7 +44,7 @@ func (c *SidecarAdapter) RunWorkload(ctx context.Context, txStream *workload.Str
 		ArtifactsPath: c.res.Profile.Policy.ArtifactsPath,
 		// The sidecar adapter submits a config block manually.
 		SendGenesisBlock: true,
-	})
+	}, nil)
 	if err != nil {
 		return err
 	}

--- a/mock/orderer.go
+++ b/mock/orderer.go
@@ -193,6 +193,7 @@ func NewMockOrderer(config *OrdererConfig, tlsUpdater connection.TLSCertUpdater)
 
 	// Initialize TLS with CAs from genesis block if available.
 	if protoutil.IsConfigBlock(genesisBlock.Block) {
+		logger.Debugf("reading root CAs from genesis block")
 		if err := o.updateTLSFromConfigBlock(genesisBlock.Block); err != nil {
 			logger.Warnf("Failed to initialize TLS from genesis block: %v", err)
 		}
@@ -389,7 +390,7 @@ func (o *Orderer) Run(ctx context.Context) error {
 
 		if protoutil.IsConfigBlock(b) {
 			blockParams.LastConfigBlockIndex = b.Header.Number
-			// Update dynamic TLS with CAs from the new config block.
+			logger.Debugf("reading root CAs from config block")
 			if err := o.updateTLSFromConfigBlock(b); err != nil {
 				logger.Warnf("Failed to update TLS from config block %d: %v", b.Header.Number, err)
 			}

--- a/mock/orderer.go
+++ b/mock/orderer.go
@@ -74,6 +74,7 @@ type (
 		cutBlock             chan any
 		cache                *blockCache
 		healthcheck          *health.Server
+		tlsUpdater           connection.TLSCertUpdater
 
 		// config uses atomic.Pointer to allow safe concurrent reads by the Run() goroutine
 		// while supporting runtime updates (e.g., BlockTimeout changes in tests).
@@ -146,7 +147,7 @@ var (
 )
 
 // NewMockOrderer creates multiple orderer instances.
-func NewMockOrderer(config *OrdererConfig) (*Orderer, error) {
+func NewMockOrderer(config *OrdererConfig, tlsUpdater connection.TLSCertUpdater) (*Orderer, error) {
 	if config.BlockSize == 0 {
 		config.BlockSize = defaultConfig.BlockSize
 	}
@@ -186,8 +187,17 @@ func NewMockOrderer(config *OrdererConfig) (*Orderer, error) {
 		cutBlock:     make(chan any),
 		cache:        newBlockCache(config.OutBlockCapacity),
 		healthcheck:  connection.DefaultHealthCheckService(),
+		tlsUpdater:   tlsUpdater,
 	}
 	o.config.Store(config)
+
+	// Initialize TLS with CAs from genesis block if available.
+	if protoutil.IsConfigBlock(genesisBlock.Block) {
+		if err := o.updateTLSFromConfigBlock(genesisBlock.Block); err != nil {
+			logger.Warnf("Failed to initialize TLS from genesis block: %v", err)
+		}
+	}
+
 	return o, nil
 }
 
@@ -379,6 +389,10 @@ func (o *Orderer) Run(ctx context.Context) error {
 
 		if protoutil.IsConfigBlock(b) {
 			blockParams.LastConfigBlockIndex = b.Header.Number
+			// Update dynamic TLS with CAs from the new config block.
+			if err := o.updateTLSFromConfigBlock(b); err != nil {
+				logger.Warnf("Failed to update TLS from config block %d: %v", b.Header.Number, err)
+			}
 		}
 
 		tick.Reset(o.config.Load().BlockTimeout)
@@ -568,4 +582,30 @@ func addEnvelope(c *fifoCache[any], e *common.Envelope) bool {
 	digestRaw := sha256.Sum256(e.Payload)
 	digest := base64.StdEncoding.EncodeToString(digestRaw[:])
 	return c.addIfNotExist(digest, nil)
+}
+
+// updateTLSFromConfigBlock extracts application TLS CAs from a config block
+// and updates the dynamic TLS configuration.
+// This is called when new config blocks are processed to enable runtime CA rotation.
+func (o *Orderer) updateTLSFromConfigBlock(configBlock *common.Block) error {
+	if o.tlsUpdater == nil {
+		return nil
+	}
+
+	if configBlock == nil || len(configBlock.Data.Data) == 0 {
+		return errors.New("config block is nil or has no data")
+	}
+
+	certs, err := connection.ExtractAppTLSCAsFromEnvelope(configBlock.Data.Data[0])
+	if err != nil {
+		return errors.Wrap(err, "failed to extract TLS CAs from config envelope")
+	}
+
+	if err := o.tlsUpdater.SetClientRootCAs(certs); err != nil {
+		return errors.Wrap(err, "failed to update dynamic TLS")
+	}
+
+	logger.Infof("Updated dynamic TLS with %d CA certificates from config block %d",
+		len(certs), configBlock.Header.Number)
+	return nil
 }

--- a/mock/orderer_test.go
+++ b/mock/orderer_test.go
@@ -21,9 +21,11 @@ import (
 	"github.com/hyperledger/fabric-x-common/protoutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
 
 	"github.com/hyperledger/fabric-x-committer/utils/channel"
 	"github.com/hyperledger/fabric-x-committer/utils/connection"
+	"github.com/hyperledger/fabric-x-committer/utils/grpcerror"
 	"github.com/hyperledger/fabric-x-committer/utils/test"
 	"github.com/hyperledger/fabric-x-committer/utils/testcrypto"
 )
@@ -157,7 +159,7 @@ func TestOrderer(t *testing.T) {
 		PayloadCacheSize: 10,
 		SendGenesisBlock: true,
 		ArtifactsPath:    artifactsPath,
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Minute)
@@ -308,7 +310,7 @@ func TestOrdererStreamingAPI(t *testing.T) {
 	o, err := NewMockOrderer(&OrdererConfig{
 		BlockSize:        1,
 		SendGenesisBlock: true,
-	})
+	}, nil)
 	require.NoError(t, err)
 	require.NotNil(t, o)
 	test.RunServiceForTest(t.Context(), t, func(ctx context.Context) error {
@@ -617,4 +619,139 @@ func makeEnvelopePayload(i int) *common.Envelope {
 	return &common.Envelope{
 		Payload: fmt.Appendf(nil, "%d", i),
 	}
+}
+
+// TestMockOrdererDynamicTLSUpdate verifies that the mock orderer dynamically updates
+// its trusted TLS CA pool when config blocks add or remove peer organizations.
+//
+// Test Workflow:
+//  1. Initial Setup: Start the orderer with three peer organizations (peer-org-0, peer-org-1, peer-org-2).
+//     Verify that clients from all three organizations can connect successfully.
+//  2. Dynamic Removal: Submit a new configuration block that reduces the number of
+//     peer organizations to one (only peer-org-0 remains).
+//     This removes peer-org-1 and peer-org-2 from the channel configuration.
+//  3. Negative Verification: Verify that peer-org-1 and peer-org-2 clients are now rejected
+//     because their organizations were removed from the config. Verify peer-org-0 still works.
+func TestMockOrdererDynamicTLSUpdate(t *testing.T) {
+	t.Parallel()
+
+	artifactsPath := t.TempDir()
+
+	// Step 1: Create initial config block with 3 peer organizations
+	_, err := testcrypto.CreateOrExtendConfigBlockWithCrypto(artifactsPath, &testcrypto.ConfigBlock{
+		ChannelID:             "test-channel",
+		OrdererEndpoints:      []*types.OrdererEndpoint{{ID: 0, Host: "localhost", Port: 7050}},
+		PeerOrganizationCount: 3,
+	})
+	require.NoError(t, err)
+
+	// Create server TLS config for the orderer
+	serverTLSConfig, clientTLSConfig := test.CreateServerAndClientTLSConfig(t, connection.MutualTLSMode)
+
+	// Create a real DynamicTLS instance
+	dynamicTLS, err := connection.NewDynamicTLSFromConfig(serverTLSConfig)
+	require.NoError(t, err)
+
+	// Create orderer with DynamicTLS as the TLS updater
+	o, err := NewMockOrderer(&OrdererConfig{
+		BlockSize:        3,
+		BlockTimeout:     time.Hour,
+		OutBlockCapacity: 10,
+		PayloadCacheSize: 10,
+		SendGenesisBlock: true,
+		ArtifactsPath:    artifactsPath,
+	}, dynamicTLS)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	t.Cleanup(cancel)
+
+	test.RunServiceForTest(ctx, t, func(ctx context.Context) error {
+		return connection.FilterStreamRPCError(o.Run(ctx))
+	}, o.WaitForReady)
+
+	// Start the gRPC server with the dynamic TLS provider
+	serverConfig := test.NewLocalHostServer(serverTLSConfig)
+	listener, err := serverConfig.Listener(ctx)
+	require.NoError(t, err)
+	server, err := serverConfig.GrpcServer(dynamicTLS)
+	require.NoError(t, err)
+	o.RegisterService(server)
+
+	var wg sync.WaitGroup
+	t.Cleanup(wg.Wait)
+	t.Cleanup(server.Stop)
+
+	wg.Go(func() {
+		_ = server.Serve(listener)
+	})
+
+	// Helper to attempt a connection and return an error
+	tryConnect := func(tlsCfg connection.TLSConfig) error {
+		creds, err := tlsCfg.ClientCredentials()
+		if err != nil {
+			return err
+		}
+		conn, err := grpc.NewClient(serverConfig.Endpoint.Address(), grpc.WithTransportCredentials(creds))
+		if err != nil {
+			return err
+		}
+		defer conn.Close() //nolint:errcheck
+
+		callCtx, callCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer callCancel()
+
+		client := ab.NewAtomicBroadcastClient(conn)
+		_, err = client.Deliver(callCtx)
+		// If we get an application-level error (not a TLS error), the connection succeeded
+		if grpcerror.FilterUnavailableErrorCode(err) != nil {
+			return nil
+		}
+		return err
+	}
+
+	// Build TLS configs for each peer organization
+	orgTLS := [3]connection.TLSConfig{
+		test.OrgClientTLSConfig(artifactsPath, 0, serverTLSConfig.CACertPaths),
+		test.OrgClientTLSConfig(artifactsPath, 1, serverTLSConfig.CACertPaths),
+		test.OrgClientTLSConfig(artifactsPath, 2, serverTLSConfig.CACertPaths),
+	}
+
+	// Step 1: Verify all three peer orgs can connect initially
+	t.Log("Step 1: Initial connection - all three orgs should connect")
+	for orgIdx, tlsCfg := range orgTLS {
+		require.NoError(t, tryConnect(tlsCfg), "peer-org-%d should connect initially", orgIdx)
+	}
+
+	// Step 2: Submit config block removing peer-org-1 and peer-org-2 (keep only peer-org-0)
+	t.Log("Step 2: Dynamic removal - submit config with 1 peer org")
+	newConfigBlock, err := testcrypto.CreateOrExtendConfigBlockWithCrypto(artifactsPath, &testcrypto.ConfigBlock{
+		ChannelID:             "test-channel",
+		OrdererEndpoints:      []*types.OrdererEndpoint{{ID: 0, Host: "localhost", Port: 7050}},
+		PeerOrganizationCount: 1,
+	})
+	require.NoError(t, err)
+
+	consenters, err := testcrypto.GetConsenterIdentities(artifactsPath)
+	require.NoError(t, err)
+
+	err = o.SubmitBlockWithConsenters(ctx, &BlockWithConsenters{
+		Block:            newConfigBlock,
+		ConsenterSigners: consenters,
+	})
+	require.NoError(t, err)
+
+	// Wait for the config block to be processed
+	_, err = o.GetBlock(ctx, 1)
+	require.NoError(t, err)
+
+	// Step 3: Verify peer-org-1 and peer-org-2 are rejected, peer-org-0 still works
+	t.Log("Step 3: Negative assertion - peer-org-1 and peer-org-2 rejected, peer-org-0 accepted")
+	require.NoError(t, tryConnect(orgTLS[0]), "peer-org-0 should still connect")
+	require.Error(t, tryConnect(orgTLS[1]), "peer-org-1 should be rejected")
+	require.Error(t, tryConnect(orgTLS[2]), "peer-org-2 should be rejected")
+
+	// Step 6: Verify static TLS client still works
+	t.Log("Step 6: Static persistence - static TLS client still trusted")
+	require.NoError(t, tryConnect(clientTLSConfig), "static TLS client should still connect")
 }

--- a/mock/orderer_test.go
+++ b/mock/orderer_test.go
@@ -638,8 +638,6 @@ func TestMockOrdererDynamicTLSUpdate(t *testing.T) {
 
 	// Create initial config block with 3 peer organizations
 	_, err := testcrypto.CreateOrExtendConfigBlockWithCrypto(artifactsPath, &testcrypto.ConfigBlock{
-		ChannelID:             "test-channel",
-		OrdererEndpoints:      []*types.OrdererEndpoint{{ID: 0, Host: "localhost", Port: 7050}},
 		PeerOrganizationCount: 3,
 	})
 	require.NoError(t, err)
@@ -649,7 +647,7 @@ func TestMockOrdererDynamicTLSUpdate(t *testing.T) {
 	dynamicTLS, err := connection.NewDynamicTLSFromConfig(serverTLSConfig)
 	require.NoError(t, err)
 
-	o, err := NewMockOrderer(&OrdererConfig{
+	orderer, err := NewMockOrderer(&OrdererConfig{
 		BlockSize:        3,
 		BlockTimeout:     time.Hour,
 		OutBlockCapacity: 10,
@@ -659,24 +657,23 @@ func TestMockOrdererDynamicTLSUpdate(t *testing.T) {
 	}, dynamicTLS)
 	require.NoError(t, err)
 
-	ctx, cancel := context.WithTimeout(t.Context(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Minute)
 	t.Cleanup(cancel)
 
 	test.RunServiceForTest(ctx, t, func(ctx context.Context) error {
-		return connection.FilterStreamRPCError(o.Run(ctx))
-	}, o.WaitForReady)
+		return connection.FilterStreamRPCError(orderer.Run(ctx))
+	}, orderer.WaitForReady)
 
 	serverConfig := test.NewLocalHostServer(serverTLSConfig)
 	listener, err := serverConfig.Listener(ctx)
 	require.NoError(t, err)
 	server, err := serverConfig.GrpcServer(dynamicTLS)
 	require.NoError(t, err)
-	o.RegisterService(server)
+	orderer.RegisterService(server)
 
 	var wg sync.WaitGroup
 	t.Cleanup(wg.Wait)
 	t.Cleanup(server.Stop)
-
 	wg.Go(func() {
 		_ = server.Serve(listener)
 	})
@@ -720,8 +717,6 @@ func TestMockOrdererDynamicTLSUpdate(t *testing.T) {
 
 	// Submit config block removing peer-org-1 and peer-org-2 (keep only peer-org-0)
 	newConfigBlock, err := testcrypto.CreateOrExtendConfigBlockWithCrypto(artifactsPath, &testcrypto.ConfigBlock{
-		ChannelID:             "test-channel",
-		OrdererEndpoints:      []*types.OrdererEndpoint{{ID: 0, Host: "localhost", Port: 7050}},
 		PeerOrganizationCount: 1,
 	})
 	require.NoError(t, err)
@@ -729,32 +724,29 @@ func TestMockOrdererDynamicTLSUpdate(t *testing.T) {
 	consenters, err := testcrypto.GetConsenterIdentities(artifactsPath)
 	require.NoError(t, err)
 
-	err = o.SubmitBlockWithConsenters(ctx, &BlockWithConsenters{
+	err = orderer.SubmitBlockWithConsenters(ctx, &BlockWithConsenters{
 		Block:            newConfigBlock,
 		ConsenterSigners: consenters,
 	})
 	require.NoError(t, err)
 
 	// Wait for the config block to be processed
-	_, err = o.GetBlock(ctx, 1)
+	_, err = orderer.GetBlock(ctx, 1)
 	require.NoError(t, err)
 
-	// Verify peer-org-0 still works after TLS update
-	require.Eventually(t, func() bool {
-		return tryConnect(orgTLS[0]) == nil
-	}, 20*time.Second, 100*time.Millisecond, "peer-org-0 should still connect")
-
-	// Verify peer-org-1 and peer-org-2 are rejected after TLS update
-	require.Eventually(t, func() bool {
-		return tryConnect(orgTLS[1]) != nil
-	}, 20*time.Second, 100*time.Millisecond, "peer-org-1 should be rejected")
-
-	require.Eventually(t, func() bool {
-		return tryConnect(orgTLS[2]) != nil
-	}, 20*time.Second, 100*time.Millisecond, "peer-org-2 should be rejected")
-
-	// Verify static TLS client still works
-	require.Eventually(t, func() bool {
-		return tryConnect(clientTLSConfig) == nil
-	}, 20*time.Second, 100*time.Millisecond, "static TLS client should still connect")
+	for _, tc := range []struct {
+		name          string
+		tlsCfg        connection.TLSConfig
+		shouldConnect bool
+	}{
+		{"peer-org-0 should still connect", orgTLS[0], true},
+		{"static TLS client should still connect", clientTLSConfig, true},
+		{"peer-org-1 should be rejected", orgTLS[1], false},
+		{"peer-org-2 should be rejected", orgTLS[2], false},
+	} {
+		require.Eventually(t, func() bool {
+			connected := tryConnect(tc.tlsCfg) == nil
+			return connected == tc.shouldConnect
+		}, 20*time.Second, 250*time.Millisecond, tc.name)
+	}
 }

--- a/mock/orderer_test.go
+++ b/mock/orderer_test.go
@@ -629,15 +629,14 @@ func makeEnvelopePayload(i int) *common.Envelope {
 //     Verify that clients from all three organizations can connect successfully.
 //  2. Dynamic Removal: Submit a new configuration block that reduces the number of
 //     peer organizations to one (only peer-org-0 remains).
-//     This removes peer-org-1 and peer-org-2 from the channel configuration.
-//  3. Negative Verification: Verify that peer-org-1 and peer-org-2 clients are now rejected
-//     because their organizations were removed from the config. Verify peer-org-0 still works.
+//  3. Verification: Verify that peer-org-1 and peer-org-2 clients are rejected
+//     while peer-org-0 and the static TLS client still work.
 func TestMockOrdererDynamicTLSUpdate(t *testing.T) {
 	t.Parallel()
 
 	artifactsPath := t.TempDir()
 
-	// Step 1: Create initial config block with 3 peer organizations
+	// Create initial config block with 3 peer organizations
 	_, err := testcrypto.CreateOrExtendConfigBlockWithCrypto(artifactsPath, &testcrypto.ConfigBlock{
 		ChannelID:             "test-channel",
 		OrdererEndpoints:      []*types.OrdererEndpoint{{ID: 0, Host: "localhost", Port: 7050}},
@@ -645,14 +644,11 @@ func TestMockOrdererDynamicTLSUpdate(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// Create server TLS config for the orderer
 	serverTLSConfig, clientTLSConfig := test.CreateServerAndClientTLSConfig(t, connection.MutualTLSMode)
 
-	// Create a real DynamicTLS instance
 	dynamicTLS, err := connection.NewDynamicTLSFromConfig(serverTLSConfig)
 	require.NoError(t, err)
 
-	// Create orderer with DynamicTLS as the TLS updater
 	o, err := NewMockOrderer(&OrdererConfig{
 		BlockSize:        3,
 		BlockTimeout:     time.Hour,
@@ -670,7 +666,6 @@ func TestMockOrdererDynamicTLSUpdate(t *testing.T) {
 		return connection.FilterStreamRPCError(o.Run(ctx))
 	}, o.WaitForReady)
 
-	// Start the gRPC server with the dynamic TLS provider
 	serverConfig := test.NewLocalHostServer(serverTLSConfig)
 	listener, err := serverConfig.Listener(ctx)
 	require.NoError(t, err)
@@ -686,30 +681,6 @@ func TestMockOrdererDynamicTLSUpdate(t *testing.T) {
 		_ = server.Serve(listener)
 	})
 
-	// Helper to attempt a connection and return an error
-	tryConnect := func(tlsCfg connection.TLSConfig) error {
-		creds, err := tlsCfg.ClientCredentials()
-		if err != nil {
-			return err
-		}
-		conn, err := grpc.NewClient(serverConfig.Endpoint.Address(), grpc.WithTransportCredentials(creds))
-		if err != nil {
-			return err
-		}
-		defer conn.Close() //nolint:errcheck
-
-		callCtx, callCancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer callCancel()
-
-		client := ab.NewAtomicBroadcastClient(conn)
-		_, err = client.Deliver(callCtx)
-		// If we get an application-level error (not a TLS error), the connection succeeded
-		if grpcerror.FilterUnavailableErrorCode(err) != nil {
-			return nil
-		}
-		return err
-	}
-
 	// Build TLS configs for each peer organization
 	orgTLS := [3]connection.TLSConfig{
 		test.OrgClientTLSConfig(artifactsPath, 0, serverTLSConfig.CACertPaths),
@@ -717,14 +688,37 @@ func TestMockOrdererDynamicTLSUpdate(t *testing.T) {
 		test.OrgClientTLSConfig(artifactsPath, 2, serverTLSConfig.CACertPaths),
 	}
 
-	// Step 1: Verify all three peer orgs can connect initially
-	t.Log("Step 1: Initial connection - all three orgs should connect")
-	for orgIdx, tlsCfg := range orgTLS {
-		require.NoError(t, tryConnect(tlsCfg), "peer-org-%d should connect initially", orgIdx)
+	tryConnect := func(tlsCfg connection.TLSConfig) error {
+		creds, credErr := tlsCfg.ClientCredentials()
+		if credErr != nil {
+			return credErr
+		}
+		conn, connErr := grpc.NewClient(serverConfig.Endpoint.Address(), grpc.WithTransportCredentials(creds))
+		if connErr != nil {
+			return connErr
+		}
+		defer conn.Close() //nolint:errcheck
+
+		callCtx, callCancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer callCancel()
+
+		client := ab.NewAtomicBroadcastClient(conn)
+		_, deliverErr := client.Deliver(callCtx)
+		// If we get an application-level error (not a TLS error), the connection succeeded
+		if grpcerror.FilterUnavailableErrorCode(deliverErr) != nil {
+			return nil
+		}
+		return deliverErr
 	}
 
-	// Step 2: Submit config block removing peer-org-1 and peer-org-2 (keep only peer-org-0)
-	t.Log("Step 2: Dynamic removal - submit config with 1 peer org")
+	// Verify all three peer orgs can connect initially
+	for orgIdx, tlsCfg := range orgTLS {
+		require.Eventually(t, func() bool {
+			return tryConnect(tlsCfg) == nil
+		}, 20*time.Second, 100*time.Millisecond, "peer-org-%d should connect initially", orgIdx)
+	}
+
+	// Submit config block removing peer-org-1 and peer-org-2 (keep only peer-org-0)
 	newConfigBlock, err := testcrypto.CreateOrExtendConfigBlockWithCrypto(artifactsPath, &testcrypto.ConfigBlock{
 		ChannelID:             "test-channel",
 		OrdererEndpoints:      []*types.OrdererEndpoint{{ID: 0, Host: "localhost", Port: 7050}},
@@ -745,13 +739,22 @@ func TestMockOrdererDynamicTLSUpdate(t *testing.T) {
 	_, err = o.GetBlock(ctx, 1)
 	require.NoError(t, err)
 
-	// Step 3: Verify peer-org-1 and peer-org-2 are rejected, peer-org-0 still works
-	t.Log("Step 3: Negative assertion - peer-org-1 and peer-org-2 rejected, peer-org-0 accepted")
-	require.NoError(t, tryConnect(orgTLS[0]), "peer-org-0 should still connect")
-	require.Error(t, tryConnect(orgTLS[1]), "peer-org-1 should be rejected")
-	require.Error(t, tryConnect(orgTLS[2]), "peer-org-2 should be rejected")
+	// Verify peer-org-0 still works after TLS update
+	require.Eventually(t, func() bool {
+		return tryConnect(orgTLS[0]) == nil
+	}, 20*time.Second, 100*time.Millisecond, "peer-org-0 should still connect")
 
-	// Step 6: Verify static TLS client still works
-	t.Log("Step 6: Static persistence - static TLS client still trusted")
-	require.NoError(t, tryConnect(clientTLSConfig), "static TLS client should still connect")
+	// Verify peer-org-1 and peer-org-2 are rejected after TLS update
+	require.Eventually(t, func() bool {
+		return tryConnect(orgTLS[1]) != nil
+	}, 20*time.Second, 100*time.Millisecond, "peer-org-1 should be rejected")
+
+	require.Eventually(t, func() bool {
+		return tryConnect(orgTLS[2]) != nil
+	}, 20*time.Second, 100*time.Millisecond, "peer-org-2 should be rejected")
+
+	// Verify static TLS client still works
+	require.Eventually(t, func() bool {
+		return tryConnect(clientTLSConfig) == nil
+	}, 20*time.Second, 100*time.Millisecond, "static TLS client should still connect")
 }

--- a/mock/test_exports.go
+++ b/mock/test_exports.go
@@ -200,7 +200,7 @@ func NewOrdererTestEnv(t *testing.T, p *OrdererTestParameters) *OrdererTestEnv {
 	p.OrdererConfig.ArtifactsPath = p.ArtifactsPath
 
 	// Start the system.
-	ordererService, err := NewMockOrderer(p.OrdererConfig)
+	ordererService, err := NewMockOrderer(p.OrdererConfig, nil)
 	require.NoError(t, err)
 	// Register the party states.
 	for _, ep := range allEndpoints {


### PR DESCRIPTION
#### Type of change

- New feature
- Improvement (improvement to code, performance, etc)
- Test update
 
#### Description

Enables mock-orderer to automatically load peer organization CA certificates from config blocks, eliminating the need to configure them in YAML files.

#### Additional details

* CA certificates from config blocks are merged with static CAs from YAML configuration.

#### Related issues

* Resolves #317 
