### PR TITLE
[coordinator] Fix numWaitingTxsForStatus not counting rejected transactions

### DIFF
--- a/service/coordinator/coordinator.go
+++ b/service/coordinator/coordinator.go
@@ -343,7 +343,7 @@ func (c *Service) receiveAndProcessBlock(
 		// still be forwarded to downstream components for complete processing.
 
 		promutil.AddToCounter(c.metrics.transactionReceivedTotal, len(blk.Txs)+len(blk.Rejected))
-		c.numWaitingTxsForStatus.Add(int32(len(blk.Txs))) //nolint:gosec
+		c.numWaitingTxsForStatus.Add(int32(len(blk.Txs) + len(blk.Rejected))) //nolint:gosec
 
 		if len(blk.Txs) > 0 {
 			// TODO: make it configurable.

--- a/service/coordinator/coordinator_test.go
+++ b/service/coordinator/coordinator_test.go
@@ -929,6 +929,33 @@ func TestChunkSizeSentForDepGraph(t *testing.T) {
 	}, 4*time.Second, 100*time.Millisecond)
 }
 
+func TestWaitingTxsCountReturnsToZeroForBlockWithRejectedTxs(t *testing.T) {
+	t.Parallel()
+	env := newCoordinatorTestEnv(t, &testConfig{numSigService: 1, numVcService: 1, mockVcService: true})
+
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Minute)
+	t.Cleanup(cancel)
+	env.startServiceAndOpenStream(ctx, t)
+	env.createNamespaces(t, 0, "1")
+
+	b, expectedTxsStatus := makeTestBlock(1)
+	rejectedStatus := committerpb.NewTxStatus(
+		committerpb.Status_MALFORMED_UNSUPPORTED_ENVELOPE_PAYLOAD,
+		"rejected",
+		0,
+		1,
+	)
+	b.Rejected = []*committerpb.TxStatus{rejectedStatus}
+	expectedTxsStatus = append(expectedTxsStatus, rejectedStatus)
+
+	err := env.csStream.Send(b)
+	require.NoError(t, err)
+
+	actualTxsStatus := readTxStatus(t, env.csStream, len(expectedTxsStatus))
+	test.RequireProtoElementsMatch(t, expectedTxsStatus, actualTxsStatus)
+	require.Equal(t, int32(0), env.coordinator.numWaitingTxsForStatus.Load())
+}
+
 func TestWaitingTxsCount(t *testing.T) {
 	t.Parallel()
 	env := newCoordinatorTestEnv(t, &testConfig{numSigService: 1, numVcService: 1, mockVcService: true})


### PR DESCRIPTION
#### Type of change

- Bug fix
 
#### Description

**Problem**:
The coordinator numWaitingTxsForStatus counter only incremented by len(blk.Txs), ignoring len(blk.Rejected). When a block contained rejected transactions, the counter was never decremented back to zero because sendTxStatus decrements by the actual number of statuses returned (which includes rejected txs). This caused the waiting transaction count to go negative, breaking the
NumberOfWaitingTransactionsForStatus API and any callers that rely on it to determine when all transactions have been processed.

**Root cause**:
In receiveAndProcessBlock, the counter increment only used len(blk.Txs) without len(blk.Rejected), despite the metrics counter on the line above correctly including both via len(blk.Txs)+len(blk.Rejected).

**Fix**:
Change numWaitingTxsForStatus to add len(blk.Txs) + len(blk.Rejected), matching the metrics and ensuring the counter is correctly decremented to zero when all transaction statuses (including rejected) are sent back to the sidecar.

Added TestWaitingTxsCountReturnsToZeroForBlockWithRejectedTxs to verify the counter returns to zero after processing a block that contains both normal and rejected transactions.

#### Related issues

  - resolves #604 