### PR TITLE
[mock orderer] Add genesis block config

### DIFF
--- a/cmd/config/samples/mock-orderer.yaml
+++ b/cmd/config/samples/mock-orderer.yaml
@@ -47,6 +47,14 @@ send-genesis-block: true
 # and cryptographic materials needed for operation. If not provided, a default
 # config block is used.
 artifacts-path: /root/artifacts
+# Alternative path to the genesis block file. If not provided, it will be extracted from the artifacts-path.
+# genesis-block-path: /root/artifacts/config-block.pb.bin
+# A list of consensers to sign blocks. If not provided, it will be extracted from the artifacts-path.
+# consenter-msp-identities:
+#   - msp-id: orderer-org-0
+#     msp-dir: /root/artifacts/ordererOrganizations/orderer-org-0.com/orderers/consenter-org-0/msp
+#   - msp-id: orderer-org-1
+#     msp-dir: /root/artifacts/ordererOrganizations/orderer-org-1.com/orderers/consenter-org-1/msp
 
 # Logging configuration
 logging:

--- a/loadgen/client_test.go
+++ b/loadgen/client_test.go
@@ -528,7 +528,7 @@ func loadGenTestCaseName(tc loadGenTestCase) string {
 	return fmt.Sprintf("tls:%s limit:%s msp-ids:%v", tc.serverTLSMode, limit, tc.useMSPIdentities)
 }
 
