### PR TITLE
Fix dead/missing Prometheus metrics in verifier and VC service

### DIFF
--- a/docs/metrics_reference.md
+++ b/docs/metrics_reference.md
@@ -83,27 +83,26 @@ The following Verifier metrics are exported for consumption by Prometheus.
 
 The following Validator-Committer metrics are exported for consumption by Prometheus.
 
-| Name                                                                            | Type      | Labels | Description                                                                                                    |
-|---------------------------------------------------------------------------------|-----------|--------|----------------------------------------------------------------------------------------------------------------|
-| vcservice_grpc_received_transaction_total                                       | counter   |        | Number of transactions received by the service                                                                 |
-| vcservice_grpc_processed_transaction_total                                      | counter   |        | Number of transactions processed by the service                                                                |
-| vcservice_committed_transaction_total                                           | counter   |        | The total number of transactions committed                                                                     |
-| vcservice_mvcc_conflict_total                                                   | counter   |        | The total number of transactions that failed due to MVCC conflict                                              |
-| vcservice_duplicate_transaction_total                                           | counter   |        | The total number of duplicate transactions                                                                     |
-| vcservice_preparer_input_queue_size                                             | gauge     |        | The preparer input queue size                                                                                  |
-| vcservice_validator_input_queue_size                                            | gauge     |        | The validator input queue size                                                                                 |
-| vcservice_committer_input_queue_size                                            | gauge     |        | The committer input queue size                                                                                 |
-| vcservice_txstatus_output_queue_size                                            | gauge     |        | The txstatus output queue size                                                                                 |
-| vcservice_preparer_tx_batch_latency_seconds                                     | histogram |        | The latency of the preparer processing a batch of transactions                                                 |
-| vcservice_validator_tx_batch_latency_seconds                                    | histogram |        | The latency of the validator processing a batch of transactions                                                |
-| vcservice_committer_tx_batch_latency_seconds                                    | histogram |        | The latency of the committer processing a batch of transactions                                                |
-| vcservice_database_tx_batch_validation_latency_seconds                          | histogram |        | The latency of the database validating a batch of transactions                                                 |
-| vcservice_database_tx_batch_query_version_latency_seconds                       | histogram |        | The latency of the database querying version for keys in a batch of transactions                               |
-| vcservice_database_tx_batch_commit_latency_seconds                              | histogram |        | The latency of the database committing a batch of transactions                                                 |
-| vcservice_database_tx_batch_commit_txs_status_latency_seconds                   | histogram |        | The latency of the database committing a batch of transactions and updating their status                       |
-| vcservice_database_tx_batch_commit_update_latency_seconds                       | histogram |        | The latency of the database committing a batch of transactions which involes updating existing keys            |
-| vcservice_database_tx_batch_commit_insert_new_key_with_value_latency_seconds    | histogram |        | The latency of the database committing a batch of transactions which involes inserting new keys with values    |
-| vcservice_database_tx_batch_commit_insert_new_key_without_value_latency_seconds | histogram |        | The latency of the database committing a batch of transactions which involes inserting new keys without values |
+| Name                                                                         | Type      | Labels | Description                                                                                                 |
+|------------------------------------------------------------------------------|-----------|--------|-------------------------------------------------------------------------------------------------------------|
+| vcservice_grpc_received_transaction_total                                    | counter   |        | Number of transactions received by the service                                                              |
+| vcservice_grpc_processed_transaction_total                                   | counter   |        | Number of transactions processed by the service                                                             |
+| vcservice_committed_transaction_total                                        | counter   |        | The total number of transactions committed                                                                  |
+| vcservice_mvcc_conflict_total                                                | counter   |        | The total number of transactions that failed due to MVCC conflict                                           |
+| vcservice_duplicate_transaction_total                                        | counter   |        | The total number of duplicate transactions                                                                  |
+| vcservice_preparer_input_queue_size                                          | gauge     |        | The preparer input queue size                                                                               |
+| vcservice_validator_input_queue_size                                         | gauge     |        | The validator input queue size                                                                              |
+| vcservice_committer_input_queue_size                                         | gauge     |        | The committer input queue size                                                                              |
+| vcservice_txstatus_output_queue_size                                         | gauge     |        | The txstatus output queue size                                                                              |
+| vcservice_preparer_tx_batch_latency_seconds                                  | histogram |        | The latency of the preparer processing a batch of transactions                                              |
+| vcservice_validator_tx_batch_latency_seconds                                 | histogram |        | The latency of the validator processing a batch of transactions                                             |
+| vcservice_committer_tx_batch_latency_seconds                                 | histogram |        | The latency of the committer processing a batch of transactions                                             |
+| vcservice_database_tx_batch_validation_latency_seconds                       | histogram |        | The latency of the database validating a batch of transactions                                              |
+| vcservice_database_tx_batch_query_version_latency_seconds                    | histogram |        | The latency of the database querying version for keys in a batch of transactions                            |
+| vcservice_database_tx_batch_commit_latency_seconds                           | histogram |        | The latency of the database committing a batch of transactions                                              |
+| vcservice_database_tx_batch_commit_txs_status_latency_seconds                | histogram |        | The latency of the database committing a batch of transactions and updating their status                    |
+| vcservice_database_tx_batch_commit_update_latency_seconds                    | histogram |        | The latency of the database committing a batch of transactions which involes updating existing keys         |
+| vcservice_database_tx_batch_commit_insert_new_key_with_value_latency_seconds | histogram |        | The latency of the database committing a batch of transactions which involes inserting new keys with values |
 
 ## Query Service Metrics
 

