### PR TITLE
[vc] Delay DB connection to Run()

### DIFF
--- a/cmd/committer/start_cmd.go
+++ b/cmd/committer/start_cmd.go
@@ -70,12 +70,7 @@ func startService(ctx context.Context, name, configPath string) error {
 		service = coordinator.NewCoordinatorService(c)
 
 	case *vc.Config:
-		vcService, err := vc.NewValidatorCommitterService(ctx, c)
-		if err != nil {
-			return errors.Wrap(err, "failed to create validator committer service")
-		}
-		defer vcService.Close()
-		service = vcService
+		service = vc.NewValidatorCommitterService(ctx, c)
 
 	case *verifier.Config:
 		service = verifier.New(c)

--- a/cmd/config/samples/vc.yaml
+++ b/cmd/config/samples/vc.yaml
@@ -39,6 +39,13 @@ monitoring:
     #   - Must be greater than 0
     #   - Must be less than or equal to requests-per-second
     burst: 0
+
+# Maximum time to wait for the VC service to become ready before startup fails.
+# The VC service is considered ready after it successfully
+# establishes a connection pool to the database.
+# Default: 5m
+startup-timeout: 5m
+
 # Database connection configuration
 database:
   # List of database endpoints to connect to. For YugabyteDB clusters, list all nodes.

--- a/loadgen/client_test.go
+++ b/loadgen/client_test.go
@@ -482,6 +482,8 @@ func clientConfigWithOrdererForTestCase(t *testing.T, tc loadGenTestCase) (
 			//nolint:gosec // uint64 -> int.
 			BlockSize:        int(lgEnv.clientConf.LoadProfile.Block.MaxSize),
 			SendGenesisBlock: true,
+			// We use large enough payload cache size to avoid repeated TXs.
+			PayloadCacheSize: 1024 * 1024,
 		},
 		ArtifactsPath:   policy.ArtifactsPath,
 		ServerTLSConfig: lgEnv.serverTLSConfig,

--- a/service/vc/committer.go
+++ b/service/vc/committer.go
@@ -23,8 +23,6 @@ import (
 
 // transactionCommitter is responsible for committing the transactions.
 type transactionCommitter struct {
-	// db is a handler for the state database holding all the committed states
-	db *database
 	// incomingValidatedTransactions is the channel from which the committer receives the validated transactions
 	// from the validator
 	incomingValidatedTransactions <-chan *validatedTransactions
@@ -37,37 +35,32 @@ type transactionCommitter struct {
 
 // newCommitter creates a new transactionCommitter.
 func newCommitter(
-	db *database,
 	validatedTxs <-chan *validatedTransactions,
 	txsStatus chan<- *committerpb.TxStatusBatch,
 	metrics *perfMetrics,
 ) *transactionCommitter {
 	logger.Info("Initializing new committer")
 	return &transactionCommitter{
-		db:                            db,
 		incomingValidatedTransactions: validatedTxs,
 		outgoingTransactionsStatus:    txsStatus,
 		metrics:                       metrics,
 	}
 }
 
-func (c *transactionCommitter) run(ctx context.Context, numWorkers int) error {
+func (c *transactionCommitter) run(ctx context.Context, db *database, numWorkers int) error {
 	logger.Infof("Starting transactionCommitter with %d workers", numWorkers)
 	g, eCtx := errgroup.WithContext(ctx)
 	for range numWorkers {
 		g.Go(func() error {
-			return c.commit(eCtx)
+			return c.commit(eCtx, db)
 		})
 	}
 
 	return g.Wait()
 }
 
-func (c *transactionCommitter) commit(ctx context.Context) error {
+func (c *transactionCommitter) commit(ctx context.Context, db *database) error {
 	// NOTE: Three retry is adequate for now. We can make it configurable in the future.
-	var txsStatus *committerpb.TxStatusBatch
-	var err error
-
 	incomingValidatedTransactions := channel.NewReader(ctx, c.incomingValidatedTransactions)
 	outgoingTransactionsStatus := channel.NewWriter(ctx, c.outgoingTransactionsStatus)
 	for {
@@ -85,7 +78,7 @@ func (c *transactionCommitter) commit(ctx context.Context) error {
 		// Rather than distinguishing retryable transaction error, we retry for all errors.
 		// This is for simplicity and we can improve it in future.
 		// TODO: Add test to ensure commit is retried.
-		txsStatus, err = c.commitTransactions(ctx, vTx)
+		txsStatus, err := c.commitTransactions(ctx, db, vTx)
 		if err != nil {
 			return fmt.Errorf("failed to commit transactions: %w", err)
 		}
@@ -100,10 +93,11 @@ func (c *transactionCommitter) commit(ctx context.Context) error {
 
 func (c *transactionCommitter) commitTransactions(
 	ctx context.Context,
+	db *database,
 	vTx *validatedTransactions,
 ) (*committerpb.TxStatusBatch, error) {
 	// We eliminate blind writes outside the retry loop to avoid doing it more than once.
-	if err := c.populateVersionsAndCategorizeBlindWrites(ctx, vTx); err != nil {
+	if err := c.populateVersionsAndCategorizeBlindWrites(ctx, db, vTx); err != nil {
 		return nil, err
 	}
 
@@ -137,8 +131,8 @@ func (c *transactionCommitter) commitTransactions(
 			txIDToHeight: vTx.txIDToHeight,
 		}
 
-		res, retryErr := retry.ExecuteWithResult(ctx, c.db.retryProfile, func() (*commitResult, error) {
-			return c.db.commit(ctx, info)
+		res, retryErr := retry.ExecuteWithResult(ctx, db.retryProfile, func() (*commitResult, error) {
+			return db.commit(ctx, info)
 		})
 		if retryErr != nil {
 			return nil, retryErr
@@ -152,7 +146,7 @@ func (c *transactionCommitter) commitTransactions(
 			//       The setCorrectStatusForDuplicateTxID function checks whether the transaction is truly a
 			//       duplicate or a resubmission. If it is a resubmission, it retrieves the correct status from
 			//       the tx_status table.
-			if err := c.setCorrectStatusForDuplicateTxID(ctx, info.batchStatus, info.txIDToHeight); err != nil {
+			if err := c.setCorrectStatusForDuplicateTxID(ctx, db, info.batchStatus, info.txIDToHeight); err != nil {
 				return nil, fmt.Errorf("failed to set correct status for duplicate txs: %w", err)
 			}
 			return info.batchStatus, nil
@@ -189,13 +183,13 @@ func prepareStatusForCommit(vTx *validatedTransactions) *committerpb.TxStatusBat
 // populateVersionsAndCategorizeBlindWrites fetches the current version of the blind-writes keys, and assigns them
 // to the appropriate category (new/update).
 func (c *transactionCommitter) populateVersionsAndCategorizeBlindWrites(
-	ctx context.Context, vTx *validatedTransactions,
+	ctx context.Context, db *database, vTx *validatedTransactions,
 ) error {
 	state := make(map[string]keyToVersion)
 	for nsID, writes := range groupWritesByNamespace(vTx.validTxBlindWrites) {
 		// TODO: Though we could run the following in a goroutine per namespace, we restrain
 		// 		 from doing so till we evaluate the performance
-		versionOfPresentKeys, err := c.db.queryVersionsIfPresent(ctx, nsID, writes.keys)
+		versionOfPresentKeys, err := db.queryVersionsIfPresent(ctx, nsID, writes.keys)
 		if err != nil {
 			return err
 		}
@@ -225,6 +219,7 @@ func (c *transactionCommitter) populateVersionsAndCategorizeBlindWrites(
 
 func (c *transactionCommitter) setCorrectStatusForDuplicateTxID(
 	ctx context.Context,
+	db *database,
 	txsStatus *committerpb.TxStatusBatch,
 	txIDToHeight transactionIDToHeight,
 ) error {
@@ -241,7 +236,7 @@ func (c *transactionCommitter) setCorrectStatusForDuplicateTxID(
 		return nil
 	}
 
-	idStatusHeight, err := c.db.readStatusWithHeight(ctx, dupTxIDs)
+	idStatusHeight, err := db.readStatusWithHeight(ctx, dupTxIDs)
 	if err != nil {
 		return err
 	}

--- a/service/vc/committer_test.go
+++ b/service/vc/committer_test.go
@@ -34,9 +34,9 @@ func newCommitterTestEnv(t *testing.T) *committerTestEnv {
 
 	dbEnv := newDatabaseTestEnvWithTablesSetup(t)
 	metrics := newVCServiceMetrics()
-	c := newCommitter(dbEnv.DB, validatedTxs, txStatus, metrics)
+	c := newCommitter(validatedTxs, txStatus, metrics)
 	test.RunServiceForTest(t.Context(), t, func(ctx context.Context) error {
-		return c.run(ctx, 1)
+		return c.run(ctx, dbEnv.DB, 1)
 	}, nil)
 	return &committerTestEnv{
 		c:            c,

--- a/service/vc/database.go
+++ b/service/vc/database.go
@@ -91,25 +91,10 @@ func newDatabase(ctx context.Context, config *DatabaseConfig, metrics *perfMetri
 
 	logger.Infof("validator persister connected to database at [%s]", config.EndpointsString())
 
-	defer func() {
-		if err != nil {
-			pool.Close()
-		}
-	}()
-
-	tablePreSplitTablets := config.TablePreSplitTablets
-	if tablePreSplitTablets > 0 {
-		isYugabyte, err := isYugabyteDB(ctx, pool)
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to detect database type")
-		}
-
-		if !isYugabyte {
-			logger.Info("PostgreSQL detected; ignoring table-pre-split-tablets configuration")
-			tablePreSplitTablets = 0
-		} else {
-			logger.Infof("YugabyteDB detected; tables will be pre-split into %d tablets", tablePreSplitTablets)
-		}
+	tablePreSplitTablets, err := getTablePreSplitTablets(ctx, pool, config)
+	if err != nil {
+		pool.Close()
+		return nil, err
 	}
 
 	return &database{
@@ -118,6 +103,26 @@ func newDatabase(ctx context.Context, config *DatabaseConfig, metrics *perfMetri
 		retryProfile:         config.Retry,
 		tablePreSplitTablets: tablePreSplitTablets,
 	}, nil
+}
+
+func getTablePreSplitTablets(ctx context.Context, pg *pgxpool.Pool, config *DatabaseConfig) (int, error) {
+	tablePreSplitTablets := config.TablePreSplitTablets
+	if tablePreSplitTablets == 0 {
+		return 0, nil
+	}
+
+	isYugabyte, err := isYugabyteDB(ctx, pg)
+	if err != nil {
+		return 0, errors.Wrap(err, "failed to detect database type")
+	}
+
+	if !isYugabyte {
+		logger.Info("PostgreSQL detected; ignoring table-pre-split-tablets configuration")
+		tablePreSplitTablets = 0
+	} else {
+		logger.Infof("YugabyteDB detected; tables will be pre-split into %d tablets", tablePreSplitTablets)
+	}
+	return tablePreSplitTablets, nil
 }
 
 // isYugabyteDB queries the database version string to determine whether the backend is YugabyteDB.

--- a/service/vc/test_exports.go
+++ b/service/vc/test_exports.go
@@ -87,9 +87,7 @@ func NewValidatorAndCommitServiceTestEnv(t *testing.T, opts *TestEnvOpts) *Valid
 			ResourceLimits: opts.ResourceLimits,
 		}
 		serverConfig := test.NewLocalHostServiceConfig(opts.ServerCreds)
-		vcs, err := NewValidatorCommitterService(initCtx, config)
-		require.NoError(t, err)
-		t.Cleanup(vcs.Close)
+		vcs := NewValidatorCommitterService(initCtx, config)
 		test.RunServiceAndServeForTest(t.Context(), t, vcs, serverConfig)
 		vcservices[i] = vcs
 		configs[i] = config

--- a/service/vc/validator.go
+++ b/service/vc/validator.go
@@ -21,8 +21,6 @@ import (
 
 // transactionValidator validates the reads of transactions against the committed states.
 type transactionValidator struct {
-	// db is the state database holding all the committed states.
-	db *database
 	// incomingPreparedTransactions is the channel from which the validator receives prepared transactions.
 	incomingPreparedTransactions <-chan *preparedTransactions
 	// outgoingValidatedTransactions is the channel to which the validator sends validated transactions so that
@@ -58,14 +56,12 @@ func (v *validatedTransactions) Debug() {
 
 // newValidator creates a new validator.
 func newValidator(
-	db *database,
 	preparedTxs <-chan *preparedTransactions,
 	validatedTxs chan<- *validatedTransactions,
 	metrics *perfMetrics,
 ) *transactionValidator {
 	logger.Info("Initializing new validator")
 	return &transactionValidator{
-		db:                            db,
 		incomingPreparedTransactions:  preparedTxs,
 		outgoingValidatedTransactions: validatedTxs,
 		metrics:                       metrics,
@@ -73,19 +69,19 @@ func newValidator(
 }
 
 // start starts the validator with the given number of workers.
-func (v *transactionValidator) run(ctx context.Context, numWorkers int) error {
+func (v *transactionValidator) run(ctx context.Context, db *database, numWorkers int) error {
 	logger.Infof("Starting Validator with %d workers", numWorkers)
 	g, eCtx := errgroup.WithContext(ctx)
 	for range numWorkers {
 		g.Go(func() error {
-			return v.validate(eCtx)
+			return v.validate(eCtx, db)
 		})
 	}
 
 	return g.Wait()
 }
 
-func (v *transactionValidator) validate(ctx context.Context) error {
+func (v *transactionValidator) validate(ctx context.Context, db *database) error {
 	incomingPreparedTransactions := channel.NewReader(ctx, v.incomingPreparedTransactions)
 	outgoingValidatedTransactions := channel.NewWriter(ctx, v.outgoingValidatedTransactions)
 
@@ -103,7 +99,7 @@ func (v *transactionValidator) validate(ctx context.Context) error {
 		// 		 over parallelize and make contention among preparer, validator, and committer
 		//       goroutines to acquire the CPU. Based on performance evaluation, we can decide
 		//       to run per namespace validation in parallel.
-		nsToReadConflicts, valErr := v.validateReads(ctx, prepTx.nsToReads)
+		nsToReadConflicts, valErr := v.validateReads(ctx, db, prepTx.nsToReads)
 		if valErr != nil {
 			return valErr
 		}
@@ -132,6 +128,7 @@ func (v *transactionValidator) validate(ctx context.Context) error {
 
 func (v *transactionValidator) validateReads(
 	ctx context.Context,
+	db *database,
 	nsToReads namespaceToReads,
 ) (namespaceToReads /* conflicts */, error) {
 	// nsToReadConflicts maintains all conflicting reads per namespace.
@@ -139,7 +136,7 @@ func (v *transactionValidator) validateReads(
 	nsToReadConflicts := make(namespaceToReads)
 
 	for nsID, r := range nsToReads {
-		conflicts, err := v.db.validateNamespaceReads(ctx, nsID, r)
+		conflicts, err := db.validateNamespaceReads(ctx, nsID, r)
 		if err != nil {
 			return nil, err
 		}

--- a/service/vc/validator_committer_service.go
+++ b/service/vc/validator_committer_service.go
@@ -64,6 +64,7 @@ type ValidatorCommitterService struct {
 	// Further, when isStreamActive is active, NumberOfWaitingTransactionsForStatus would return an
 	// error as this gRPC api can be called only when the stream is inactive.
 	isStreamActive atomic.Bool
+	ready          *channel.Ready
 }
 
 // NewValidatorCommitterService creates a new ValidatorCommitterService.
@@ -73,7 +74,7 @@ type ValidatorCommitterService struct {
 func NewValidatorCommitterService(
 	ctx context.Context,
 	config *Config,
-) (*ValidatorCommitterService, error) {
+) *ValidatorCommitterService {
 	logger.Info("Initializing new validator committer service.")
 	l := config.ResourceLimits
 
@@ -86,35 +87,36 @@ func NewValidatorCommitterService(
 	txsStatus := make(chan *committerpb.TxStatusBatch, l.MaxWorkersForCommitter*queueMultiplier)
 
 	metrics := newVCServiceMetrics()
-	db, err := newDatabase(ctx, config.Database, metrics)
-	if err != nil {
-		logger.Errorf("%+v", err)
-		return nil, err
-	}
-
-	vc := &ValidatorCommitterService{
+	return &ValidatorCommitterService{
 		preparer:                 newPreparer(toPrepareTxs, preparedTxs, metrics),
-		validator:                newValidator(db, preparedTxs, validatedTxs, metrics),
-		committer:                newCommitter(db, validatedTxs, txsStatus, metrics),
+		validator:                newValidator(preparedTxs, validatedTxs, metrics),
+		committer:                newCommitter(validatedTxs, txsStatus, metrics),
 		receivedTxBatch:          receivedTxBatch,
 		toPrepareTxs:             toPrepareTxs,
 		preparedTxs:              preparedTxs,
 		validatedTxs:             validatedTxs,
 		txsStatus:                txsStatus,
-		db:                       db,
 		metrics:                  metrics,
 		minTxBatchSize:           config.ResourceLimits.MinTransactionBatchSize,
 		timeoutForMinTxBatchSize: config.ResourceLimits.TimeoutForMinTransactionBatchSize,
 		config:                   config,
 		healthcheck:              serve.DefaultHealthCheckService(),
+		ready:                    channel.NewReady(),
 	}
-	return vc, nil
 }
 
 // Run starts the validator and committer service.
 func (vc *ValidatorCommitterService) Run(ctx context.Context) error {
 	logger.Info("Starting ValidatorCommitterService")
-	defer vc.Close()
+	db, err := newDatabase(ctx, vc.config.Database, vc.metrics)
+	if err != nil {
+		return err
+	}
+	defer db.close()
+	vc.db = db
+	vc.ready.SignalReady()
+	defer vc.ready.Reset()
+
 	g, eCtx := errgroup.WithContext(ctx)
 
 	g.Go(func() error {
@@ -136,12 +138,12 @@ func (vc *ValidatorCommitterService) Run(ctx context.Context) error {
 
 	logger.Infof("Starting %d workers for the transaction validator", l.MaxWorkersForValidator)
 	g.Go(func() error {
-		return vc.validator.run(eCtx, l.MaxWorkersForValidator)
+		return vc.validator.run(eCtx, db, l.MaxWorkersForValidator)
 	})
 
 	logger.Infof("Starting %d workers for the transaction committer", l.MaxWorkersForCommitter)
 	g.Go(func() error {
-		return vc.committer.run(eCtx, l.MaxWorkersForCommitter)
+		return vc.committer.run(eCtx, db, l.MaxWorkersForCommitter)
 	})
 
 	if err := g.Wait(); err != nil {
@@ -152,10 +154,10 @@ func (vc *ValidatorCommitterService) Run(ctx context.Context) error {
 	return nil
 }
 
-// WaitForReady indicates if the service is ready to be exposed as a gRPC service.
-// This implementation always returns true as the service is considered ready immediately.
-func (*ValidatorCommitterService) WaitForReady(context.Context) bool {
-	return true
+// WaitForReady wait for the service to be ready to be exposed as gRPC service.
+// If the context ended before the service is ready, returns false.
+func (vc *ValidatorCommitterService) WaitForReady(ctx context.Context) bool {
+	return vc.ready.WaitForReady(ctx)
 }
 
 // RegisterService registers the validator-committer's gRPC services and monitoring server.
@@ -387,9 +389,4 @@ func (vc *ValidatorCommitterService) sendTransactionStatus(
 		promutil.AddToCounter(vc.metrics.transactionDuplicateTxTotal, dup)
 		promutil.AddToCounter(vc.metrics.transactionProcessedTotal, len(txStatus.Status))
 	}
-}
-
-// Close is closing the db connection.
-func (vc *ValidatorCommitterService) Close() {
-	vc.db.close()
 }

--- a/service/vc/validator_test.go
+++ b/service/vc/validator_test.go
@@ -33,9 +33,9 @@ func newValidatorTestEnv(t *testing.T) *validatorTestEnv {
 
 	dbEnv := newDatabaseTestEnvWithTablesSetup(t)
 	metrics := newVCServiceMetrics()
-	v := newValidator(dbEnv.DB, preparedTxs, validatedTxs, metrics)
+	v := newValidator(preparedTxs, validatedTxs, metrics)
 	test.RunServiceForTest(t.Context(), t, func(ctx context.Context) error {
-		return v.run(ctx, 1)
+		return v.run(ctx, dbEnv.DB, 1)
 	}, nil)
 
 	return &validatorTestEnv{


### PR DESCRIPTION
#### Type of change

- Bug fix
 
#### Description

- Delay DB connection to Run()
- Increase the loadgen-test payload-cache-size to prevent repeated TXs

#### Additional details

If VC was created but Run() was not called, and Close() was not called manually, the DB connection will remain open (resource leak).
This PR resolves that by delaying the DB connection to the Run() method, closing it automatically when Run() ends.

#### Related issues

- resolves #587
- resolves #537 