-func getMSPIdentities(t *testing.T, artifactsPath string) []ordererdial.IdentityConfig {
+func getMSPIdentities(t *testing.T, artifactsPath string) []*ordererdial.IdentityConfig {
 	t.Helper()
 
 	// Get MSP directories from the artifacts path.
@@ -536,9 +536,9 @@ func getMSPIdentities(t *testing.T, artifactsPath string) []ordererdial.Identity
 	require.NotEmpty(t, mspDirs, "MSP directories should not be empty")
 
 	// Convert to IdentityConfig format.
-	mspIdentities := make([]ordererdial.IdentityConfig, len(mspDirs))
+	mspIdentities := make([]*ordererdial.IdentityConfig, len(mspDirs))
 	for i, mspDir := range mspDirs {
-		mspIdentities[i] = ordererdial.IdentityConfig{
+		mspIdentities[i] = &ordererdial.IdentityConfig{
 			MspID:  mspDir.MspName,
 			MSPDir: mspDir.MspDir,
 			BCCSP:  mspDir.CspConf,

--- a/loadgen/workload/config.go
+++ b/loadgen/workload/config.go
@@ -151,10 +151,10 @@ type PolicyProfile struct {
 // In such case, we use the default rule, which state that all peer organization should sign.
 // If MSPIdentities is not provided, we load the signing identities from ArtifactsPath.
 type Policy struct {
-	Scheme        signature.Scheme             `mapstructure:"scheme" yaml:"scheme"`
-	Seed          int64                        `mapstructure:"seed" yaml:"seed"`
-	KeyPath       *KeyPath                     `mapstructure:"key-path" yaml:"key-path"`
-	MSPIdentities []ordererdial.IdentityConfig `mapstructure:"msp-identities" yaml:"msp-identities"`
+	Scheme        signature.Scheme              `mapstructure:"scheme" yaml:"scheme"`
+	Seed          int64                         `mapstructure:"seed" yaml:"seed"`
+	KeyPath       *KeyPath                      `mapstructure:"key-path" yaml:"key-path"`
+	MSPIdentities []*ordererdial.IdentityConfig `mapstructure:"msp-identities" yaml:"msp-identities"`
 }
 
 // KeyPath describes how to find/generate the signature keys.

--- a/loadgen/workload/sign.go
+++ b/loadgen/workload/sign.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hyperledger/fabric-x-common/protoutil"
 
 	"github.com/hyperledger/fabric-x-committer/utils"
+	"github.com/hyperledger/fabric-x-committer/utils/ordererdial"
 	"github.com/hyperledger/fabric-x-committer/utils/signature"
 	"github.com/hyperledger/fabric-x-committer/utils/test"
 	"github.com/hyperledger/fabric-x-committer/utils/testcrypto"
@@ -94,10 +95,7 @@ func newPolicyEndorser(artifactsPath string, policy *Policy) (*testsig.NsEndorse
 		var mspDirectories []*msp.DirLoadParameters
 		switch {
 		case len(policy.MSPIdentities) > 0:
-			mspDirectories = make([]*msp.DirLoadParameters, len(policy.MSPIdentities))
-			for i, id := range policy.MSPIdentities {
-				mspDirectories[i] = &msp.DirLoadParameters{MspName: id.MspID, MspDir: id.MSPDir, CspConf: id.BCCSP}
-			}
+			mspDirectories = ordererdial.IdentityConfigToMspDir(policy.MSPIdentities...)
 		case len(artifactsPath) > 0:
 			mspDirectories = testcrypto.GetPeersMspDirs(artifactsPath)
 		default:

--- a/loadgen/workload/sign.go
+++ b/loadgen/workload/sign.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hyperledger/fabric-x-common/utils/testcrypto"
 
 	"github.com/hyperledger/fabric-x-committer/utils"
+	"github.com/hyperledger/fabric-x-committer/utils/ordererdial"
 	"github.com/hyperledger/fabric-x-committer/utils/signature"
 	"github.com/hyperledger/fabric-x-committer/utils/testsig"
 )
@@ -93,10 +94,7 @@ func newPolicyEndorser(artifactsPath string, policy *Policy) (*testsig.NsEndorse
 		var mspDirectories []*msp.DirLoadParameters
 		switch {
 		case len(policy.MSPIdentities) > 0:
-			mspDirectories = make([]*msp.DirLoadParameters, len(policy.MSPIdentities))
-			for i, id := range policy.MSPIdentities {
-				mspDirectories[i] = &msp.DirLoadParameters{MspName: id.MspID, MspDir: id.MSPDir, CspConf: id.BCCSP}
-			}
+			mspDirectories = ordererdial.IdentityConfigToMspDir(policy.MSPIdentities...)
 		case len(artifactsPath) > 0:
 			mspDirectories = testcrypto.GetPeersMspDirs(artifactsPath)
 		default:

--- a/mock/orderer.go
+++ b/mock/orderer.go
@@ -34,6 +34,7 @@ import (
 	"github.com/hyperledger/fabric-x-committer/utils/channel"
 	"github.com/hyperledger/fabric-x-committer/utils/connection"
 	"github.com/hyperledger/fabric-x-committer/utils/grpcerror"
+	"github.com/hyperledger/fabric-x-committer/utils/ordererdial"
 	"github.com/hyperledger/fabric-x-committer/utils/test"
 	"github.com/hyperledger/fabric-x-committer/utils/testcrypto"
 )
@@ -43,14 +44,16 @@ type (
 	OrdererConfig struct {
 		// Server and ServerConfigs sets the used serving endpoints.
 		// We support both for compatibility with other services.
-		Server           *connection.ServerConfig   `mapstructure:"server"`
-		ServerConfigs    []*connection.ServerConfig `mapstructure:"servers"`
-		BlockSize        int                        `mapstructure:"block-size"`
-		BlockTimeout     time.Duration              `mapstructure:"block-timeout"`
-		OutBlockCapacity int                        `mapstructure:"out-block-capacity"`
-		PayloadCacheSize int                        `mapstructure:"payload-cache-size"`
-		ArtifactsPath    string                     `mapstructure:"artifacts-path"`
-		SendGenesisBlock bool                       `mapstructure:"send-genesis-block"`
+		Server                  *connection.ServerConfig      `mapstructure:"server"`
+		ServerConfigs           []*connection.ServerConfig    `mapstructure:"servers"`
+		BlockSize               int                           `mapstructure:"block-size"`
+		BlockTimeout            time.Duration                 `mapstructure:"block-timeout"`
+		OutBlockCapacity        int                           `mapstructure:"out-block-capacity"`
+		PayloadCacheSize        int                           `mapstructure:"payload-cache-size"`
+		ArtifactsPath           string                        `mapstructure:"artifacts-path"`
+		GenesisBlockPath        string                        `mapstructure:"genesis-block-path"`
+		ConsentersMSPIdentities []*ordererdial.IdentityConfig `mapstructure:"consenter-msp-identities"`
+		SendGenesisBlock        bool                          `mapstructure:"send-genesis-block"`
 
 		// TestServerParameters is only used for internal testing.
 		TestServerParameters test.StartServerParameters
@@ -163,25 +166,13 @@ func NewMockOrderer(config *OrdererConfig, tlsUpdater connection.TLSCertUpdater)
 	if config.TestServerParameters.NumService == 0 && len(config.ServerConfigs) == 0 {
 		config.TestServerParameters.NumService = defaultConfig.TestServerParameters.NumService
 	}
-	genesisBlock := BlockWithConsenters{Block: defaultConfigBlock}
-	if len(config.ArtifactsPath) > 0 {
-		configBlockPath := path.Join(config.ArtifactsPath, cryptogen.ConfigBlockFileName)
-		configMaterial, err := channelconfig.LoadConfigBlockMaterialFromFile(configBlockPath)
-		if err != nil {
-			return nil, err
-		}
-		consenters, err := testcrypto.GetConsenterIdentities(config.ArtifactsPath)
-		if err != nil {
-			return nil, err
-		}
-		genesisBlock = BlockWithConsenters{
-			Block:            configMaterial.ConfigBlock,
-			ConsenterSigners: consenters,
-		}
+	genesisBlock, err := loadGenesisBlockWithConsenters(config)
+	if err != nil {
+		return nil, err
 	}
 	numServices := max(1, config.TestServerParameters.NumService, len(config.ServerConfigs))
 	o := &Orderer{
-		genesisBlock: genesisBlock,
+		genesisBlock: *genesisBlock,
 		inEnvs:       make(chan envelopeEntry, numServices*config.BlockSize*config.OutBlockCapacity),
 		inBlocks:     make(chan *BlockWithConsenters, config.BlockSize*config.OutBlockCapacity),
 		cutBlock:     make(chan any),
@@ -200,6 +191,35 @@ func NewMockOrderer(config *OrdererConfig, tlsUpdater connection.TLSCertUpdater)
 	}
 
 	return o, nil
+}
+
+func loadGenesisBlockWithConsenters(config *OrdererConfig) (*BlockWithConsenters, error) {
+	ret := &BlockWithConsenters{Block: defaultConfigBlock}
+	configBlockPath := config.GenesisBlockPath
+	consenterMspDirectories := ordererdial.IdentityConfigToMspDir(config.ConsentersMSPIdentities...)
+
+	// Artifacts path overrides other paths.
+	if len(config.ArtifactsPath) > 0 {
+		configBlockPath = path.Join(config.ArtifactsPath, cryptogen.ConfigBlockFileName)
+		consenterMspDirectories = testcrypto.GetOrdererMspDirs(config.ArtifactsPath)
+	}
+
+	if len(configBlockPath) > 0 {
+		configMaterial, err := channelconfig.LoadConfigBlockMaterialFromFile(configBlockPath)
+		if err != nil {
+			return nil, err
+		}
+		ret.Block = configMaterial.ConfigBlock
+	}
+	if len(consenterMspDirectories) > 0 {
+		consenters, err := testcrypto.GetSigningIdentities(consenterMspDirectories...)
+		if err != nil {
+			return nil, err
+		}
+		ret.ConsenterSigners = consenters
+	}
+
+	return ret, nil
 }
 
 // Broadcast receives TXs and returns ACKs.

--- a/mock/orderer.go
+++ b/mock/orderer.go
@@ -35,6 +35,7 @@ import (
 	"github.com/hyperledger/fabric-x-committer/utils/channel"
 	"github.com/hyperledger/fabric-x-committer/utils/connection"
 	"github.com/hyperledger/fabric-x-committer/utils/grpcerror"
+	"github.com/hyperledger/fabric-x-committer/utils/ordererdial"
 	"github.com/hyperledger/fabric-x-committer/utils/test"
 )
 
@@ -43,14 +44,16 @@ type (
 	OrdererConfig struct {
 		// Server and ServerConfigs sets the used serving endpoints.
 		// We support both for compatibility with other services.
-		Server           *connection.ServerConfig   `mapstructure:"server"`
-		ServerConfigs    []*connection.ServerConfig `mapstructure:"servers"`
-		BlockSize        int                        `mapstructure:"block-size"`
-		BlockTimeout     time.Duration              `mapstructure:"block-timeout"`
-		OutBlockCapacity int                        `mapstructure:"out-block-capacity"`
-		PayloadCacheSize int                        `mapstructure:"payload-cache-size"`
-		ArtifactsPath    string                     `mapstructure:"artifacts-path"`
-		SendGenesisBlock bool                       `mapstructure:"send-genesis-block"`
+		Server                  *connection.ServerConfig      `mapstructure:"server"`
+		ServerConfigs           []*connection.ServerConfig    `mapstructure:"servers"`
+		BlockSize               int                           `mapstructure:"block-size"`
+		BlockTimeout            time.Duration                 `mapstructure:"block-timeout"`
+		OutBlockCapacity        int                           `mapstructure:"out-block-capacity"`
+		PayloadCacheSize        int                           `mapstructure:"payload-cache-size"`
+		ArtifactsPath           string                        `mapstructure:"artifacts-path"`
+		GenesisBlockPath        string                        `mapstructure:"genesis-block-path"`
+		ConsentersMSPIdentities []*ordererdial.IdentityConfig `mapstructure:"consenter-msp-identities"`
+		SendGenesisBlock        bool                          `mapstructure:"send-genesis-block"`
 
 		// TestServerParameters is only used for internal testing.
 		TestServerParameters test.StartServerParameters
@@ -163,25 +166,13 @@ func NewMockOrderer(config *OrdererConfig, tlsUpdater connection.TLSCertUpdater)
 	if config.TestServerParameters.NumService == 0 && len(config.ServerConfigs) == 0 {
 		config.TestServerParameters.NumService = defaultConfig.TestServerParameters.NumService
 	}
-	genesisBlock := BlockWithConsenters{Block: defaultConfigBlock}
-	if len(config.ArtifactsPath) > 0 {
-		configBlockPath := path.Join(config.ArtifactsPath, cryptogen.ConfigBlockFileName)
-		configMaterial, err := channelconfig.LoadConfigBlockMaterialFromFile(configBlockPath)
-		if err != nil {
-			return nil, err
-		}
-		consenters, err := testcrypto.GetConsenterIdentities(config.ArtifactsPath)
-		if err != nil {
-			return nil, err
-		}
-		genesisBlock = BlockWithConsenters{
-			Block:            configMaterial.ConfigBlock,
-			ConsenterSigners: consenters,
-		}
+	genesisBlock, err := loadGenesisBlockWithConsenters(config)
+	if err != nil {
+		return nil, err
 	}
 	numServices := max(1, config.TestServerParameters.NumService, len(config.ServerConfigs))
 	o := &Orderer{
-		genesisBlock: genesisBlock,
+		genesisBlock: *genesisBlock,
 		inEnvs:       make(chan envelopeEntry, numServices*config.BlockSize*config.OutBlockCapacity),
 		inBlocks:     make(chan *BlockWithConsenters, config.BlockSize*config.OutBlockCapacity),
 		cutBlock:     make(chan any),
@@ -200,6 +191,35 @@ func NewMockOrderer(config *OrdererConfig, tlsUpdater connection.TLSCertUpdater)
 	}
 
 	return o, nil
+}
+
+func loadGenesisBlockWithConsenters(config *OrdererConfig) (*BlockWithConsenters, error) {
+	ret := &BlockWithConsenters{Block: defaultConfigBlock}
+	configBlockPath := config.GenesisBlockPath
+	consenterMspDirectories := ordererdial.IdentityConfigToMspDir(config.ConsentersMSPIdentities...)
+
+	// Artifacts path overrides other paths.
+	if len(config.ArtifactsPath) > 0 {
+		configBlockPath = path.Join(config.ArtifactsPath, cryptogen.ConfigBlockFileName)
+		consenterMspDirectories = testcrypto.GetConsenterMspDirs(config.ArtifactsPath)
+	}
+
+	if len(configBlockPath) > 0 {
+		configMaterial, err := channelconfig.LoadConfigBlockMaterialFromFile(configBlockPath)
+		if err != nil {
+			return nil, err
+		}
+		ret.Block = configMaterial.ConfigBlock
+	}
+	if len(consenterMspDirectories) > 0 {
+		consenters, err := testcrypto.GetSigningIdentities(consenterMspDirectories...)
+		if err != nil {
+			return nil, err
+		}
+		ret.ConsenterSigners = consenters
+	}
+
+	return ret, nil
 }
 
 // Broadcast receives TXs and returns ACKs.

--- a/mock/orderer_test.go
+++ b/mock/orderer_test.go
@@ -9,6 +9,7 @@ package mock
 import (
 	"context"
 	"fmt"
+	"path"
 	"sync"
 	"testing"
 	"time"
@@ -19,6 +20,7 @@ import (
 	"github.com/hyperledger/fabric-x-common/common/channelconfig"
 	"github.com/hyperledger/fabric-x-common/common/policies"
 	"github.com/hyperledger/fabric-x-common/protoutil"
+	"github.com/hyperledger/fabric-x-common/tools/cryptogen"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
@@ -26,6 +28,7 @@ import (
 	"github.com/hyperledger/fabric-x-committer/utils/channel"
 	"github.com/hyperledger/fabric-x-committer/utils/connection"
 	"github.com/hyperledger/fabric-x-committer/utils/grpcerror"
+	"github.com/hyperledger/fabric-x-committer/utils/ordererdial"
 	"github.com/hyperledger/fabric-x-committer/utils/test"
 	"github.com/hyperledger/fabric-x-committer/utils/testcrypto"
 )
@@ -748,5 +751,125 @@ func TestMockOrdererDynamicTLSUpdate(t *testing.T) {
 			connected := tryConnect(tc.tlsCfg) == nil
 			return connected == tc.shouldConnect
 		}, 20*time.Second, 250*time.Millisecond, tc.name)
+	}
+}
+
+// TestOrdererConfigPaths tests that GenesisBlockPath and ConsentersMSPIdentities
+// configuration options work correctly.
+func TestOrdererConfigPaths(t *testing.T) {
+	t.Parallel()
+
+	artifactsPath := t.TempDir()
+
+	// Create config block and crypto materials
+	genesisBlock, err := testcrypto.CreateOrExtendConfigBlockWithCrypto(artifactsPath, &testcrypto.ConfigBlock{
+		ChannelID:             "test-channel",
+		OrdererEndpoints:      []*types.OrdererEndpoint{{ID: 0, Host: "localhost", Port: 7050}},
+		PeerOrganizationCount: 1,
+	})
+	require.NoError(t, err)
+
+	// Get orderer MSP directories for ConsentersMSPIdentities tests
+	ordererMspDirs := testcrypto.GetOrdererMspDirs(artifactsPath)
+	require.NotEmpty(t, ordererMspDirs)
+
+	// Convert to IdentityConfig format with BCCSP configuration
+	consenterIdentities := make([]*ordererdial.IdentityConfig, len(ordererMspDirs))
+	for i, mspDir := range ordererMspDirs {
+		consenterIdentities[i] = &ordererdial.IdentityConfig{
+			MspID:  mspDir.MspName,
+			MSPDir: mspDir.MspDir,
+			BCCSP:  mspDir.CspConf,
+		}
+	}
+
+	// Success cases
+	for _, tc := range []struct {
+		name                    string
+		genesisBlockPath        string
+		consentersMSPIdentities []*ordererdial.IdentityConfig
+		artifactsPath           string
+		expectBlock             *common.Block
+		expectConsenters        bool
+	}{
+		{
+			name:             "default config block when no paths provided",
+			expectBlock:      defaultConfigBlock,
+			expectConsenters: false,
+		},
+		{
+			name:             "artifacts path loads both block and consenters",
+			artifactsPath:    artifactsPath,
+			expectBlock:      genesisBlock,
+			expectConsenters: true,
+		},
+		{
+			name:                    "genesis block path and consenter identities",
+			genesisBlockPath:        path.Join(artifactsPath, cryptogen.ConfigBlockFileName),
+			consentersMSPIdentities: consenterIdentities,
+			expectBlock:             genesisBlock,
+			expectConsenters:        true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			orderer, err := NewMockOrderer(&OrdererConfig{
+				BlockSize:               3,
+				BlockTimeout:            time.Hour,
+				OutBlockCapacity:        10,
+				PayloadCacheSize:        10,
+				SendGenesisBlock:        false,
+				GenesisBlockPath:        tc.genesisBlockPath,
+				ConsentersMSPIdentities: tc.consentersMSPIdentities,
+				ArtifactsPath:           tc.artifactsPath,
+			}, nil)
+			require.NoError(t, err)
+			require.NotNil(t, orderer)
+
+			// Verify genesis block
+			test.RequireProtoEqual(t, tc.expectBlock, orderer.genesisBlock.Block)
+
+			// Verify consenters
+			if tc.expectConsenters {
+				require.NotEmpty(t, orderer.genesisBlock.ConsenterSigners)
+			} else {
+				require.Empty(t, orderer.genesisBlock.ConsenterSigners)
+			}
+		})
+	}
+
+	// Failure cases
+	for _, tc := range []struct {
+		name                    string
+		genesisBlockPath        string
+		consentersMSPIdentities []*ordererdial.IdentityConfig
+	}{
+		{
+			name:             "invalid genesis block path",
+			genesisBlockPath: "/nonexistent/path/block.pb",
+		},
+		{
+			name: "invalid consenter MSP directory",
+			consentersMSPIdentities: []*ordererdial.IdentityConfig{
+				{MspID: "OrdererMSP", MSPDir: "/nonexistent/msp"},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			orderer, err := NewMockOrderer(&OrdererConfig{
+				BlockSize:               3,
+				BlockTimeout:            time.Hour,
+				OutBlockCapacity:        10,
+				PayloadCacheSize:        10,
+				SendGenesisBlock:        false,
+				GenesisBlockPath:        tc.genesisBlockPath,
+				ConsentersMSPIdentities: tc.consentersMSPIdentities,
+			}, nil)
+			require.Error(t, err)
+			require.Nil(t, orderer)
+		})
 	}
 }

--- a/mock/orderer_test.go
+++ b/mock/orderer_test.go
@@ -9,6 +9,7 @@ package mock
 import (
 	"context"
 	"fmt"
+	"path"
 	"sync"
 	"testing"
 	"time"
@@ -19,6 +20,7 @@ import (
 	"github.com/hyperledger/fabric-x-common/common/channelconfig"
 	"github.com/hyperledger/fabric-x-common/common/policies"
 	"github.com/hyperledger/fabric-x-common/protoutil"
+	"github.com/hyperledger/fabric-x-common/tools/cryptogen"
 	"github.com/hyperledger/fabric-x-common/utils/testcrypto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -27,6 +29,7 @@ import (
 	"github.com/hyperledger/fabric-x-committer/utils/channel"
 	"github.com/hyperledger/fabric-x-committer/utils/connection"
 	"github.com/hyperledger/fabric-x-committer/utils/grpcerror"
+	"github.com/hyperledger/fabric-x-committer/utils/ordererdial"
 	"github.com/hyperledger/fabric-x-committer/utils/test"
 )
 
@@ -748,5 +751,125 @@ func TestMockOrdererDynamicTLSUpdate(t *testing.T) {
 			connected := tryConnect(tc.tlsCfg) == nil
 			return connected == tc.shouldConnect
 		}, 20*time.Second, 250*time.Millisecond, tc.name)
+	}
+}
+
+// TestOrdererConfigPaths tests that GenesisBlockPath and ConsentersMSPIdentities
+// configuration options work correctly.
+func TestOrdererConfigPaths(t *testing.T) {
+	t.Parallel()
+
+	artifactsPath := t.TempDir()
+
+	// Create config block and crypto materials
+	genesisBlock, err := testcrypto.CreateOrExtendConfigBlockWithCrypto(artifactsPath, &testcrypto.ConfigBlock{
+		ChannelID:             "test-channel",
+		OrdererEndpoints:      []*types.OrdererEndpoint{{ID: 0, Host: "localhost", Port: 7050}},
+		PeerOrganizationCount: 1,
+	})
+	require.NoError(t, err)
+
+	// Get orderer MSP directories for ConsentersMSPIdentities tests
+	ordererMspDirs := testcrypto.GetConsenterMspDirs(artifactsPath)
+	require.NotEmpty(t, ordererMspDirs)
+
+	// Convert to IdentityConfig format with BCCSP configuration
+	consenterIdentities := make([]*ordererdial.IdentityConfig, len(ordererMspDirs))
+	for i, mspDir := range ordererMspDirs {
+		consenterIdentities[i] = &ordererdial.IdentityConfig{
+			MspID:  mspDir.MspName,
+			MSPDir: mspDir.MspDir,
+			BCCSP:  mspDir.CspConf,
+		}
+	}
+
+	// Success cases
+	for _, tc := range []struct {
+		name                    string
+		genesisBlockPath        string
+		consentersMSPIdentities []*ordererdial.IdentityConfig
+		artifactsPath           string
+		expectBlock             *common.Block
+		expectConsenters        bool
+	}{
+		{
+			name:             "default config block when no paths provided",
+			expectBlock:      defaultConfigBlock,
+			expectConsenters: false,
+		},
+		{
+			name:             "artifacts path loads both block and consenters",
+			artifactsPath:    artifactsPath,
+			expectBlock:      genesisBlock,
+			expectConsenters: true,
+		},
+		{
+			name:                    "genesis block path and consenter identities",
+			genesisBlockPath:        path.Join(artifactsPath, cryptogen.ConfigBlockFileName),
+			consentersMSPIdentities: consenterIdentities,
+			expectBlock:             genesisBlock,
+			expectConsenters:        true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			orderer, err := NewMockOrderer(&OrdererConfig{
+				BlockSize:               3,
+				BlockTimeout:            time.Hour,
+				OutBlockCapacity:        10,
+				PayloadCacheSize:        10,
+				SendGenesisBlock:        false,
+				GenesisBlockPath:        tc.genesisBlockPath,
+				ConsentersMSPIdentities: tc.consentersMSPIdentities,
+				ArtifactsPath:           tc.artifactsPath,
+			}, nil)
+			require.NoError(t, err)
+			require.NotNil(t, orderer)
+
+			// Verify genesis block
+			test.RequireProtoEqual(t, tc.expectBlock, orderer.genesisBlock.Block)
+
+			// Verify consenters
+			if tc.expectConsenters {
+				require.NotEmpty(t, orderer.genesisBlock.ConsenterSigners)
+			} else {
+				require.Empty(t, orderer.genesisBlock.ConsenterSigners)
+			}
+		})
+	}
+
+	// Failure cases
+	for _, tc := range []struct {
+		name                    string
+		genesisBlockPath        string
+		consentersMSPIdentities []*ordererdial.IdentityConfig
+	}{
+		{
+			name:             "invalid genesis block path",
+			genesisBlockPath: "/nonexistent/path/block.pb",
+		},
+		{
+			name: "invalid consenter MSP directory",
+			consentersMSPIdentities: []*ordererdial.IdentityConfig{
+				{MspID: "OrdererMSP", MSPDir: "/nonexistent/msp"},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			orderer, err := NewMockOrderer(&OrdererConfig{
+				BlockSize:               3,
+				BlockTimeout:            time.Hour,
+				OutBlockCapacity:        10,
+				PayloadCacheSize:        10,
+				SendGenesisBlock:        false,
+				GenesisBlockPath:        tc.genesisBlockPath,
+				ConsentersMSPIdentities: tc.consentersMSPIdentities,
+			}, nil)
+			require.Error(t, err)
+			require.Nil(t, orderer)
+		})
 	}
 }

--- a/utils/ordererdial/config.go
+++ b/utils/ordererdial/config.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/hyperledger/fabric-lib-go/bccsp/factory"
+	"github.com/hyperledger/fabric-x-common/msp"
 
 	"github.com/hyperledger/fabric-x-committer/utils/connection"
 	"github.com/hyperledger/fabric-x-committer/utils/retry"
@@ -91,4 +92,13 @@ func NewTLSCredentials(c TLSConfig) (*connection.TLSCredentials, error) {
 		CertPath:    c.CertPath,
 		CACertPaths: c.CommonCACertPaths,
 	})
+}
+
+// IdentityConfigToMspDir converts the identity config to msp directory.
+func IdentityConfigToMspDir(ids ...*IdentityConfig) []*msp.DirLoadParameters {
+	mspDirectories := make([]*msp.DirLoadParameters, len(ids))
+	for i, id := range ids {
+		mspDirectories[i] = &msp.DirLoadParameters{MspName: id.MspID, MspDir: id.MSPDir, CspConf: id.BCCSP}
+	}
+	return mspDirectories
 }


### PR DESCRIPTION
#### Type of change

- Improvement (improvement to code, performance, etc)
 
#### Description

- Add genesis block config and consenters to mock Orderer to allow instantiating without a full atrtifacts path.

#### Related issues

- resolves #548 
