### PR TITLE
feat(vc): add committer init-from-snapshot bootstrap mode

### DIFF
--- a/cmd/committer/init_cmd.go
+++ b/cmd/committer/init_cmd.go
@@ -1,0 +1,89 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package main
+
+import (
+	"github.com/cockroachdb/errors"
+	"github.com/spf13/cobra"
+
+	"github.com/hyperledger/fabric-x-committer/cmd/cliutil"
+	"github.com/hyperledger/fabric-x-committer/service/vc"
+)
+
+// initFromSnapshotCMD creates the "init-from-snapshot" subcommand. It reads
+// a genesis-data file produced by the fxmigrate exporter and bootstraps the
+// validator-committer's state database from it. The command is one-shot:
+// it runs the import and exits, it does not start the VC service.
+//
+// The intended workflow is:
+//
+//  1. Operator runs the migration tool (fxmigrate) against a Fabric peer
+//     snapshot to produce a genesis-data file.
+//  2. Operator provisions a fresh database for the new Fabric-X deployment.
+//  3. Operator runs `committer init-from-snapshot --config <vc.yaml>
+//     --snapshot-data <genesis.bin>` against that fresh database.
+//  4. Operator starts the committer normally (`committer start vc`); it
+//     resumes processing at block N+1 where N is the snapshot's block height.
+func initFromSnapshotCMD() *cobra.Command {
+	var (
+		configPath   string
+		snapshotPath string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "init-from-snapshot",
+		Short: "Initialise the VC state database from a Fabric peer snapshot.",
+		Long: `init-from-snapshot bootstraps a fresh validator-committer state database
+from a genesis-data file produced by the fxmigrate exporter.
+
+The command is one-shot: it imports the snapshot and exits. The committer
+must then be started normally with "committer start vc" to resume block
+processing at the snapshot's block height + 1.
+
+This command must be run against a fresh database. Re-running on a database
+that already has the target namespace will fail rather than silently merging
+state.`,
+		Args:         cobra.NoArgs,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return runInitFromSnapshot(cmd, configPath, snapshotPath)
+		},
+	}
+
+	cliutil.SetDefaultFlags(cmd, &configPath)
+	cmd.Flags().StringVar(
+		&snapshotPath,
+		"snapshot-data",
+		"",
+		"Path to the genesis-data file produced by fxmigrate (required)",
+	)
+	if err := cmd.MarkFlagRequired("snapshot-data"); err != nil {
+		// MarkFlagRequired only errors when the flag was never registered, which
+		// would indicate a programming bug here rather than a user input issue.
+		panic(err)
+	}
+
+	return cmd
+}
+
+func runInitFromSnapshot(cmd *cobra.Command, configPath, snapshotPath string) error {
+	conf, err := readConfig(vcService, configPath)
+	if err != nil {
+		return err
+	}
+	vcConf, ok := conf.(*vc.Config)
+	if !ok {
+		return errors.Newf("init-from-snapshot requires a VC config; got %T", conf)
+	}
+
+	cmd.Printf("Initialising state database from snapshot: %s\n", snapshotPath)
+	if err := vc.BootstrapFromSnapshot(cmd.Context(), vcConf.Database, snapshotPath); err != nil {
+		return err
+	}
+	cmd.Println("Bootstrap complete. Start the committer with `committer start vc` to begin block processing.")
+	return nil
+}

--- a/cmd/committer/main.go
+++ b/cmd/committer/main.go
@@ -32,5 +32,6 @@ func committerCMD() *cobra.Command {
 	cmd.AddCommand(cliutil.VersionCmd())
 	cmd.AddCommand(startCMD())
 	cmd.AddCommand(healthcheckCMD())
+	cmd.AddCommand(initFromSnapshotCMD())
 	return cmd
 }

--- a/service/vc/bootstrap.go
+++ b/service/vc/bootstrap.go
@@ -1,0 +1,97 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package vc
+
+import (
+	"context"
+
+	"github.com/cockroachdb/errors"
+)
+
+// BootstrapFromSnapshot initialises the validator-committer's state database
+// from a genesis-data file produced by the fxmigrate exporter.
+//
+// The flow is one-shot:
+//
+//  1. Open the snapshot data file and read its header.
+//  2. Connect to the configured database via a StateImporter.
+//  3. Initialise the system schema (metadata, tx_status, __meta, __config).
+//  4. Create the namespace declared in the header.
+//  5. Stream the snapshot entries into the namespace table via PostgreSQL COPY.
+//  6. Set the last-committed block number from the header so the committer
+//     resumes processing at block N+1 when started normally.
+//  7. Cross-check the imported row count against the header's declared count
+//     to detect a truncated or partially-written snapshot file.
+//  8. Verify the persisted row count and block height in the database.
+//
+// BootstrapFromSnapshot is intended to be run against a fresh database. If the
+// target namespace already exists CreateNamespace will fail and the function
+// will return that error: silently re-importing on top of existing state would
+// mask operator error.
+func BootstrapFromSnapshot(ctx context.Context, dbConfig *DatabaseConfig, snapshotPath string) error {
+	snap, err := OpenSnapshotData(snapshotPath)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if cerr := snap.Close(); cerr != nil {
+			logger.Warnf("Failed to close snapshot data file: %v", cerr)
+		}
+	}()
+
+	hdr := snap.Header()
+	logger.Infof(
+		"Bootstrap-from-snapshot starting: namespace=%s source_channel=%s "+
+			"block_height=%d declared_entries=%d",
+		hdr.Namespace, hdr.SourceChannel, hdr.BlockHeight, hdr.EntryCount,
+	)
+
+	importer, err := NewStateImporterFromConfig(ctx, dbConfig)
+	if err != nil {
+		return err
+	}
+	defer importer.Close()
+
+	if err = importer.InitSchema(ctx); err != nil {
+		return errors.Wrap(err, "failed to init schema")
+	}
+	if err = importer.CreateNamespace(ctx, hdr.Namespace); err != nil {
+		return errors.Wrapf(err, "failed to create namespace [%s]", hdr.Namespace)
+	}
+
+	rowCount, err := importer.ImportNamespaceState(ctx, hdr.Namespace, snap)
+	if err != nil {
+		return err
+	}
+	logger.Infof("Imported %d rows into namespace [%s]", rowCount, hdr.Namespace)
+
+	if int64(hdr.EntryCount) != rowCount {
+		return errors.Newf(
+			"snapshot integrity violation: header declares %d entries but %d were imported",
+			hdr.EntryCount, rowCount,
+		)
+	}
+
+	if err = importer.SetBlockHeight(ctx, hdr.BlockHeight); err != nil {
+		return err
+	}
+
+	summary := &ImportSummary{
+		NamespaceRowCounts: map[string]int64{hdr.Namespace: rowCount},
+		BlockNumber:        hdr.BlockHeight,
+		TotalKeys:          rowCount,
+	}
+	if err = importer.VerifyImport(ctx, summary); err != nil {
+		return errors.Wrap(err, "failed to verify import")
+	}
+
+	logger.Infof(
+		"Bootstrap-from-snapshot complete: namespace=%s imported_rows=%d block_height=%d",
+		hdr.Namespace, rowCount, hdr.BlockHeight,
+	)
+	return nil
+}

