### PR TITLE
[sidecar] Fix empty timeout notifications

### DIFF
--- a/service/sidecar/notify.go
+++ b/service/sidecar/notify.go
@@ -274,13 +274,12 @@ func (m *subscriptions) removeAndEnqueueTimeoutEvents(
 		}
 	}
 	// txIDs can be empty when the timeout fires after a status event has already
-	// removed all of this request's subscriptions (e.g., removeAndEnqueueStatusEvents
+	// removed all of this request's subscriptions (i.e., removeAndEnqueueStatusEvents
 	// ran first). In that case there is nothing to report, so we skip the write.
-	if len(txIDs) == 0 {
-		return 0, 0
+	if len(txIDs) > 0 {
+		req.streamEventQueue.Write(&committerpb.NotificationResponse{
+			TimeoutTxIds: txIDs,
+		})
 	}
-	req.streamEventQueue.Write(&committerpb.NotificationResponse{
-		TimeoutTxIds: txIDs,
-	})
 	return pendingTxIDsRemoved, uniquePendingTxIDsRemoved
 }

--- a/service/sidecar/notify.go
+++ b/service/sidecar/notify.go
@@ -273,6 +273,12 @@ func (m *subscriptions) removeAndEnqueueTimeoutEvents(
 			delete(requests, req)
 		}
 	}
+	// txIDs can be empty when the timeout fires after a status event has already
+	// removed all of this request's subscriptions (e.g., removeAndEnqueueStatusEvents
+	// ran first). In that case there is nothing to report, so we skip the write.
+	if len(txIDs) == 0 {
+		return 0, 0
+	}
 	req.streamEventQueue.Write(&committerpb.NotificationResponse{
 		TimeoutTxIds: txIDs,
 	})

--- a/service/sidecar/notify_test.go
+++ b/service/sidecar/notify_test.go
@@ -475,6 +475,69 @@ func TestNotifierGlobalLimit(t *testing.T) {
 	require.Len(t, res.TxStatusEvents, 2)
 }
 
