### PR TITLE
[sidecar] Fix empty ledger newest delivery seek

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0
 	github.com/hyperledger/fabric-lib-go v1.1.3
 	github.com/hyperledger/fabric-protos-go-apiv2 v0.3.7
-	github.com/hyperledger/fabric-x-common v0.2.4
+	github.com/hyperledger/fabric-x-common v0.2.5-0.20260526151648-855f12b2d438
 	github.com/jackc/puddle/v2 v2.2.2
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/prometheus/client_golang v1.23.2

--- a/go.sum
+++ b/go.sum
@@ -188,8 +188,8 @@ github.com/hyperledger/fabric-lib-go v1.1.3 h1:alvgtBlbm373P3BLIxdHKVT4I64mORDwQ
 github.com/hyperledger/fabric-lib-go v1.1.3/go.mod h1:zwnGaLwmQ/usgC6Xbzh8jCnOniViRHSsg7WYErxbr30=
 github.com/hyperledger/fabric-protos-go-apiv2 v0.3.7 h1:sQ5qv8vQQfwewa1JlCiSCC8dLElmaU2/frLolpgibEY=
 github.com/hyperledger/fabric-protos-go-apiv2 v0.3.7/go.mod h1:bJnwzfv03oZQeCc863pdGTDgf5nmCy6Za3RAE7d2XsQ=
-github.com/hyperledger/fabric-x-common v0.2.4 h1:HUhppbbQ35Zw4v/TrjPQ6kYvu3kBrqop1lVlfmWHZF0=
-github.com/hyperledger/fabric-x-common v0.2.4/go.mod h1:EdyBG6jVFYYxJ5DgjxGVLE/Lav3GPhdftABZv5j+ttg=
+github.com/hyperledger/fabric-x-common v0.2.5-0.20260526151648-855f12b2d438 h1:yVjqCihBd0YJ58XyldjlrGc+7+87fIftQE+eVXwrPlE=
+github.com/hyperledger/fabric-x-common v0.2.5-0.20260526151648-855f12b2d438/go.mod h1:EdyBG6jVFYYxJ5DgjxGVLE/Lav3GPhdftABZv5j+ttg=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imkira/go-interpol v1.1.0 h1:KIiKr0VSG2CUW1hl1jpiyuzuJeKUUpC8iM1AIE7N1Vk=
 github.com/imkira/go-interpol v1.1.0/go.mod h1:z0h2/2T3XF8kyEPpRgJ3kmNv+C43p+I/CoI+jC3w2iA=

--- a/service/sidecar/block_delivery_test.go
+++ b/service/sidecar/block_delivery_test.go
@@ -7,7 +7,9 @@ SPDX-License-Identifier: Apache-2.0
 package sidecar
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"github.com/hyperledger/fabric-protos-go-apiv2/common"
 	ab "github.com/hyperledger/fabric-protos-go-apiv2/orderer"
@@ -18,6 +20,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/hyperledger/fabric-x-committer/utils/connection"
 	"github.com/hyperledger/fabric-x-committer/utils/serve"
 	"github.com/hyperledger/fabric-x-committer/utils/test"
 )