--- a/service/vc/snapshot_loader.go
+++ b/service/vc/snapshot_loader.go
@@ -1,0 +1,205 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package vc
+
+import (
+	"bufio"
+	"encoding/binary"
+	"encoding/json"
+	"io"
+	"os"
+
+	"github.com/cockroachdb/errors"
+)
+
+// snapshotReadBufferSize is the size of the buffered reader wrapping the
+// snapshot file. 1 MiB is the same buffer size the producer (fxmigrate) uses,
+// keeping read patterns symmetric.
+const snapshotReadBufferSize = 1 << 20
+
+// SnapshotHeader is the JSON header at the start of a genesis-data file
+// produced by the fxmigrate exporter. The on-wire format is specified in
+// fabric-x-rfcs PR #5.
+type SnapshotHeader struct {
+	Version       string `json:"version"`
+	Namespace     string `json:"namespace"`
+	SourceChannel string `json:"source_channel"`
+	BlockHeight   uint64 `json:"block_height"`
+	ExportedAt    string `json:"exported_at"`
+	EntryCount    int    `json:"entry_count"`
+}
+
+// SnapshotData is a streaming reader over a genesis-data file. After opening,
+// the parsed header is available via Header(); the entries that follow are
+// read one at a time through the StateIterator methods (Next, Key, Value,
+// Version, Err). Close must be called when iteration is finished.
+//
+// SnapshotData satisfies the StateIterator interface so it can be passed
+// directly to StateImporter.ImportNamespaceState without an adapter.
+//
+// File format (big-endian):
+//
+//	[header_len uint32][header JSON bytes]
+//	repeated:
+//	    [key_len uint32][key bytes]
+//	    [value_len uint32][value bytes]
+//	    [version uint64]
+type SnapshotData struct {
+	file   *os.File
+	reader *bufio.Reader
+	header *SnapshotHeader
+
+	// current record, valid only after a successful Next().
+	key     []byte
+	value   []byte
+	version uint64
+
+	// sticky error: once set by a failing Next, all subsequent Next calls
+	// short-circuit to false and Err() reports the failure.
+	err error
+}
+
+// OpenSnapshotData opens the genesis-data file at path and reads its header.
+// The returned SnapshotData is positioned at the first entry and ready for
+// Next. The caller is responsible for calling Close.
+func OpenSnapshotData(path string) (*SnapshotData, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to open snapshot data file")
+	}
+
+	s := &SnapshotData{
+		file:   f,
+		reader: bufio.NewReaderSize(f, snapshotReadBufferSize),
+	}
+
+	hdr, err := s.readHeader()
+	if err != nil {
+		_ = f.Close()
+		return nil, err
+	}
+	s.header = hdr
+	return s, nil
+}
+
+// Header returns the parsed snapshot header. Available immediately after
+// OpenSnapshotData returns.
+func (s *SnapshotData) Header() *SnapshotHeader {
+	return s.header
+}
+
+// Close releases the underlying file handle.
+func (s *SnapshotData) Close() error {
+	if err := s.file.Close(); err != nil {
+		return errors.Wrap(err, "closing snapshot data file")
+	}
+	return nil
+}
+
+// Next advances to the next entry. Returns false at end-of-file or on error.
+// Use Err to distinguish a clean EOF (nil) from a read failure.
+func (s *SnapshotData) Next() bool {
+	if s.err != nil {
+		return false
+	}
+
+	key, err := s.readLenPrefixed()
+	if errors.Is(err, io.EOF) {
+		return false
+	}
+	if err != nil {
+		s.err = errors.Wrap(err, "reading entry key")
+		return false
+	}
+
+	value, err := s.readLenPrefixed()
+	if err != nil {
+		s.err = errors.Wrap(err, "reading entry value")
+		return false
+	}
+
+	version, err := s.readUint64()
+	if err != nil {
+		s.err = errors.Wrap(err, "reading entry version")
+		return false
+	}
+
+	s.key = key
+	s.value = value
+	s.version = version
+	return true
+}
+
+// Key returns the current record's key. Only valid after a successful Next.
+func (s *SnapshotData) Key() []byte { return s.key }
+
+// Value returns the current record's value. Only valid after a successful Next.
+func (s *SnapshotData) Value() []byte { return s.value }
+
+// Version returns the current record's MVCC version. Only valid after a
+// successful Next.
+func (s *SnapshotData) Version() uint64 { return s.version }
+
+// Err returns any error encountered during iteration. nil indicates a clean
+// end-of-file.
+func (s *SnapshotData) Err() error { return s.err }
+
+func (s *SnapshotData) readHeader() (*SnapshotHeader, error) {
+	hdrLen, err := s.readUint32()
+	if err != nil {
+		return nil, errors.Wrap(err, "reading header length")
+	}
+	if hdrLen == 0 {
+		return nil, errors.New("snapshot data file has empty header")
+	}
+
+	hdrBytes := make([]byte, hdrLen)
+	if _, err := io.ReadFull(s.reader, hdrBytes); err != nil {
+		return nil, errors.Wrap(err, "reading header bytes")
+	}
+
+	var hdr SnapshotHeader
+	if err := json.Unmarshal(hdrBytes, &hdr); err != nil {
+		return nil, errors.Wrap(err, "parsing header JSON")
+	}
+
+	if hdr.Namespace == "" {
+		return nil, errors.New("snapshot header has empty namespace")
+	}
+	return &hdr, nil
+}
+
+func (s *SnapshotData) readLenPrefixed() ([]byte, error) {
+	n, err := s.readUint32()
+	if err != nil {
+		return nil, err
+	}
+	if n == 0 {
+		return nil, nil
+	}
+	buf := make([]byte, n)
+	if _, err := io.ReadFull(s.reader, buf); err != nil {
+		return nil, err
+	}
+	return buf, nil
+}
+
+func (s *SnapshotData) readUint32() (uint32, error) {
+	var buf [4]byte
+	if _, err := io.ReadFull(s.reader, buf[:]); err != nil {
+		return 0, err
+	}
+	return binary.BigEndian.Uint32(buf[:]), nil
+}
+
+func (s *SnapshotData) readUint64() (uint64, error) {
+	var buf [8]byte
+	if _, err := io.ReadFull(s.reader, buf[:]); err != nil {
+		return 0, err
+	}
+	return binary.BigEndian.Uint64(buf[:]), nil
+}

