### PR TITLE
[docs] add site url to mkdocs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,6 +3,7 @@
 ---
 site_name: Fabric-X Committer
 site_description: High-throughput transaction validation and commit for Hyperledger Fabric-X
+site_url: https://hyperledger.github.io/fabric-x-committer/
 repo_url: https://github.com/hyperledger/fabric-x-committer
 repo_name: hyperledger/fabric-x-committer
 


### PR DESCRIPTION
#### Type of change

- Documentation update
 
#### Description

Added site_url (https://hyperledger.github.io/fabric-x-committer/ ) to the mkdocs so that the theme is applied. 