@@ -132,17 +135,116 @@ func newBlockStoreWithBlocks(t *testing.T, numBlocks int) (*blockStore, [][3]str
 // seekEnvelope creates a signed deliver envelope requesting blocks [start, stop].
 func seekEnvelope(t *testing.T, start, stop uint64) *common.Envelope {
 	t.Helper()
+	return seekEnvelopeWithSeekInfo(t, &ab.SeekInfo{
+		Start:    &ab.SeekPosition{Type: &ab.SeekPosition_Specified{Specified: &ab.SeekSpecified{Number: start}}},
+		Stop:     &ab.SeekPosition{Type: &ab.SeekPosition_Specified{Specified: &ab.SeekSpecified{Number: stop}}},
+		Behavior: ab.SeekInfo_BLOCK_UNTIL_READY,
+	})
+}
+
+// seekEnvelopeWithSeekInfo creates a signed deliver envelope with the given SeekInfo.
+func seekEnvelopeWithSeekInfo(t *testing.T, seekInfo *ab.SeekInfo) *common.Envelope {
+	t.Helper()
 	env, err := protoutil.CreateSignedEnvelope(
 		common.HeaderType_DELIVER_SEEK_INFO,
 		"",
 		nil, // no signer needed — the sidecar doesn't verify deliver request signatures.
-		&ab.SeekInfo{
-			Start:    &ab.SeekPosition{Type: &ab.SeekPosition_Specified{Specified: &ab.SeekSpecified{Number: start}}},
-			Stop:     &ab.SeekPosition{Type: &ab.SeekPosition_Specified{Specified: &ab.SeekSpecified{Number: stop}}},
-			Behavior: ab.SeekInfo_BLOCK_UNTIL_READY,
-		},
+		seekInfo,
 		0, 0,
 	)
 	require.NoError(t, err)
 	return env
+}
+
+func TestBlockDeliveryWaitsForBlockZeroOnEmptyLedger(t *testing.T) {
+	t.Parallel()
+
+	type deliverResult struct {
+		response *peer.DeliverResponse
+		err      error
+	}
+
+	for _, tc := range []struct {
+		name     string
+		seekInfo *ab.SeekInfo
+	}{
+		{
+			name: "newest stop",
+			seekInfo: &ab.SeekInfo{
+				Start:    &ab.SeekPosition{Type: &ab.SeekPosition_Specified{Specified: &ab.SeekSpecified{Number: 0}}},
+				Stop:     &ab.SeekPosition{Type: &ab.SeekPosition_Newest{Newest: &ab.SeekNewest{}}},
+				Behavior: ab.SeekInfo_BLOCK_UNTIL_READY,
+			},
+		},
+		{
+			name: "newest start and stop",
+			seekInfo: &ab.SeekInfo{
+				Start:    &ab.SeekPosition{Type: &ab.SeekPosition_Newest{Newest: &ab.SeekNewest{}}},
+				Stop:     &ab.SeekPosition{Type: &ab.SeekPosition_Newest{Newest: &ab.SeekNewest{}}},
+				Behavior: ab.SeekInfo_BLOCK_UNTIL_READY,
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			metrics := newPerformanceMetrics()
+			bs, err := newBlockStore(t.TempDir(), 0, metrics)
+			require.NoError(t, err)
+			t.Cleanup(bs.close)
+
+			wrapper := &blockDeliveryWrapper{Service: &Service{blockStore: bs, metrics: metrics}}
+			serverConfig := test.NewLocalHostServiceConfig(test.InsecureTLSConfig)
+			test.ServeForTest(t.Context(), t, serverConfig, wrapper)
+			conn := test.NewInsecureConnection(t, &serverConfig.GRPC.Endpoint)
+			deliverClient := peer.NewDeliverClient(conn)
+
+			streamCtx, streamCancel := context.WithCancel(t.Context())
+			defer streamCancel()
+			stream, err := deliverClient.Deliver(streamCtx)
+			require.NoError(t, err)
+			require.NoError(t, stream.Send(seekEnvelopeWithSeekInfo(t, tc.seekInfo)))
+
+			resultCh := make(chan deliverResult, 1)
+			go func() {
+				resp, recvErr := stream.Recv()
+				resultCh <- deliverResult{response: resp, err: recvErr}
+			}()
+
+			require.Never(t, func() bool {
+				return len(resultCh) > 0
+			}, time.Second, 250*time.Millisecond, "deliver returned before block 0 was available")
+
+			inputBlock := make(chan *common.Block, 10)
+			test.RunServiceForTest(t.Context(), t, func(ctx context.Context) error {
+				return connection.FilterStreamRPCError(bs.run(ctx, &blockStoreRunConfig{
+					IncomingCommittedBlock: inputBlock,
+				}))
+			}, nil)
+
+			valid := byte(committerpb.Status_COMMITTED)
+			metadata := &common.BlockMetadata{
+				Metadata: [][]byte{nil, nil, {valid, valid, valid}},
+			}
+			blk, _ := createBlockForTest(t, 0, nil)
+			blk.Metadata = metadata
+			inputBlock <- blk
+			ensureAtLeastHeight(t, bs, 1)
+
+			ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+			defer cancel()
+			var result deliverResult
+			select {
+			case result = <-resultCh:
+			case <-ctx.Done():
+				require.NoError(t, ctx.Err())
+			}
+			require.NoError(t, result.err)
+			require.Equal(t, uint64(0), result.response.GetBlock().GetHeader().GetNumber())
+
+			statusResp, err := stream.Recv()
+			require.NoError(t, err)
+			require.Equal(t, common.Status_SUCCESS, statusResp.GetStatus())
+		})
+	}
 }

--- a/service/sidecar/block_delivery_test.go
+++ b/service/sidecar/block_delivery_test.go
@@ -20,6 +20,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/hyperledger/fabric-x-committer/utils/channel"
 	"github.com/hyperledger/fabric-x-committer/utils/connection"
 	"github.com/hyperledger/fabric-x-committer/utils/serve"
 	"github.com/hyperledger/fabric-x-committer/utils/test"
@@ -231,14 +232,8 @@ func TestBlockDeliveryWaitsForBlockZeroOnEmptyLedger(t *testing.T) {
 			inputBlock <- blk
 			ensureAtLeastHeight(t, bs, 1)
 
-			ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
-			defer cancel()
-			var result deliverResult
-			select {
-			case result = <-resultCh:
-			case <-ctx.Done():
-				require.NoError(t, ctx.Err())
-			}
+			result, ok := channel.NewReader(t.Context(), resultCh).ReadWithTimeout(2 * time.Second)
+			require.True(t, ok)
 			require.NoError(t, result.err)
 			require.Equal(t, uint64(0), result.response.GetBlock().GetHeader().GetNumber())
 

--- a/service/sidecar/sidecar.go
+++ b/service/sidecar/sidecar.go
@@ -540,23 +540,25 @@ func (s *Service) deliverBlocks(
 	if err != nil {
 		return common.Status_BAD_REQUEST, err
 	}
-	cursor, stopNum, err := s.getCursor(seekInfo)
-	if err != nil {
-		return common.Status_BAD_REQUEST, err
-	}
-	defer cursor.Close()
-	logger.Debugf("Received seekInfo.")
 
 	ctx := srv.Context()
 
 	if seekInfo.Behavior == ab.SeekInfo_BLOCK_UNTIL_READY {
-		// We use a retry backoff here to avoid busy waiting when blocks are not yet available.
+		// Wait before creating the cursor. FileLedger cannot create a waiting block-zero
+		// iterator while the ledger is empty because the block-zero index does not exist yet.
 		if !retry.WaitForCondition(ctx, &blockReadyRetryProfile, func() bool {
 			return s.blockStore.ledger.Height() > 0
 		}) {
 			return 0, errors.New("blocks not yet available")
 		}
 	}
+
+	cursor, stopNum, err := s.getCursor(seekInfo)
+	if err != nil {
+		return common.Status_BAD_REQUEST, err
+	}
+	defer cursor.Close()
+	logger.Debugf("Received seekInfo.")
 
 	for ctx.Err() == nil {
 		block, retStatus := cursor.Next(ctx)
@@ -591,7 +593,11 @@ func (s *Service) getCursor(seekInfo *ab.SeekInfo) (blockledger.Iterator, uint64
 		if proto.Equal(seekInfo.Start, seekInfo.Stop) {
 			return cursor, number, nil
 		}
-		return cursor, s.blockStore.ledger.Height() - 1, nil
+		height := s.blockStore.ledger.Height()
+		if height == 0 {
+			return cursor, 0, nil
+		}
+		return cursor, height - 1, nil
 	case *ab.SeekPosition_Specified:
 		if stop.Specified.Number < number {
 			cursor.Close()

--- a/service/sidecar/sidecar.go
+++ b/service/sidecar/sidecar.go
@@ -580,18 +580,18 @@ func (s *Service) deliverBlocks(
 }
 
 func (s *Service) getCursor(seekInfo *ab.SeekInfo) (blockledger.Iterator, uint64, error) {
-	cursor, number := s.blockStore.ledger.Iterator(seekInfo.Start)
+	cursor, startNum := s.blockStore.ledger.Iterator(seekInfo.Start)
 
 	switch stop := seekInfo.Stop.Type.(type) {
 	case *ab.SeekPosition_Oldest:
-		return cursor, number, nil
+		return cursor, startNum, nil
 	case *ab.SeekPosition_Newest:
 		// when seeking only the newest block (i.e. starting
 		// and stopping at newest), don't reevaluate the ledger
 		// height as this can lead to multiple blocks being
 		// sent when only one is expected
 		if proto.Equal(seekInfo.Start, seekInfo.Stop) {
-			return cursor, number, nil
+			return cursor, startNum, nil
 		}
 		height := s.blockStore.ledger.Height()
 		if height == 0 {
@@ -599,7 +599,7 @@ func (s *Service) getCursor(seekInfo *ab.SeekInfo) (blockledger.Iterator, uint64
 		}
 		return cursor, height - 1, nil
 	case *ab.SeekPosition_Specified:
-		if stop.Specified.Number < number {
+		if stop.Specified.Number < startNum {
 			cursor.Close()
 			return nil, 0, errors.New("start number greater than stop number")
 		}


### PR DESCRIPTION
#### Type of change

- Bug fix

#### Description

When SeekPosition_Newest is used on an empty ledger (height=0), FileLedger.Iterator(Newest) computes Height()-1, underflowing to math.MaxUint64. Similarly, Stop=Newest computes height-1, also underflowing. Additionally, for BLOCK_UNTIL_READY behavior, the cursor was created before waiting for block zero, which could fail on FileLedger since the block-zero index does not exist yet.

- Move WaitForCondition (height > 0) before cursor creation for BLOCK_UNTIL_READY
- In getCursor, replace Start=Newest with Specified{Number:0} when height is 0
- Guard Stop=Newest against zero height, returning 0 instead of height-1

#### Related issues

 - resolves #600 