--- a/service/vc/snapshot_loader_test.go
+++ b/service/vc/snapshot_loader_test.go
@@ -1,0 +1,234 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package vc
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"math"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// snapshotEntry is one key-value-version triple to write into a fixture.
+type snapshotEntry struct {
+	key     []byte
+	value   []byte
+	version uint64
+}
+
+// writeSnapshotFixture writes a genesis-data file at path with the given
+// header and entries, using the same binary layout the production reader
+// expects. Returns the file path.
+func writeSnapshotFixture(t *testing.T, path string, hdr SnapshotHeader, entries []snapshotEntry) {
+	t.Helper()
+	hdrBytes, err := json.Marshal(hdr)
+	require.NoError(t, err)
+	require.LessOrEqual(t, len(hdrBytes), math.MaxUint32)
+
+	f, err := os.Create(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = f.Close() })
+
+	write32 := func(v uint32) {
+		var buf [4]byte
+		binary.BigEndian.PutUint32(buf[:], v)
+		_, werr := f.Write(buf[:])
+		require.NoError(t, werr)
+	}
+	write64 := func(v uint64) {
+		var buf [8]byte
+		binary.BigEndian.PutUint64(buf[:], v)
+		_, werr := f.Write(buf[:])
+		require.NoError(t, werr)
+	}
+	writeBytes := func(b []byte) {
+		require.LessOrEqual(t, len(b), math.MaxUint32)
+		write32(uint32(len(b))) //nolint:gosec // length is bounds-checked above against math.MaxUint32.
+		if len(b) > 0 {
+			_, werr := f.Write(b)
+			require.NoError(t, werr)
+		}
+	}
+
+	writeBytes(hdrBytes)
+	for _, e := range entries {
+		writeBytes(e.key)
+		writeBytes(e.value)
+		write64(e.version)
+	}
+}
+
+func defaultHeader() SnapshotHeader {
+	return SnapshotHeader{
+		Version:       "1",
+		Namespace:     "token",
+		SourceChannel: "mychannel",
+		BlockHeight:   100,
+		ExportedAt:    "2026-04-22T12:00:00Z",
+		EntryCount:    0,
+	}
+}
+
+func TestOpenSnapshotData_HeaderRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "genesis.bin")
+	hdr := defaultHeader()
+	hdr.EntryCount = 2
+	writeSnapshotFixture(t, path, hdr, []snapshotEntry{
+		{key: []byte("k1"), value: []byte("v1"), version: 1},
+		{key: []byte("k2"), value: []byte("v2"), version: 2},
+	})
+
+	snap, err := OpenSnapshotData(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = snap.Close() })
+
+	got := snap.Header()
+	require.Equal(t, "1", got.Version)
+	require.Equal(t, "token", got.Namespace)
+	require.Equal(t, "mychannel", got.SourceChannel)
+	require.Equal(t, uint64(100), got.BlockHeight)
+	require.Equal(t, 2, got.EntryCount)
+}
+
+func TestOpenSnapshotData_EntryStream(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "genesis.bin")
+	want := []snapshotEntry{
+		{key: []byte("alpha"), value: []byte("aaa"), version: 10},
+		{key: []byte("beta"), value: []byte("bbb"), version: 20},
+		{key: []byte("gamma"), value: []byte("ccc"), version: 30},
+	}
+	hdr := defaultHeader()
+	hdr.EntryCount = len(want)
+	writeSnapshotFixture(t, path, hdr, want)
+
+	snap, err := OpenSnapshotData(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = snap.Close() })
+
+	var got []snapshotEntry
+	for snap.Next() {
+		got = append(got, snapshotEntry{
+			key:     append([]byte(nil), snap.Key()...),
+			value:   append([]byte(nil), snap.Value()...),
+			version: snap.Version(),
+		})
+	}
+	require.NoError(t, snap.Err())
+	require.Equal(t, want, got)
+}
+
+func TestOpenSnapshotData_EmptyEntries(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "empty.bin")
+	writeSnapshotFixture(t, path, defaultHeader(), nil)
+
+	snap, err := OpenSnapshotData(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = snap.Close() })
+
+	require.False(t, snap.Next())
+	require.NoError(t, snap.Err())
+}
+
+func TestOpenSnapshotData_BinaryValues(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "binary.bin")
+	want := []snapshotEntry{
+		{key: []byte{0x00, 0x01, 0x02}, value: []byte{0xFF, 0xFE, 0x00}, version: 99},
+	}
+	hdr := defaultHeader()
+	hdr.EntryCount = len(want)
+	writeSnapshotFixture(t, path, hdr, want)
+
+	snap, err := OpenSnapshotData(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = snap.Close() })
+
+	require.True(t, snap.Next())
+	require.Equal(t, want[0].key, snap.Key())
+	require.Equal(t, want[0].value, snap.Value())
+	require.Equal(t, want[0].version, snap.Version())
+	require.False(t, snap.Next())
+	require.NoError(t, snap.Err())
+}
+
+func TestOpenSnapshotData_MissingFile(t *testing.T) {
+	t.Parallel()
+
+	_, err := OpenSnapshotData(filepath.Join(t.TempDir(), "does-not-exist.bin"))
+	require.Error(t, err)
+}
+
+func TestOpenSnapshotData_EmptyHeader(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "bad.bin")
+	// Write a header length of zero — invalid per the format.
+	f, err := os.Create(path)
+	require.NoError(t, err)
+	var zero [4]byte
+	_, err = f.Write(zero[:])
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	_, err = OpenSnapshotData(path)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "empty header")
+}
+
+func TestOpenSnapshotData_EmptyNamespace(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "bad.bin")
+	hdr := defaultHeader()
+	hdr.Namespace = ""
+	writeSnapshotFixture(t, path, hdr, nil)
+
+	_, err := OpenSnapshotData(path)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "empty namespace")
+}
+
+func TestOpenSnapshotData_TruncatedEntry(t *testing.T) {
+	t.Parallel()
+
+	// Write a valid header followed by half of one entry's key length —
+	// the iterator should surface the truncation as an error, not a clean EOF.
+	path := filepath.Join(t.TempDir(), "truncated.bin")
+	hdrBytes, err := json.Marshal(defaultHeader())
+	require.NoError(t, err)
+
+	f, err := os.Create(path)
+	require.NoError(t, err)
+	var hdrLen [4]byte
+	binary.BigEndian.PutUint32(hdrLen[:], uint32(len(hdrBytes))) //nolint:gosec // header bytes < 4 GiB by construction.
+	_, err = f.Write(hdrLen[:])
+	require.NoError(t, err)
+	_, err = f.Write(hdrBytes)
+	require.NoError(t, err)
+	// Two bytes of a uint32 — io.ReadFull will report ErrUnexpectedEOF.
+	_, err = f.Write([]byte{0x00, 0x00})
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	snap, err := OpenSnapshotData(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = snap.Close() })
+
+	require.False(t, snap.Next())
+	require.Error(t, snap.Err())
+}

