### PR TITLE
Rename MetricsEndpoint to HTTPEndpoint and MetricsTLS to httpTLS

### DIFF
--- a/cmd/cliutil/test_exports.go
+++ b/cmd/cliutil/test_exports.go
@@ -85,10 +85,10 @@ func StartDefaultSystem(t *testing.T) config.SystemConfig {
 
 func convertServiceConfig(c *serve.Config) config.ServiceConfig {
 	return config.ServiceConfig{
-		GrpcEndpoint:    &c.GRPC.Endpoint,
-		MetricsEndpoint: &c.HTTP.Endpoint,
-		GrpcTLS:         c.GRPC.TLS,
-		MetricsTLS:      c.HTTP.TLS,
+		GrpcEndpoint: &c.GRPC.Endpoint,
+		HTTPEndpoint: &c.HTTP.Endpoint,
+		GrpcTLS:      c.GRPC.TLS,
+		HTTPTLS:      c.HTTP.TLS,
 	}
 }
 

--- a/cmd/config/create_config_file.go
+++ b/cmd/config/create_config_file.go
@@ -78,10 +78,10 @@ type (
 
 	// ServiceConfig stores the service's server and metrics endpoints, along with their TLS configuration.
 	ServiceConfig struct {
-		GrpcEndpoint    *connection.Endpoint
-		MetricsEndpoint *connection.Endpoint
-		GrpcTLS         connection.TLSConfig
-		MetricsTLS      connection.TLSConfig
+		GrpcEndpoint *connection.Endpoint
+		HTTPEndpoint *connection.Endpoint
+		GrpcTLS      connection.TLSConfig
+		HTTPTLS      connection.TLSConfig
 	}
 
 	// DatabaseConfig represents the used DB.

--- a/cmd/config/templates/shared.yaml.tmpl
+++ b/cmd/config/templates/shared.yaml.tmpl
@@ -54,7 +54,7 @@ endpoints:
 {{- /* {{ include "monitoring" . | indent 0 }} */ -}}
 {{- define "monitoring" }}
 monitoring:
-{{ include "endpointWithTLS" (dict "Endpoint" (.ThisService.MetricsEndpoint | default "localhost:0") "TLS" .ThisService.MetricsTLS) | indent 2 }}
+{{ include "endpointWithTLS" (dict "Endpoint" (.ThisService.HTTPEndpoint | default "localhost:0") "TLS" .ThisService.HTTPTLS) | indent 2 }}
 {{- end }}
 
 {{- /* {{ include "logging" . | indent 0 }} */ -}}

--- a/integration/runner/ports.go
+++ b/integration/runner/ports.go
@@ -48,9 +48,9 @@ func (p *serviceAllocator) allocateService(t *testing.T, count int) []config.Ser
 	for i := range serviceConfigs {
 		conf := &serviceConfigs[i]
 		conf.GrpcEndpoint = p.allocateEndpoint(t)
-		conf.MetricsEndpoint = p.allocateEndpoint(t)
+		conf.HTTPEndpoint = p.allocateEndpoint(t)
 		conf.GrpcTLS, _ = p.credFactory.CreateServerCredentials(t, p.tlsMode, conf.GrpcEndpoint.Host)
-		conf.MetricsTLS, _ = p.credFactory.CreateServerCredentials(t, p.tlsMode, conf.MetricsEndpoint.Host)
+		conf.HTTPTLS, _ = p.credFactory.CreateServerCredentials(t, p.tlsMode, conf.HTTPEndpoint.Host)
 	}
 	return serviceConfigs
 }

--- a/integration/test/loadgen_test.go
+++ b/integration/test/loadgen_test.go
@@ -77,7 +77,7 @@ func TestLoadGenWithTLSModes(t *testing.T) {
 					require.NoError(t, err)
 
 					metricsURL, err := monitoring.MakeMetricsURL(
-						c.SystemConfig.Services.LoadGen.MetricsEndpoint.Address(), &c.SystemConfig.ClientTLS,
+						c.SystemConfig.Services.LoadGen.HTTPEndpoint.Address(), &c.SystemConfig.ClientTLS,
 					)
 					require.NoError(t, err)
 					require.EventuallyWithT(t, func(ct *assert.CollectT) {


### PR DESCRIPTION
#### Type of change

- Improvement (improvement to code, performance, etc)
 
#### Description

- Rename MetricsEndpoint to HTTPEndpoint and MetricsTLS to httpTLS

#### Related issues

- resolves #563 