+// TestNotifierQueuedTimeoutAfterStatusDoesNotEmitEmptyResponse verifies that
+// when a request's timeout timer fires and queues a callback, a status event
+// may be processed first, removing all of the request's TX IDs from the
+// subscription map. The late timeout callback must not emit an empty timeout
+// response when there are no TX IDs left to report.
+func TestNotifierQueuedTimeoutAfterStatusDoesNotEmitEmptyResponse(t *testing.T) {
+	t.Parallel()
+
+	// Set up a channel to capture responses and a subscriptions map with 1 slot.
+	responses := make(chan *committerpb.NotificationResponse, 2)
+	q := channel.NewWriter(t.Context(), responses)
+	req := &notificationRequest{
+		request: &committerpb.NotificationRequest{
+			TxStatusRequest: &committerpb.TxIDsBatch{TxIds: []string{"tx1"}},
+			Timeout:         durationpb.New(1 * time.Millisecond),
+		},
+		streamEventQueue: q,
+		timer:            time.NewTimer(time.Hour),
+	}
+	defer req.timer.Stop()
+	subs := &subscriptions{
+		txIDToRequests: make(map[string]map[*notificationRequest]any),
+		availableSlots: 1,
+	}
+
+	// Subscribe: the request is now tracked in the map under "tx1".
+	rejected, uniqueNew := subs.addRequest(req)
+	require.Empty(t, rejected)
+	require.Equal(t, 1, uniqueNew)
+
+	// Simulate the race: the timeout timer has already queued this request for
+	// processing, but the status event arrives and is handled first.
+	// The status delivery removes "tx1" from the subscription map and emits a
+	// status response.
+	queuedTimeoutReq := req
+	removed, uniqueRemoved := subs.removeAndEnqueueStatusEvents([]*committerpb.TxStatus{
+		{Ref: committerpb.NewTxRef("tx1", 1, 0)},
+	})
+	require.Equal(t, 1, removed)
+	require.Equal(t, 1, uniqueRemoved)
+
+	// Verify the status response was emitted.
+	res := <-responses
+	require.Empty(t, res.TimeoutTxIds)
+	test.RequireProtoElementsMatch(t, []*committerpb.TxStatus{
+		{Ref: committerpb.NewTxRef("tx1", 1, 0)},
+	}, res.TxStatusEvents)
+
+	// Now the queued timeout callback runs. Since "tx1" was already removed by
+	// the status delivery, there is nothing left to time out. The method must
+	// return zero counts and must NOT write an empty timeout response.
+	removed, uniqueRemoved = subs.removeAndEnqueueTimeoutEvents(queuedTimeoutReq)
+	require.Zero(t, removed)
+	require.Zero(t, uniqueRemoved)
+
+	// Confirm no second response was written (channel is empty).
+	select {
+	case res := <-responses:
+		require.Failf(t, "timeout response should not be emitted", "response: %v", res)
+	default:
+	}
+}
+
 func newNotifierTestEnv(tb testing.TB, numOfClients int) *notifierTestEnv {
 	tb.Helper()
 	return newNotifierTestEnvWithConfig(tb, numOfClients, &NotificationServiceConfig{

--- a/service/sidecar/notify_test.go
+++ b/service/sidecar/notify_test.go
@@ -475,67 +475,102 @@ func TestNotifierGlobalLimit(t *testing.T) {
 	require.Len(t, res.TxStatusEvents, 2)
 }
 
-// TestNotifierQueuedTimeoutAfterStatusDoesNotEmitEmptyResponse verifies that
-// when a request's timeout timer fires and queues a callback, a status event
-// may be processed first, removing all of the request's TX IDs from the
-// subscription map. The late timeout callback must not emit an empty timeout
-// response when there are no TX IDs left to report.
-func TestNotifierQueuedTimeoutAfterStatusDoesNotEmitEmptyResponse(t *testing.T) {
+func TestNotifierLateTimeoutDoesNotEmitEmptyResponse(t *testing.T) {
 	t.Parallel()
 
-	// Set up a channel to capture responses and a subscriptions map with 1 slot.
+	for _, tc := range []struct {
+		name                     string
+		queueTimeoutBeforeStatus bool
+	}{
+		{
+			name:                     "queued timeout then status then timeout processing",
+			queueTimeoutBeforeStatus: true,
+		},
+		{
+			name:                     "status then late timeout callback",
+			queueTimeoutBeforeStatus: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			subs, req, responses := newSingleTxSubscription(t)
+			var timeoutReq *notificationRequest
+			if tc.queueTimeoutBeforeStatus {
+				timeoutReq = req
+			}
+
+			removeAndRequireStatusEvent(t, subs, responses)
+
+			if !tc.queueTimeoutBeforeStatus {
+				timeoutReq = req
+			}
+			removeAndRequireNoTimeoutEvent(t, subs, timeoutReq, responses)
+		})
+	}
+}
+
+func removeAndRequireStatusEvent(
+	tb testing.TB,
+	subs *subscriptions,
+	responses chan *committerpb.NotificationResponse,
+) {
+	tb.Helper()
+	removed, uniqueRemoved := subs.removeAndEnqueueStatusEvents([]*committerpb.TxStatus{
+		{Ref: committerpb.NewTxRef("tx1", 1, 0)},
+	})
+	require.Equal(tb, 1, removed)
+	require.Equal(tb, 1, uniqueRemoved)
+
+	res := <-responses
+	require.Empty(tb, res.TimeoutTxIds)
+	test.RequireProtoElementsMatch(tb, []*committerpb.TxStatus{
+		{Ref: committerpb.NewTxRef("tx1", 1, 0)},
+	}, res.TxStatusEvents)
+}
+
+func removeAndRequireNoTimeoutEvent(
+	tb testing.TB,
+	subs *subscriptions,
+	req *notificationRequest,
+	responses chan *committerpb.NotificationResponse,
+) {
+	tb.Helper()
+	removed, uniqueRemoved := subs.removeAndEnqueueTimeoutEvents(req)
+	require.Zero(tb, removed)
+	require.Zero(tb, uniqueRemoved)
+
+	select {
+	case res := <-responses:
+		require.Failf(tb, "timeout response should not be emitted", "response: %v", res)
+	default:
+	}
+}
+
+func newSingleTxSubscription(
+	tb testing.TB,
+) (*subscriptions, *notificationRequest, chan *committerpb.NotificationResponse) {
+	tb.Helper()
 	responses := make(chan *committerpb.NotificationResponse, 2)
-	q := channel.NewWriter(t.Context(), responses)
 	req := &notificationRequest{
 		request: &committerpb.NotificationRequest{
 			TxStatusRequest: &committerpb.TxIDsBatch{TxIds: []string{"tx1"}},
 			Timeout:         durationpb.New(1 * time.Millisecond),
 		},
-		streamEventQueue: q,
+		streamEventQueue: channel.NewWriter(tb.Context(), responses),
 		timer:            time.NewTimer(time.Hour),
 	}
-	defer req.timer.Stop()
+	tb.Cleanup(func() {
+		req.timer.Stop()
+	})
 	subs := &subscriptions{
 		txIDToRequests: make(map[string]map[*notificationRequest]any),
 		availableSlots: 1,
 	}
-
-	// Subscribe: the request is now tracked in the map under "tx1".
 	rejected, uniqueNew := subs.addRequest(req)
-	require.Empty(t, rejected)
-	require.Equal(t, 1, uniqueNew)
-
-	// Simulate the race: the timeout timer has already queued this request for
-	// processing, but the status event arrives and is handled first.
-	// The status delivery removes "tx1" from the subscription map and emits a
-	// status response.
-	queuedTimeoutReq := req
-	removed, uniqueRemoved := subs.removeAndEnqueueStatusEvents([]*committerpb.TxStatus{
-		{Ref: committerpb.NewTxRef("tx1", 1, 0)},
-	})
-	require.Equal(t, 1, removed)
-	require.Equal(t, 1, uniqueRemoved)
-
-	// Verify the status response was emitted.
-	res := <-responses
-	require.Empty(t, res.TimeoutTxIds)
-	test.RequireProtoElementsMatch(t, []*committerpb.TxStatus{
-		{Ref: committerpb.NewTxRef("tx1", 1, 0)},
-	}, res.TxStatusEvents)
-
-	// Now the queued timeout callback runs. Since "tx1" was already removed by
-	// the status delivery, there is nothing left to time out. The method must
-	// return zero counts and must NOT write an empty timeout response.
-	removed, uniqueRemoved = subs.removeAndEnqueueTimeoutEvents(queuedTimeoutReq)
-	require.Zero(t, removed)
-	require.Zero(t, uniqueRemoved)
-
-	// Confirm no second response was written (channel is empty).
-	select {
-	case res := <-responses:
-		require.Failf(t, "timeout response should not be emitted", "response: %v", res)
-	default:
-	}
+	require.Empty(tb, rejected)
+	require.Equal(tb, 1, uniqueNew)
+	return subs, req, responses
 }
 
 func newNotifierTestEnv(tb testing.TB, numOfClients int) *notifierTestEnv {

--- a/service/sidecar/notify_test.go
+++ b/service/sidecar/notify_test.go
@@ -478,71 +478,29 @@ func TestNotifierGlobalLimit(t *testing.T) {
 func TestNotifierLateTimeoutDoesNotEmitEmptyResponse(t *testing.T) {
 	t.Parallel()
 
-	for _, tc := range []struct {
-		name                     string
-		queueTimeoutBeforeStatus bool
-	}{
-		{
-			name:                     "queued timeout then status then timeout processing",
-			queueTimeoutBeforeStatus: true,
-		},
-		{
-			name:                     "status then late timeout callback",
-			queueTimeoutBeforeStatus: false,
-		},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
+	subs, req, responses := newSingleTxSubscription(t)
 
-			subs, req, responses := newSingleTxSubscription(t)
-			var timeoutReq *notificationRequest
-			if tc.queueTimeoutBeforeStatus {
-				timeoutReq = req
-			}
-
-			removeAndRequireStatusEvent(t, subs, responses)
-
-			if !tc.queueTimeoutBeforeStatus {
-				timeoutReq = req
-			}
-			removeAndRequireNoTimeoutEvent(t, subs, timeoutReq, responses)
-		})
-	}
-}
-
-func removeAndRequireStatusEvent(
-	tb testing.TB,
-	subs *subscriptions,
-	responses chan *committerpb.NotificationResponse,
-) {
-	tb.Helper()
+	// Process a status event for the subscribed TX ID.
 	removed, uniqueRemoved := subs.removeAndEnqueueStatusEvents([]*committerpb.TxStatus{
 		{Ref: committerpb.NewTxRef("tx1", 1, 0)},
 	})
-	require.Equal(tb, 1, removed)
-	require.Equal(tb, 1, uniqueRemoved)
+	require.Equal(t, 1, removed)
+	require.Equal(t, 1, uniqueRemoved)
 
 	res := <-responses
-	require.Empty(tb, res.TimeoutTxIds)
-	test.RequireProtoElementsMatch(tb, []*committerpb.TxStatus{
+	require.Empty(t, res.TimeoutTxIds)
+	test.RequireProtoElementsMatch(t, []*committerpb.TxStatus{
 		{Ref: committerpb.NewTxRef("tx1", 1, 0)},
 	}, res.TxStatusEvents)
-}
 
-func removeAndRequireNoTimeoutEvent(
-	tb testing.TB,
-	subs *subscriptions,
-	req *notificationRequest,
-	responses chan *committerpb.NotificationResponse,
-) {
-	tb.Helper()
-	removed, uniqueRemoved := subs.removeAndEnqueueTimeoutEvents(req)
-	require.Zero(tb, removed)
-	require.Zero(tb, uniqueRemoved)
+	// A late timeout callback must not emit an empty timeout response.
+	removed, uniqueRemoved = subs.removeAndEnqueueTimeoutEvents(req)
+	require.Zero(t, removed)
+	require.Zero(t, uniqueRemoved)
 
 	select {
 	case res := <-responses:
-		require.Failf(tb, "timeout response should not be emitted", "response: %v", res)
+		require.Failf(t, "timeout response should not be emitted", "response: %v", res)
 	default:
 	}
 }


### PR DESCRIPTION
#### Type of change

- Bug fix
 
#### Description

When a timeout callback is ordered after a status delivery, the status handler removes all TX IDs from the subscription map first. The subsequent timeout handler then iterates over the request's TX IDs but finds none still subscribed, resulting in an empty TimeoutTxIds list being written to the response channel. Add an early return when no TX IDs remain to skip the write, and add a test covering this event ordering.

#### Related issues

 - resolves #601 