--- a/service/vc/state_import.go
+++ b/service/vc/state_import.go
@@ -1,0 +1,217 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package vc
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+
+	"github.com/cockroachdb/errors"
+	"github.com/hyperledger/fabric-x-common/api/committerpb"
+	"github.com/yugabyte/pgx/v5"
+)
+
+// StateImporter provides bulk state import capabilities for initializing the
+// committer's state database from an external source such as a Fabric peer snapshot.
+//
+// Unlike the normal transaction processing pipeline (preparer -> validator -> committer),
+// imported state bypasses MVCC validation and endorsement verification since it originates
+// from a trusted, pre-validated source. This makes it suitable for the bootstrap-from-snapshot
+// startup mode where the committer initializes its state database from a migration data file.
+//
+// Usage:
+//
+//	importer := NewStateImporter(db)
+//	_ = importer.InitSchema(ctx)
+//	_ = importer.CreateNamespace(ctx, "myns")
+//	count, _ := importer.ImportNamespaceState(ctx, "myns", iterator)
+//	_ = importer.SetBlockHeight(ctx, snapshotBlockNum)
+//	_ = importer.VerifyNamespaceRowCount(ctx, "myns", expectedCount)
+type StateImporter struct {
+	db *database
+}
+
+// NewStateImporter creates a StateImporter backed by the given database.
+// This is intended for use within the vc package and tests.
+func NewStateImporter(db *database) *StateImporter {
+	return &StateImporter{db: db}
+}
+
+// NewStateImporterFromConfig creates a StateImporter by connecting to the database
+// described by the given configuration. The caller is responsible for calling Close()
+// when the importer is no longer needed.
+func NewStateImporterFromConfig(ctx context.Context, config *DatabaseConfig) (*StateImporter, error) {
+	metrics := newVCServiceMetrics()
+	db, err := newDatabase(ctx, config, metrics)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create database for state import")
+	}
+	return &StateImporter{db: db}, nil
+}
+
+// Close releases the database connection pool held by the importer.
+func (si *StateImporter) Close() {
+	si.db.close()
+}
+
+// StateIterator provides a streaming interface for reading key-value-version
+// triples during bulk state import. Implementations should return data in
+// whatever order the source provides; the importer does not require sorted input.
+//
+// Callers must check Err() after Next() returns false to distinguish EOF from failure.
+type StateIterator interface {
+	// Next advances the iterator to the next record. Returns false when exhausted or on error.
+	Next() bool
+	// Key returns the current record's key. Only valid after a successful Next() call.
+	Key() []byte
+	// Value returns the current record's value. Only valid after a successful Next() call.
+	Value() []byte
+	// Version returns the current record's MVCC version. Only valid after a successful Next() call.
+	Version() uint64
+	// Err returns any error encountered during iteration.
+	Err() error
+}
+
+// ImportSummary contains statistics collected during a bulk import operation.
+// It can be used with VerifyImport to validate integrity after import completes.
+type ImportSummary struct {
+	// NamespaceRowCounts maps each namespace ID to the number of rows imported.
+	NamespaceRowCounts map[string]int64
+	// BlockNumber is the snapshot block height that was set during import.
+	BlockNumber uint64
+	// TotalKeys is the sum of all rows across all namespaces.
+	TotalKeys int64
+}
+
+// InitSchema creates the system tables (metadata, tx_status) and system namespace
+// tables (__meta, __config). This must be called before any other import operation.
+func (si *StateImporter) InitSchema(ctx context.Context) error {
+	return si.db.setupSystemTablesAndNamespaces(ctx)
+}
+
+// CreateNamespace creates the table and stored functions for a user-defined namespace.
+// The namespace must not already exist. System namespaces (__meta, __config) are created
+// by InitSchema and should not be passed here.
+func (si *StateImporter) CreateNamespace(ctx context.Context, nsID string) error {
+	return createNsTables(nsID, si.db.tablePreSplitTablets, func(q string) error {
+		_, err := si.db.pool.Exec(ctx, q)
+		return err
+	})
+}
+
+// ImportNamespaceState bulk-inserts key-value-version state into a namespace table
+// using PostgreSQL's COPY protocol for high throughput.
+//
+// The namespace table must already exist (created via CreateNamespace or InitSchema).
+// Returns the number of rows imported. The iterator is consumed fully; callers should
+// check iter.Err() after this method returns for any source-side errors.
+func (si *StateImporter) ImportNamespaceState(
+	ctx context.Context,
+	nsID string,
+	iter StateIterator,
+) (int64, error) {
+	tableName := pgx.Identifier{TableName(nsID)}
+	columns := []string{"key", "value", "version"}
+
+	src := &copyFromIterator{iter: iter}
+	count, err := si.db.pool.CopyFrom(ctx, tableName, columns, src)
+	if err != nil {
+		return 0, errors.Wrapf(err, "COPY into namespace [%s] failed", nsID)
+	}
+
+	if iterErr := iter.Err(); iterErr != nil {
+		return count, errors.Wrapf(iterErr, "iterator error after importing namespace [%s]", nsID)
+	}
+
+	logger.Infof("Imported %d rows into namespace [%s]", count, nsID)
+	return count, nil
+}
+
+// ImportPolicy inserts a namespace policy entry into the __meta system namespace.
+// This is used during snapshot import to register the endorsement policies for
+// each migrated namespace so that the coordinator can recover them on startup.
+func (si *StateImporter) ImportPolicy(ctx context.Context, nsID string, policy []byte) error {
+	q := FmtNsID(insertNsStatesSQLTempl, committerpb.MetaNamespaceID)
+	ret := si.db.pool.QueryRow(ctx, q, [][]byte{[]byte(nsID)}, [][]byte{policy})
+	violating, err := readArrayResult[[]byte](ret)
+	if err != nil {
+		return errors.Wrapf(err, "failed to import policy for namespace [%s]", nsID)
+	}
+	if len(violating) > 0 {
+		return errors.Newf("policy for namespace [%s] already exists", nsID)
+	}
+	return nil
+}
+
+// SetBlockHeight sets the last committed block number in the metadata table.
+// After import, the committer will resume processing from blockNumber+1.
+func (si *StateImporter) SetBlockHeight(ctx context.Context, blockNumber uint64) error {
+	v := make([]byte, 8)
+	binary.BigEndian.PutUint64(v, blockNumber)
+	_, err := si.db.pool.Exec(ctx, setMetadataPrepSQLStmt, lastCommittedBlockNumberKey, v)
+	return errors.Wrap(err, "failed to set block height after import")
+}
+
+// VerifyNamespaceRowCount checks that the actual number of rows in a namespace table
+// matches the expected count. Returns nil if they match, or an error describing the mismatch.
+func (si *StateImporter) VerifyNamespaceRowCount(ctx context.Context, nsID string, expected int64) error {
+	var actual int64
+	query := fmt.Sprintf("SELECT count(*) FROM %s", TableName(nsID))
+	if err := si.db.pool.QueryRow(ctx, query).Scan(&actual); err != nil {
+		return errors.Wrapf(err, "failed to count rows in namespace [%s]", nsID)
+	}
+	if actual != expected {
+		return errors.Newf(
+			"row count mismatch for namespace [%s]: expected %d, got %d",
+			nsID, expected, actual,
+		)
+	}
+	return nil
+}
+
+// VerifyImport validates the integrity of a completed import by checking row counts
+// for every namespace in the summary and verifying the stored block height.
+func (si *StateImporter) VerifyImport(ctx context.Context, expected *ImportSummary) error {
+	for nsID, expectedCount := range expected.NamespaceRowCounts {
+		if err := si.VerifyNamespaceRowCount(ctx, nsID, expectedCount); err != nil {
+			return err
+		}
+	}
+
+	blkRef, err := si.db.getNextBlockNumberToCommit(ctx)
+	if err != nil {
+		return errors.Wrap(err, "failed to read block height during verification")
+	}
+
+	// getNextBlockNumberToCommit returns lastCommitted+1, so we compare against expected+1.
+	if blkRef.Number != expected.BlockNumber+1 {
+		return errors.Newf(
+			"block height mismatch: expected next block %d, got %d",
+			expected.BlockNumber+1, blkRef.Number,
+		)
+	}
+
+	return nil
+}
+
+// copyFromIterator adapts a StateIterator to pgx.CopyFromSource.
+type copyFromIterator struct {
+	iter StateIterator
+}
+
+func (c *copyFromIterator) Next() bool {
+	return c.iter.Next()
+}
+
+func (c *copyFromIterator) Values() ([]any, error) {
+	return []any{c.iter.Key(), c.iter.Value(), int64(c.iter.Version())}, nil //nolint:gosec
+}
+
+func (c *copyFromIterator) Err() error {
+	return c.iter.Err()
+}