--- a/service/vc/metrics.go
+++ b/service/vc/metrics.go
@@ -35,13 +35,12 @@ type perfMetrics struct {
 	validatorTxBatchLatencySeconds prometheus.Histogram
 	committerTxBatchLatencySeconds prometheus.Histogram
 
-	databaseTxBatchValidationLatencySeconds                     prometheus.Histogram
-	databaseTxBatchQueryVersionLatencySeconds                   prometheus.Histogram
-	databaseTxBatchCommitLatencySeconds                         prometheus.Histogram
-	databaseTxBatchCommitTxsStatusLatencySeconds                prometheus.Histogram
-	databaseTxBatchCommitUpdateLatencySeconds                   prometheus.Histogram
-	databaseTxBatchCommitInsertNewKeyWithoutValueLatencySeconds prometheus.Histogram
-	databaseTxBatchCommitInsertNewKeyWithValueLatencySeconds    prometheus.Histogram
+	databaseTxBatchValidationLatencySeconds                  prometheus.Histogram
+	databaseTxBatchQueryVersionLatencySeconds                prometheus.Histogram
+	databaseTxBatchCommitLatencySeconds                      prometheus.Histogram
+	databaseTxBatchCommitTxsStatusLatencySeconds             prometheus.Histogram
+	databaseTxBatchCommitUpdateLatencySeconds                prometheus.Histogram
+	databaseTxBatchCommitInsertNewKeyWithValueLatencySeconds prometheus.Histogram
 }
 
 func newVCServiceMetrics() *perfMetrics {
@@ -163,14 +162,6 @@ func newVCServiceMetrics() *perfMetrics {
 			Name:      "tx_batch_commit_insert_new_key_with_value_latency_seconds",
 			Help: "The latency of the database committing a batch of transactions which involes " +
 				"inserting new keys with values",
-			Buckets: buckets,
-		}),
-		databaseTxBatchCommitInsertNewKeyWithoutValueLatencySeconds: p.NewHistogram(prometheus.HistogramOpts{
-			Namespace: "vcservice",
-			Subsystem: "database",
-			Name:      "tx_batch_commit_insert_new_key_without_value_latency_seconds",
-			Help: "The latency of the database committing a batch of transactions which involes " +
-				"inserting new keys without values",
 			Buckets: buckets,
 		}),
 	}

--- a/service/verifier/metrics.go
+++ b/service/verifier/metrics.go
@@ -27,7 +27,7 @@ func newMonitoring() *metrics {
 			Namespace: "verifier_server",
 			Subsystem: "tx",
 		}),
-		ActiveStreams: prometheus.NewGauge(prometheus.GaugeOpts{
+		ActiveStreams: p.NewGauge(prometheus.GaugeOpts{
 			Namespace: "verifier_server",
 			Subsystem: "grpc",
 			Name:      "active_streams",


### PR DESCRIPTION
#### Type of change

- Bug fix

#### Description

- verifier: register ActiveStreams gauge with provider (p.NewGauge) instead of raw prometheus.NewGauge() so it appears on /metrics endpoint. The unregistered gauge was never scraped, making the Active Streams dashboard panel always empty.

- vc: remove databaseTxBatchCommitInsertNewKeyWithoutValueLatencySeconds histogram. This metric was declared and registered but never observed because no separate code path for 'insert without value' exists — all inserts go through insertStates() which records InsertNewKeyWithValueLatency. The dead metric caused an always-empty dashboard panel.

#### Related issues

  - resolves #578 
  - resolves #579 
