### PR TITLE
feat(deliverorderer): add skip-block-signature-verification escape hatch

### DIFF
--- a/utils/deliverorderer/config.go
+++ b/utils/deliverorderer/config.go
@@ -91,6 +91,9 @@ type (
 		OutputBlockWithSourceID chan<- *deliver.BlockWithSourceID
 
 		SuspicionGracePeriodPerBlock time.Duration
+
+		// SkipBlockSignatureVerification mirrors ordererdial.Config.SkipBlockSignatureVerification.
+		SkipBlockSignatureVerification bool
 	}
 
 	// SessionInfo represents the processing state of blocks to support recovery and resumption.
@@ -99,6 +102,9 @@ type (
 		LatestKnownConfig           *common.Block
 		NextBlockVerificationConfig *common.Block
 		LastBlock                   *common.Block
+
+		// SkipBlockSignatureVerification mirrors ordererdial.Config.SkipBlockSignatureVerification.
+		SkipBlockSignatureVerification bool
 	}
 )
 
@@ -130,12 +136,13 @@ func LoadParametersFromConfig(c *ordererdial.Config) (p Parameters, err error) {
 		return p, errors.WithHint(idErr, "error creating identity signer")
 	}
 	return Parameters{
-		FaultToleranceLevel:          c.FaultToleranceLevel,
-		TLS:                          *tls,
-		TLSCertHash:                  tlsCertHash,
-		Retry:                        c.Retry,
-		Signer:                       signer,
-		SuspicionGracePeriodPerBlock: c.SuspicionGracePeriodPerBlock,
-		LatestKnownConfig:            latestConfigBlock,
+		FaultToleranceLevel:            c.FaultToleranceLevel,
+		TLS:                            *tls,
+		TLSCertHash:                    tlsCertHash,
+		Retry:                          c.Retry,
+		Signer:                         signer,
+		SuspicionGracePeriodPerBlock:   c.SuspicionGracePeriodPerBlock,
+		LatestKnownConfig:              latestConfigBlock,
+		SkipBlockSignatureVerification: c.SkipBlockSignatureVerification,
 	}, nil
 }