--- a/service/vc/state_import_test.go
+++ b/service/vc/state_import_test.go
@@ -1,0 +1,372 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package vc
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hyperledger/fabric-x-common/api/committerpb"
+	"github.com/stretchr/testify/require"
+)
+
+// sliceIterator is a test helper that implements StateIterator over in-memory slices.
+type sliceIterator struct {
+	keys     [][]byte
+	values   [][]byte
+	versions []uint64
+	pos      int
+	err      error
+}
+
+func newSliceIterator(keys, values [][]byte, versions []uint64) *sliceIterator {
+	return &sliceIterator{keys: keys, values: values, versions: versions, pos: -1}
+}
+
+func (s *sliceIterator) Next() bool {
+	if s.err != nil {
+		return false
+	}
+	s.pos++
+	return s.pos < len(s.keys)
+}
+
+func (s *sliceIterator) Key() []byte     { return s.keys[s.pos] }
+func (s *sliceIterator) Value() []byte   { return s.values[s.pos] }
+func (s *sliceIterator) Version() uint64 { return s.versions[s.pos] }
+func (s *sliceIterator) Err() error      { return s.err }
+
+// emptyIterator returns no records.
+type emptyIterator struct{}
+
+func (*emptyIterator) Next() bool      { return false }
+func (*emptyIterator) Key() []byte     { return nil }
+func (*emptyIterator) Value() []byte   { return nil }
+func (*emptyIterator) Version() uint64 { return 0 }
+func (*emptyIterator) Err() error      { return nil }
+
+func newImporterWithSchema(t *testing.T) (*StateImporter, *DatabaseTestEnv) {
+	t.Helper()
+	env := NewDatabaseTestEnv(t)
+	ctx, _ := createContext(t)
+	importer := NewStateImporter(env.DB)
+	require.NoError(t, importer.InitSchema(ctx))
+	return importer, env
+}
+
+func TestStateImporter_InitSchema(t *testing.T) {
+	t.Parallel()
+	env := NewDatabaseTestEnv(t)
+	ctx, _ := createContext(t)
+	importer := NewStateImporter(env.DB)
+
+	require.NoError(t, importer.InitSchema(ctx))
+
+	// Verify system tables exist.
+	tables := readTables(t, env.DB.pool)
+	require.Contains(t, tables, "metadata")
+	require.Contains(t, tables, "tx_status")
+	require.Contains(t, tables, TableName(committerpb.MetaNamespaceID))
+	require.Contains(t, tables, TableName(committerpb.ConfigNamespaceID))
+}
+
+func TestStateImporter_CreateNamespace(t *testing.T) {
+	t.Parallel()
+	importer, env := newImporterWithSchema(t)
+	ctx, _ := createContext(t)
+
+	require.NoError(t, importer.CreateNamespace(ctx, "myns"))
+
+	tables := readTables(t, env.DB.pool)
+	require.Contains(t, tables, TableName("myns"))
+
+	methods := readMethods(t, env.DB.pool)
+	require.Contains(t, methods, "insert_ns_myns")
+	require.Contains(t, methods, "update_ns_myns")
+	require.Contains(t, methods, "validate_reads_ns_myns")
+}
+
+func TestStateImporter_ImportNamespaceState(t *testing.T) {
+	t.Parallel()
+	importer, env := newImporterWithSchema(t)
+	ctx, _ := createContext(t)
+
+	require.NoError(t, importer.CreateNamespace(ctx, "importns"))
+
+	keys := [][]byte{[]byte("k1"), []byte("k2"), []byte("k3")}
+	values := [][]byte{[]byte("v1"), []byte("v2"), []byte("v3")}
+	versions := []uint64{5, 10, 15}
+
+	iter := newSliceIterator(keys, values, versions)
+	count, err := importer.ImportNamespaceState(ctx, "importns", iter)
+	require.NoError(t, err)
+	require.Equal(t, int64(3), count)
+
+	// Verify the data was written correctly.
+	rows := env.FetchKeys(t, "importns", keys)
+	require.Len(t, rows, 3)
+	require.Equal(t, []byte("v1"), rows["k1"].Value)
+	require.Equal(t, uint64(5), rows["k1"].Version)
+	require.Equal(t, []byte("v2"), rows["k2"].Value)
+	require.Equal(t, uint64(10), rows["k2"].Version)
+	require.Equal(t, []byte("v3"), rows["k3"].Value)
+	require.Equal(t, uint64(15), rows["k3"].Version)
+}
+
+func TestStateImporter_ImportNamespaceState_Empty(t *testing.T) {
+	t.Parallel()
+	importer, _ := newImporterWithSchema(t)
+	ctx, _ := createContext(t)
+
+	require.NoError(t, importer.CreateNamespace(ctx, "emptyns"))
+
+	count, err := importer.ImportNamespaceState(ctx, "emptyns", &emptyIterator{})
+	require.NoError(t, err)
+	require.Equal(t, int64(0), count)
+}
+
+func TestStateImporter_ImportNamespaceState_LargeBatch(t *testing.T) {
+	t.Parallel()
+	importer, _ := newImporterWithSchema(t)
+	ctx, _ := createContext(t)
+
+	require.NoError(t, importer.CreateNamespace(ctx, "largens"))
+
+	const numKeys = 10_000
+	keys := make([][]byte, numKeys)
+	values := make([][]byte, numKeys)
+	versions := make([]uint64, numKeys)
+	for i := range numKeys {
+		keys[i] = []byte(fmt.Sprintf("key-%06d", i))
+		values[i] = []byte(fmt.Sprintf("val-%06d", i))
+		versions[i] = uint64(i)
+	}
+
+	iter := newSliceIterator(keys, values, versions)
+	count, err := importer.ImportNamespaceState(ctx, "largens", iter)
+	require.NoError(t, err)
+	require.Equal(t, int64(numKeys), count)
+
+	// Spot-check a few rows.
+	require.NoError(t, importer.VerifyNamespaceRowCount(ctx, "largens", numKeys))
+}
+
+func TestStateImporter_ImportNamespaceState_NonexistentTable(t *testing.T) {
+	t.Parallel()
+	importer, _ := newImporterWithSchema(t)
+	ctx, _ := createContext(t)
+
+	// Table was never created — import should fail.
+	iter := newSliceIterator([][]byte{[]byte("k")}, [][]byte{[]byte("v")}, []uint64{0})
+	_, err := importer.ImportNamespaceState(ctx, "no_such_ns", iter)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "no_such_ns")
+}
+
+func TestStateImporter_ImportPolicy(t *testing.T) {
+	t.Parallel()
+	importer, env := newImporterWithSchema(t)
+	ctx, _ := createContext(t)
+
+	require.NoError(t, importer.CreateNamespace(ctx, "policyns"))
+	policyBytes := []byte("serialized-policy-data")
+
+	require.NoError(t, importer.ImportPolicy(ctx, "policyns", policyBytes))
+
+	// Verify policy was written to __meta namespace.
+	rows := env.FetchKeys(t, committerpb.MetaNamespaceID, [][]byte{[]byte("policyns")})
+	require.Len(t, rows, 1)
+	require.Equal(t, policyBytes, rows["policyns"].Value)
+}
+
+func TestStateImporter_ImportPolicy_Duplicate(t *testing.T) {
+	t.Parallel()
+	importer, _ := newImporterWithSchema(t)
+	ctx, _ := createContext(t)
+
+	require.NoError(t, importer.ImportPolicy(ctx, "dupns", []byte("policy1")))
+
+	// Second import for the same namespace should fail.
+	err := importer.ImportPolicy(ctx, "dupns", []byte("policy2"))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "already exists")
+}
+
+func TestStateImporter_SetBlockHeight(t *testing.T) {
+	t.Parallel()
+	importer, env := newImporterWithSchema(t)
+	ctx, _ := createContext(t)
+
+	require.NoError(t, importer.SetBlockHeight(ctx, 42))
+
+	// Verify via the existing database method.
+	blkRef, err := env.DB.getNextBlockNumberToCommit(ctx)
+	require.NoError(t, err)
+	require.Equal(t, uint64(43), blkRef.Number) // next = last + 1
+}
+
+func TestStateImporter_SetBlockHeight_Zero(t *testing.T) {
+	t.Parallel()
+	importer, env := newImporterWithSchema(t)
+	ctx, _ := createContext(t)
+
+	require.NoError(t, importer.SetBlockHeight(ctx, 0))
+
+	blkRef, err := env.DB.getNextBlockNumberToCommit(ctx)
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), blkRef.Number)
+}
+
+func TestStateImporter_VerifyNamespaceRowCount_Match(t *testing.T) {
+	t.Parallel()
+	importer, _ := newImporterWithSchema(t)
+	ctx, _ := createContext(t)
+
+	require.NoError(t, importer.CreateNamespace(ctx, "verifyns"))
+
+	iter := newSliceIterator(
+		[][]byte{[]byte("a"), []byte("b")},
+		[][]byte{[]byte("1"), []byte("2")},
+		[]uint64{0, 0},
+	)
+	_, err := importer.ImportNamespaceState(ctx, "verifyns", iter)
+	require.NoError(t, err)
+
+	require.NoError(t, importer.VerifyNamespaceRowCount(ctx, "verifyns", 2))
+}
+
+func TestStateImporter_VerifyNamespaceRowCount_Mismatch(t *testing.T) {
+	t.Parallel()
+	importer, _ := newImporterWithSchema(t)
+	ctx, _ := createContext(t)
+
+	require.NoError(t, importer.CreateNamespace(ctx, "mismatchns"))
+
+	iter := newSliceIterator(
+		[][]byte{[]byte("a")},
+		[][]byte{[]byte("1")},
+		[]uint64{0},
+	)
+	_, err := importer.ImportNamespaceState(ctx, "mismatchns", iter)
+	require.NoError(t, err)
+
+	err = importer.VerifyNamespaceRowCount(ctx, "mismatchns", 5)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "row count mismatch")
+	require.Contains(t, err.Error(), "expected 5")
+	require.Contains(t, err.Error(), "got 1")
+}
+
+func TestStateImporter_VerifyImport(t *testing.T) {
+	t.Parallel()
+	importer, _ := newImporterWithSchema(t)
+	ctx, _ := createContext(t)
+
+	require.NoError(t, importer.CreateNamespace(ctx, "ns_a"))
+	require.NoError(t, importer.CreateNamespace(ctx, "ns_b"))
+
+	iterA := newSliceIterator(
+		[][]byte{[]byte("k1"), []byte("k2")},
+		[][]byte{[]byte("v1"), []byte("v2")},
+		[]uint64{0, 1},
+	)
+	_, err := importer.ImportNamespaceState(ctx, "ns_a", iterA)
+	require.NoError(t, err)
+
+	iterB := newSliceIterator(
+		[][]byte{[]byte("k3")},
+		[][]byte{[]byte("v3")},
+		[]uint64{0},
+	)
+	_, err = importer.ImportNamespaceState(ctx, "ns_b", iterB)
+	require.NoError(t, err)
+
+	require.NoError(t, importer.SetBlockHeight(ctx, 100))
+
+	summary := &ImportSummary{
+		NamespaceRowCounts: map[string]int64{
+			"ns_a": 2,
+			"ns_b": 1,
+		},
+		BlockNumber: 100,
+		TotalKeys:   3,
+	}
+
+	require.NoError(t, importer.VerifyImport(ctx, summary))
+}
+
+func TestStateImporter_VerifyImport_BlockHeightMismatch(t *testing.T) {
+	t.Parallel()
+	importer, _ := newImporterWithSchema(t)
+	ctx, _ := createContext(t)
+
+	require.NoError(t, importer.SetBlockHeight(ctx, 50))
+
+	summary := &ImportSummary{
+		NamespaceRowCounts: map[string]int64{},
+		BlockNumber:        99, // does not match
+	}
+
+	err := importer.VerifyImport(ctx, summary)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "block height mismatch")
+}
+
+func TestStateImporter_EndToEnd_MultiNamespace(t *testing.T) {
+	t.Parallel()
+	importer, env := newImporterWithSchema(t)
+	ctx, _ := createContext(t)
+
+	// Simulate importing a Fabric snapshot with 3 namespaces.
+	namespaces := []string{"chaincode1", "chaincode2", "lifecycle"}
+	for _, ns := range namespaces {
+		require.NoError(t, importer.CreateNamespace(ctx, ns))
+		require.NoError(t, importer.ImportPolicy(ctx, ns, []byte("policy-for-"+ns)))
+	}
+
+	// Import state for each namespace.
+	summary := &ImportSummary{
+		NamespaceRowCounts: make(map[string]int64),
+	}
+
+	for i, ns := range namespaces {
+		numKeys := (i + 1) * 100
+		keys := make([][]byte, numKeys)
+		values := make([][]byte, numKeys)
+		versions := make([]uint64, numKeys)
+		for j := range numKeys {
+			keys[j] = []byte(fmt.Sprintf("%s-key-%04d", ns, j))
+			values[j] = []byte(fmt.Sprintf("%s-val-%04d", ns, j))
+			versions[j] = uint64(j)
+		}
+
+		count, err := importer.ImportNamespaceState(ctx, ns, newSliceIterator(keys, values, versions))
+		require.NoError(t, err)
+		require.Equal(t, int64(numKeys), count)
+		summary.NamespaceRowCounts[ns] = int64(numKeys)
+		summary.TotalKeys += int64(numKeys)
+	}
+
+	// Set block height.
+	summary.BlockNumber = 500
+	require.NoError(t, importer.SetBlockHeight(ctx, summary.BlockNumber))
+
+	// Full verification.
+	require.NoError(t, importer.VerifyImport(ctx, summary))
+
+	// Verify policies are readable by the existing readNamespacePolicies method.
+	policies, err := env.DB.readNamespacePolicies(ctx)
+	require.NoError(t, err)
+	require.Len(t, policies.Policies, len(namespaces))
+
+	// Verify data survives and is usable by the normal pipeline — spot-check reads.
+	for _, ns := range namespaces {
+		rows := env.FetchKeys(t, ns, [][]byte{[]byte(ns + "-key-0000")})
+		require.Len(t, rows, 1)
+		require.Equal(t, []byte(ns+"-val-0000"), rows[ns+"-key-0000"].Value)
+	}
+}

