### PR TITLE
[vc] Fix timer reset to drain stale ticks before Reset

### DIFF
--- a/service/vc/validator_committer_service.go
+++ b/service/vc/validator_committer_service.go
@@ -317,7 +317,7 @@ func (vc *ValidatorCommitterService) batchReceivedTransactionsAndForwardForProce
 	toPrepareTxs := channel.NewWriter(ctx, vc.toPrepareTxs)
 
 	sendLargeBatch := func() {
-		defer timer.Reset(vc.timeoutForMinTxBatchSize)
+		defer resetBatchTimer(timer, vc.timeoutForMinTxBatchSize)
 		if len(largerBatch.Transactions) == 0 {
 			return
 		}
@@ -349,6 +349,19 @@ func (vc *ValidatorCommitterService) batchReceivedTransactionsAndForwardForProce
 			}
 		}
 	}
+}
+
+// resetBatchTimer safely resets a timer by draining any stale tick from the channel before
+// resetting. Per Go docs, Reset should only be used on stopped or expired timers with the
+// channel drained; otherwise Reset may incorrectly fire immediately on a stale tick.
+func resetBatchTimer(timer *time.Timer, timeout time.Duration) {
+	if !timer.Stop() {
+		select {
+		case <-timer.C:
+		default:
+		}
+	}
+	timer.Reset(timeout)
 }
 
 // sendTransactionStatus sends the status of the transactions to the client.

--- a/service/vc/validator_committer_service_test.go
+++ b/service/vc/validator_committer_service_test.go
@@ -101,6 +101,21 @@ func newValidatorAndCommitServiceTestEnvWithClient(
 	return vcsTestEnv
 }
 
+func TestResetBatchTimerDrainsExpiredTick(t *testing.T) {
+	t.Parallel()
+
+	timer := time.NewTimer(0)
+	t.Cleanup(func() { timer.Stop() })
+
+	resetBatchTimer(timer, time.Hour)
+
+	select {
+	case <-timer.C:
+		require.Fail(t, "timer delivered stale tick after reset")
+	default:
+	}
+}
+
 func TestCreateConfigAndTables(t *testing.T) {
 	t.Parallel()
 	env := newValidatorAndCommitServiceTestEnvWithClient(t, nil)


### PR DESCRIPTION
#### Type of change

- Bug fix
 
#### Description

Use resetBatchTimer helper instead of bare timer.Reset in batchReceivedTransactionsAndForwardForProcessing. Per Go docs, Reset must only be called on stopped/expired timers with the channel drained; otherwise a stale tick may fire immediately.

Place resetBatchTimer after its caller (caller before callee) and add a reasoning comment. Simplify the test by replacing the cap(timer.C) check with a brief sleep to let the nanosecond timer expire, and use t.Cleanup for timer stop.

#### Related issues

 - resolves #606 