### PR TITLE
Fix arma block verifier BFT detection in sidecar

### DIFF
--- a/utils/deliverorderer/verify.go
+++ b/utils/deliverorderer/verify.go
@@ -285,7 +285,7 @@ func fetchVerifier(bundle *channelconfig.Bundle) (*protoutil.BlockSigVerifier, e
 	}
 
 	var consenters []*common.Consenter
-	bftEnabled := bundle.ChannelConfig().Capabilities().ConsensusTypeBFT()
+	bftEnabled := oc.ConsensusType() == "BFT" || oc.ConsensusType() == "arma"
 	if bftEnabled {
 		consenters = oc.Consenters()
 	}

--- a/utils/deliverorderer/verify_test.go
+++ b/utils/deliverorderer/verify_test.go
@@ -450,7 +450,9 @@ func TestUpdateIfConfigBlock(t *testing.T) {
 		configBlock, err := testcrypto.CreateOrExtendConfigBlockWithCrypto(cryptoDir, &testcrypto.ConfigBlock{
 			ChannelID: "test-channel",
 			OrdererEndpoints: []*commontypes.OrdererEndpoint{
-				{ID: 0, Host: "127.0.0.1", Port: 1000},
+				{ID: 1, Host: "127.0.0.1", Port: 1000},
+				{ID: 2, Host: "127.0.0.1", Port: 1001},
+				{ID: 3, Host: "127.0.0.1", Port: 1002},
 			},
 		})
 		require.NoError(t, err)
@@ -461,7 +463,14 @@ func TestUpdateIfConfigBlock(t *testing.T) {
 		assert.Equal(t, configBlock.Header.Number, cs.configBlockNumber)
 		assert.NotNil(t, cs.ConfigBlock)
 		assert.NotNil(t, cs.verifier)
-		assert.Len(t, cs.OrdererOrganizations, 1)
+		assert.Len(t, cs.OrdererOrganizations, 3)
+
+		configMaterial, err := channelconfig.LoadConfigBlockMaterial(configBlock)
+		require.NoError(t, err)
+		verifier, err := fetchVerifier(configMaterial.Bundle)
+		require.NoError(t, err)
+		assert.True(t, verifier.BFT)
+		assert.Len(t, verifier.Consenters, 3)
 	})
 
 	t.Run("Malformed config block (invalid envelope) - treated as non-config", func(t *testing.T) {


### PR DESCRIPTION
#### Type of change

- Bug fix
 
#### Description

Enable BFT block signature verification when orderer consensus type is arma, not only when channel capabilities report BFT support. Arma blocks carry BFT signatures via IdentifierHeader, and channels may not enable V3_0 capabilities.

Without this, sidecar treats arma blocks as non-BFT, ignores consenters, and rejects block 1 with signature policy failures.