--- a/service/vc/test_exports.go
+++ b/service/vc/test_exports.go
@@ -356,6 +356,11 @@ func (env *DatabaseTestEnv) rowExists(t *testing.T, nsID string, exp namespaceWr
 	}
 }
 
+// NewStateImporterForTest creates a StateImporter backed by the test environment's database.
+func (env *DatabaseTestEnv) NewStateImporterForTest() *StateImporter {
+	return NewStateImporter(env.DB)
+}
+
 func (env *DatabaseTestEnv) rowNotExists(t *testing.T, nsID string, keys [][]byte) {
 	t.Helper()
 	actualRows := env.FetchKeys(t, nsID, keys)


### PR DESCRIPTION
> ⚠️ **Stacked on top of #516.** This PR's diff includes the StateImporter commit from that PR — please review #516 first or alongside this one. Once #516 merges, this PR will rebase onto `main` and the diff will collapse to only the bootstrap-mode files listed below.

## What this PR adds

This is the missing seam between the Exporter CLI ([hyperledger/fabric-x#97](https://github.com/hyperledger/fabric-x/pull/97), [hyperledger/fabric-x#180](https://github.com/hyperledger/fabric-x/pull/180)) and the StateImporter primitives in #516. It gives the committer a **one-shot bootstrap mode** so an operator can take a `genesis-data` file produced by the migration tool and use it to initialise a fresh Fabric-X state database.

```
fabric peer snapshot
      │
      │  fxmigrate export   (hyperledger/fabric-x#97)
      ▼
genesis-data file
      │
      │  committer init-from-snapshot   (this PR)
      │    └─► StateImporter             (#516)
      ▼
populated VC state database
      │
      │  fxmigrate verify   (hyperledger/fabric-x#180)
      ▼
integrity report
```

This addresses **deliverable #3** of the LFX mentorship issue [LF-Decentralized-Trust-Mentorships/mentorship-program#65](https://github.com/LF-Decentralized-Trust-Mentorships/mentorship-program/issues/65) ("Bootstrap-from-snapshot feature in the Fabric-X committer").

## Files

| File | Purpose |
|---|---|
| `service/vc/snapshot_loader.go` | Streaming reader for the genesis-data binary format documented in [hyperledger/fabric-x-rfcs#5](https://github.com/hyperledger/fabric-x-rfcs/pull/5). Defines `SnapshotHeader` and `SnapshotData`. `SnapshotData` implements the `StateIterator` interface from #516 so it plugs straight into `ImportNamespaceState` without an adapter layer. |
| `service/vc/snapshot_loader_test.go` | Eight unit tests covering the binary parser end-to-end: header round-trip, full entry stream, empty entries, binary value bytes, missing file, empty header, empty namespace, and a truncated entry to verify that a partial write surfaces as a non-nil `Err()` rather than a clean EOF. |
| `service/vc/bootstrap.go` | Orchestrator. `BootstrapFromSnapshot` opens the snapshot, creates a `StateImporter`, runs `InitSchema → CreateNamespace → ImportNamespaceState → SetBlockHeight → VerifyImport`, and cross-checks the imported row count against the header's declared count to catch a truncated snapshot before the operator starts the committer for real. |
| `cmd/committer/init_cmd.go` | The user-facing subcommand: `committer init-from-snapshot --config <vc.yaml> --snapshot-data <genesis.bin>`. Sibling to `start` and `healthcheck`. One-shot: imports the snapshot and exits. |
| `cmd/committer/main.go` | Registers the new subcommand on the root. |

## Operator workflow

```
# 1. Migrate state out of the source Fabric peer:
fxmigrate export \
  --snapshot ./peer/snapshots/completed/mychannel/100 \
  --channel  mychannel \
  --namespace token \
  --output   genesis.bin

# 2. Provision a fresh Fabric-X DB and bootstrap it:
committer init-from-snapshot \
  --config       vc-config.yaml \
  --snapshot-data genesis.bin

# 3. Cross-check before going live:
fxmigrate verify \
  --genesis  genesis.bin \
  --snapshot ./peer/snapshots/completed/mychannel/100

# 4. Start the committer normally — it will resume at block N+1:
committer start vc --config vc-config.yaml
```

## Design choices worth flagging for the reviewer

- **Independent format parser, not a cross-repo import.** The genesis-data format is a contract documented in fabric-x-rfcs#5; the producer (fxmigrate, in `hyperledger/fabric-x`) and the consumer (this committer) implement it independently. Avoids a Go module dependency between `fabric-x-committer` and `fabric-x` flowing in either direction. Open to revisiting if you'd prefer one canonical implementation.
- **Subcommand sibling, not a flag on `start`.** Bootstrap is one-shot initialisation, not a service mode. Matches the structure used by `healthcheck` and avoids overloading `start vc` with semantics that change behaviour mid-flight.
- **Single namespace per snapshot file.** That is what the genesis-data format already supports; multi-namespace would be a format change and should be addressed in the RFC first.
- **No idempotency / re-run guard.** `CreateNamespace` fails if the target namespace already exists; surfacing the conflict to the operator is preferable to silently merging into existing state on a re-run.
- **No transaction-ID history migration.** Consistent with the RFC's decision (security/format incompatibility); only state and block height are bootstrapped.

## What's deliberately deferred

- **End-to-end integration tests against a real Postgres** — both the bootstrap orchestrator and the CLI surface tests need a running DB. I'd like to add them on this branch in a follow-up commit once the design is acked, rather than bloat the initial review.
- **Policy import.** The current genesis-data format from fxmigrate doesn't carry namespace policies; once the format is extended, `BootstrapFromSnapshot` can call `ImportPolicy` from this same orchestrator with no change to the CLI surface.

## Testing

- `go build ./...` — clean.
- `go vet ./...` — clean.
- `golangci-lint run --new-from-rev=upstream/main` — no findings on the files added by this PR.
- `go test ./service/vc/... -run TestOpenSnapshotData` — all eight unit tests pass.

## Related work

- RFC: [hyperledger/fabric-x-rfcs#5](https://github.com/hyperledger/fabric-x-rfcs/pull/5)
- StateImporter primitives: #516 (this PR depends on it)
- Migration tool — Exporter CLI: [hyperledger/fabric-x#97](https://github.com/hyperledger/fabric-x/pull/97)
- Migration tool — verify command: [hyperledger/fabric-x#180](https://github.com/hyperledger/fabric-x/pull/180)
- LFX mentorship issue: [LF-Decentralized-Trust-Mentorships/mentorship-program#65](https://github.com/LF-Decentralized-Trust-Mentorships/mentorship-program/issues/65)