--- a/utils/deliverorderer/orderer.go
+++ b/utils/deliverorderer/orderer.go
@@ -129,9 +129,10 @@ func newFTDelivery(odp Parameters) (*ftDelivery, error) {
 	// We use the maximum between all the provided config blocks.
 	// This ensures we won't miss a crucial config-block that updated all the endpoints and/or the credentials.
 	state, latestConfig, err := newBlockProcessingState(&SessionInfo{
-		LastBlock:                   odp.LastBlock,
-		NextBlockVerificationConfig: odp.NextBlockVerificationConfig,
-		LatestKnownConfig:           MaxBlock(odp.LatestKnownConfig, odp.NextBlockVerificationConfig),
+		LastBlock:                      odp.LastBlock,
+		NextBlockVerificationConfig:    odp.NextBlockVerificationConfig,
+		LatestKnownConfig:              MaxBlock(odp.LatestKnownConfig, odp.NextBlockVerificationConfig),
+		SkipBlockSignatureVerification: odp.SkipBlockSignatureVerification,
 	})
 	if err != nil {
 		return nil, err

--- a/utils/deliverorderer/verify.go
+++ b/utils/deliverorderer/verify.go
@@ -40,6 +40,9 @@ type (
 		*channelconfig.ConfigBlockMaterial
 		configBlockNumber uint64
 		verifierFunc      protoutil.BlockVerifierFunc
+		// skipBlockSignatureVerification mirrors ordererdial.Config.SkipBlockSignatureVerification.
+		// When true, updateIfConfigBlock leaves verifierFunc nil so verifyBlockPolicy early-returns.
+		skipBlockSignatureVerification bool
 	}
 )
 
@@ -53,6 +56,8 @@ var ErrUnexpectedBlockNumber = errors.New("received unexpected block number")
 func newBlockProcessingState(session *SessionInfo) (
 	state blockVerificationStateMachine, latestConfig configState, err error,
 ) {
+	state.skipBlockSignatureVerification = session.SkipBlockSignatureVerification
+	latestConfig.skipBlockSignatureVerification = session.SkipBlockSignatureVerification
 	// We use headers-only stream to allow providing data-less block as the last block.
 	// We process the last block before applying the config block to avoid verifying the last block.
 	// This is because the last block might be signed by previous configuration.
@@ -257,9 +262,12 @@ func (cs *configState) updateIfConfigBlock(block *common.Block) error {
 			configMaterial.ChannelID, cs.ChannelID)
 	}
 
-	verifierFunc, err := fetchVerifier(configMaterial.Bundle)
-	if err != nil {
-		return err
+	var verifierFunc protoutil.BlockVerifierFunc
+	if !cs.skipBlockSignatureVerification {
+		verifierFunc, err = fetchVerifier(configMaterial.Bundle)
+		if err != nil {
+			return err
+		}
 	}
 
 	cs.ConfigBlockMaterial = configMaterial

--- a/utils/deliverorderer/verify.go
+++ b/utils/deliverorderer/verify.go
@@ -40,6 +40,9 @@ type (
 		*channelconfig.ConfigBlockMaterial
 		configBlockNumber uint64
 		verifier          *protoutil.BlockSigVerifier
+		// skipBlockSignatureVerification mirrors ordererdial.Config.SkipBlockSignatureVerification.
+		// When true, updateIfConfigBlock leaves verifier nil so verifyBlockPolicy early-returns.
+		skipBlockSignatureVerification bool
 	}
 )
 
@@ -53,6 +56,8 @@ var ErrUnexpectedBlockNumber = errors.New("received unexpected block number")
 func newBlockProcessingState(session *SessionInfo) (
 	state blockVerificationStateMachine, latestConfig configState, err error,
 ) {
+	state.skipBlockSignatureVerification = session.SkipBlockSignatureVerification
+	latestConfig.skipBlockSignatureVerification = session.SkipBlockSignatureVerification
 	// We use headers-only stream to allow providing data-less block as the last block.
 	// We process the last block before applying the config block to avoid verifying the last block.
 	// This is because the last block might be signed by previous configuration.
@@ -257,9 +262,12 @@ func (cs *configState) updateIfConfigBlock(block *common.Block) error {
 			configMaterial.ChannelID, cs.ChannelID)
 	}
 
-	verifier, err := fetchVerifier(configMaterial.Bundle)
-	if err != nil {
-		return err
+	var verifier *protoutil.BlockSigVerifier
+	if !cs.skipBlockSignatureVerification {
+		verifier, err = fetchVerifier(configMaterial.Bundle)
+		if err != nil {
+			return err
+		}
 	}
 
 	cs.ConfigBlockMaterial = configMaterial

--- a/utils/ordererdial/config.go
+++ b/utils/ordererdial/config.go
@@ -32,6 +32,15 @@ type (
 		// The following parameters only applies to delivery.
 		Identity                     *IdentityConfig `mapstructure:"identity"`
 		SuspicionGracePeriodPerBlock time.Duration   `mapstructure:"suspicion-grace-period-per-block"`
+
+		// SkipBlockSignatureVerification disables verification of the orderer block
+		// signatures against the channel's BlockValidation policy. Required workaround
+		// for hyperledger/fabric-x-orderer, which still has a TODO in
+		// node/crypto/signer.go:Serialize returning literal "creator" instead of a
+		// real MSP-serialized identity. Without this, v0.2.0+ committers reject every
+		// non-genesis block with "implicit policy evaluation failed - 0 sub-policies
+		// were satisfied". Remove once fabric-x-orderer implements a real Serialize.
+		SkipBlockSignatureVerification bool `mapstructure:"skip-block-signature-verification"`
 	}
 
 	// IdentityConfig defines the orderer's client MSP.

--- a/utils/ordererdial/config.go
+++ b/utils/ordererdial/config.go
@@ -33,6 +33,15 @@ type (
 		// The following parameters only applies to delivery.
 		Identity                     *IdentityConfig `mapstructure:"identity"`
 		SuspicionGracePeriodPerBlock time.Duration   `mapstructure:"suspicion-grace-period-per-block"`
+
+		// SkipBlockSignatureVerification disables verification of the orderer block
+		// signatures against the channel's BlockValidation policy. Required workaround
+		// for hyperledger/fabric-x-orderer, which still has a TODO in
+		// node/crypto/signer.go:Serialize returning literal "creator" instead of a
+		// real MSP-serialized identity. Without this, v0.2.0+ committers reject every
+		// non-genesis block with "implicit policy evaluation failed - 0 sub-policies
+		// were satisfied". Remove once fabric-x-orderer implements a real Serialize.
+		SkipBlockSignatureVerification bool `mapstructure:"skip-block-signature-verification"`
 	}
 
 	// IdentityConfig defines the orderer's client MSP.


### PR DESCRIPTION
## Problem

\`fabric-x-committer\` v0.2.0 introduced block-signature verification in \`utils/deliverorderer\` (the \`verifyBlockPolicy\` path inside \`blockVerificationStateMachine\`). The check evaluates the channel's BlockValidation policy against the block metadata signatures delivered by the orderer.

\`hyperledger/fabric-x-orderer\` (all released lines — v0.0.24, v0.1.0, v1.0.0-alpha) still carries this in \`node/crypto/signer.go\`:

\`\`\`go
// TODO: implement correct Serialize
// Serialize is called when a SignatureHeader.Creator is created. Since this creator is placeholder, the SignatureHeader.Creator must be updated with correct creator.
func (s ECDSASigner) Serialize() ([]byte, error) {
    return []byte("creator"), nil
}
\`\`\`

As a result every block metadata signature carries a literal \`"creator"\` placeholder as its Creator, which does not unmarshal as an \`msp.SerializedIdentity\` and satisfies zero sub-policies of the Orderer group's Writers. Every non-genesis block is rejected with:

\`\`\`
block signature verification failed on block [N]:
implicit policy evaluation failed - 0 sub-policies were satisfied
\`\`\`

v0.1.9 worked by accident — \`deliverorderer\` did not yet do this check, so the mismatched signatures were never evaluated. v0.2.0 added the check, but the orderer side was never updated, leaving the two halves of the ecosystem mutually incompatible on default config.

## This PR

Adds an optional yaml field:

\`\`\`yaml
orderer:
  skip-block-signature-verification: true   # default: false
\`\`\`

When set, \`configState.updateIfConfigBlock\` leaves \`verifierFunc\` nil, and the existing \`if cs.verifierFunc == nil { return nil }\` guard inside \`verifyBlockPolicy\` short-circuits the check. Default is \`false\`, so anyone running against a fixed orderer keeps strict verification.

### Plumbing

- \`ordererdial.Config\` gains \`SkipBlockSignatureVerification\`.
- \`deliverorderer.Parameters\` + \`deliverorderer.SessionInfo\` mirror the flag.
- \`LoadParametersFromConfig\` copies it through.
- \`newBlockProcessingState\` seeds the state machine + latest-config.
- \`configState.updateIfConfigBlock\` leaves \`verifierFunc\` nil when the flag is set.

4 files, +38/-13.

## Why ship this as an escape hatch rather than waiting for the orderer fix

We run \`fabric-x-committer\` against the upstream orderer today and cannot proceed without an opt-in workaround. The alternative — fixing \`ECDSASigner.Serialize\` — requires protocol-level coordination (the orderer writes \`common.MetadataSignature\` with \`IdentifierHeader\` rather than \`SignatureHeader\`, so the real path to "correct" is either orderer-side \`SignatureHeader.Creator\` population or committer-side \`IdentifierHeader\` + consenter-map resolution). That's a larger change across two repos.

Shipping this flag:
- lets operators keep the deploy unblocked (required for us, probably for anyone else integrating v0.2.0+),
- defaults off so no behavior change for anyone on a fixed orderer,
- is strictly additive — trivially reversible when the orderer side is fixed. At that point, downstream config simply drops the flag and normal verification resumes.

## Testing

Running locally against \`fabric-x-orderer\` v0.1.0 + this patch:
- With \`skip-block-signature-verification: true\`: committer tails the orderer deliver stream, commits all non-genesis blocks. Token Issue / Redeem / Transfer flows through (10+ end-to-end scenarios pass).
- With flag omitted / \`false\`: reproduces \`implicit policy evaluation failed - 0 sub-policies were satisfied\` on block 1.

Happy to extend an existing test, add a unit test in \`utils/deliverorderer\`, or split the patch as reviewers prefer.