### PR TITLE
[Coordinator] fix waiting status count

### DIFF
--- a/api/servicepb/coordinator.pb.go
+++ b/api/servicepb/coordinator.pb.go
@@ -16,6 +16,7 @@ import (
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	emptypb "google.golang.org/protobuf/types/known/emptypb"
+	wrapperspb "google.golang.org/protobuf/types/known/wrapperspb"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
@@ -81,66 +82,20 @@ func (x *CoordinatorBatch) GetRejected() []*committerpb.TxStatus {
 	return nil
 }
 
-type WaitingTransactions struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	Count         int32                  `protobuf:"varint,1,opt,name=count,proto3" json:"count,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
-}
-
-func (x *WaitingTransactions) Reset() {
-	*x = WaitingTransactions{}
-	mi := &file_api_servicepb_coordinator_proto_msgTypes[1]
-	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-	ms.StoreMessageInfo(mi)
-}
-
-func (x *WaitingTransactions) String() string {
-	return protoimpl.X.MessageStringOf(x)
-}
-
-func (*WaitingTransactions) ProtoMessage() {}
-
-func (x *WaitingTransactions) ProtoReflect() protoreflect.Message {
-	mi := &file_api_servicepb_coordinator_proto_msgTypes[1]
-	if x != nil {
-		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
-		if ms.LoadMessageInfo() == nil {
-			ms.StoreMessageInfo(mi)
-		}
-		return ms
-	}
-	return mi.MessageOf(x)
-}
-
-// Deprecated: Use WaitingTransactions.ProtoReflect.Descriptor instead.
-func (*WaitingTransactions) Descriptor() ([]byte, []int) {
-	return file_api_servicepb_coordinator_proto_rawDescGZIP(), []int{1}
-}
-
-func (x *WaitingTransactions) GetCount() int32 {
-	if x != nil {
-		return x.Count
-	}
-	return 0
-}
-
 var File_api_servicepb_coordinator_proto protoreflect.FileDescriptor
 
 const file_api_servicepb_coordinator_proto_rawDesc = "" +
 	"\n" +
-	"\x1fapi/servicepb/coordinator.proto\x12\tservicepb\x1a\x1bgoogle/protobuf/empty.proto\x1a\x1capi/committerpb/status.proto\x1a\x19api/committerpb/ref.proto\x1a\x1aapi/servicepb/common.proto\"m\n" +
+	"\x1fapi/servicepb/coordinator.proto\x12\tservicepb\x1a\x1bgoogle/protobuf/empty.proto\x1a\x1egoogle/protobuf/wrappers.proto\x1a\x1capi/committerpb/status.proto\x1a\x19api/committerpb/ref.proto\x1a\x1aapi/servicepb/common.proto\"m\n" +
 	"\x10CoordinatorBatch\x12&\n" +
 	"\x03txs\x18\x01 \x03(\v2\x14.servicepb.TxWithRefR\x03txs\x121\n" +
-	"\brejected\x18\x02 \x03(\v2\x15.committerpb.TxStatusR\brejected\"+\n" +
-	"\x13WaitingTransactions\x12\x14\n" +
-	"\x05count\x18\x01 \x01(\x05R\x05count2\xa6\x03\n" +
+	"\brejected\x18\x02 \x03(\v2\x15.committerpb.TxStatusR\brejected2\x9c\x03\n" +
 	"\vCoordinator\x12N\n" +
 	"\x0fBlockProcessing\x12\x1b.servicepb.CoordinatorBatch\x1a\x1a.committerpb.TxStatusBatch(\x010\x01\x12L\n" +
 	"\x1bSetLastCommittedBlockNumber\x12\x13.servicepb.BlockRef\x1a\x16.google.protobuf.Empty\"\x00\x12K\n" +
 	"\x1aGetNextBlockNumberToCommit\x12\x16.google.protobuf.Empty\x1a\x13.servicepb.BlockRef\"\x00\x12L\n" +
-	"\x15GetTransactionsStatus\x12\x17.committerpb.TxIDsBatch\x1a\x1a.committerpb.TxStatusBatch\x12^\n" +
-	"$NumberOfWaitingTransactionsForStatus\x12\x16.google.protobuf.Empty\x1a\x1e.servicepb.WaitingTransactionsB9Z7github.com/hyperledger/fabric-x-committer/api/servicepbb\x06proto3"
+	"\x15GetTransactionsStatus\x12\x17.committerpb.TxIDsBatch\x1a\x1a.committerpb.TxStatusBatch\x12T\n" +
+	"\x1eNoPendingTransactionProcessing\x12\x16.google.protobuf.Empty\x1a\x1a.google.protobuf.BoolValueB9Z7github.com/hyperledger/fabric-x-committer/api/servicepbb\x06proto3"
 
 var (
 	file_api_servicepb_coordinator_proto_rawDescOnce sync.Once
@@ -154,30 +109,30 @@ func file_api_servicepb_coordinator_proto_rawDescGZIP() []byte {
 	return file_api_servicepb_coordinator_proto_rawDescData
 }
 
-var file_api_servicepb_coordinator_proto_msgTypes = make([]protoimpl.MessageInfo, 2)
+var file_api_servicepb_coordinator_proto_msgTypes = make([]protoimpl.MessageInfo, 1)
 var file_api_servicepb_coordinator_proto_goTypes = []any{
 	(*CoordinatorBatch)(nil),          // 0: servicepb.CoordinatorBatch
-	(*WaitingTransactions)(nil),       // 1: servicepb.WaitingTransactions
-	(*TxWithRef)(nil),                 // 2: servicepb.TxWithRef
-	(*committerpb.TxStatus)(nil),      // 3: committerpb.TxStatus
-	(*BlockRef)(nil),                  // 4: servicepb.BlockRef
-	(*emptypb.Empty)(nil),             // 5: google.protobuf.Empty
-	(*committerpb.TxIDsBatch)(nil),    // 6: committerpb.TxIDsBatch
-	(*committerpb.TxStatusBatch)(nil), // 7: committerpb.TxStatusBatch
+	(*TxWithRef)(nil),                 // 1: servicepb.TxWithRef
+	(*committerpb.TxStatus)(nil),      // 2: committerpb.TxStatus
+	(*BlockRef)(nil),                  // 3: servicepb.BlockRef
+	(*emptypb.Empty)(nil),             // 4: google.protobuf.Empty
+	(*committerpb.TxIDsBatch)(nil),    // 5: committerpb.TxIDsBatch
+	(*committerpb.TxStatusBatch)(nil), // 6: committerpb.TxStatusBatch
+	(*wrapperspb.BoolValue)(nil),      // 7: google.protobuf.BoolValue
 }
 var file_api_servicepb_coordinator_proto_depIdxs = []int32{
-	2, // 0: servicepb.CoordinatorBatch.txs:type_name -> servicepb.TxWithRef
-	3, // 1: servicepb.CoordinatorBatch.rejected:type_name -> committerpb.TxStatus
+	1, // 0: servicepb.CoordinatorBatch.txs:type_name -> servicepb.TxWithRef
+	2, // 1: servicepb.CoordinatorBatch.rejected:type_name -> committerpb.TxStatus
 	0, // 2: servicepb.Coordinator.BlockProcessing:input_type -> servicepb.CoordinatorBatch
-	4, // 3: servicepb.Coordinator.SetLastCommittedBlockNumber:input_type -> servicepb.BlockRef
-	5, // 4: servicepb.Coordinator.GetNextBlockNumberToCommit:input_type -> google.protobuf.Empty
-	6, // 5: servicepb.Coordinator.GetTransactionsStatus:input_type -> committerpb.TxIDsBatch
-	5, // 6: servicepb.Coordinator.NumberOfWaitingTransactionsForStatus:input_type -> google.protobuf.Empty
-	7, // 7: servicepb.Coordinator.BlockProcessing:output_type -> committerpb.TxStatusBatch
-	5, // 8: servicepb.Coordinator.SetLastCommittedBlockNumber:output_type -> google.protobuf.Empty
-	4, // 9: servicepb.Coordinator.GetNextBlockNumberToCommit:output_type -> servicepb.BlockRef
-	7, // 10: servicepb.Coordinator.GetTransactionsStatus:output_type -> committerpb.TxStatusBatch
-	1, // 11: servicepb.Coordinator.NumberOfWaitingTransactionsForStatus:output_type -> servicepb.WaitingTransactions
+	3, // 3: servicepb.Coordinator.SetLastCommittedBlockNumber:input_type -> servicepb.BlockRef
+	4, // 4: servicepb.Coordinator.GetNextBlockNumberToCommit:input_type -> google.protobuf.Empty
+	5, // 5: servicepb.Coordinator.GetTransactionsStatus:input_type -> committerpb.TxIDsBatch
+	4, // 6: servicepb.Coordinator.NoPendingTransactionProcessing:input_type -> google.protobuf.Empty
+	6, // 7: servicepb.Coordinator.BlockProcessing:output_type -> committerpb.TxStatusBatch
+	4, // 8: servicepb.Coordinator.SetLastCommittedBlockNumber:output_type -> google.protobuf.Empty
+	3, // 9: servicepb.Coordinator.GetNextBlockNumberToCommit:output_type -> servicepb.BlockRef
+	6, // 10: servicepb.Coordinator.GetTransactionsStatus:output_type -> committerpb.TxStatusBatch
+	7, // 11: servicepb.Coordinator.NoPendingTransactionProcessing:output_type -> google.protobuf.BoolValue
 	7, // [7:12] is the sub-list for method output_type
 	2, // [2:7] is the sub-list for method input_type
 	2, // [2:2] is the sub-list for extension type_name
@@ -197,7 +152,7 @@ func file_api_servicepb_coordinator_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_api_servicepb_coordinator_proto_rawDesc), len(file_api_servicepb_coordinator_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   2,
+			NumMessages:   1,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/api/servicepb/coordinator.proto
+++ b/api/servicepb/coordinator.proto
@@ -11,6 +11,7 @@ option go_package = "github.com/hyperledger/fabric-x-committer/api/servicepb";
 package servicepb;
 
 import "google/protobuf/empty.proto";
+import "google/protobuf/wrappers.proto";
 
 import "api/committerpb/status.proto";
 import "api/committerpb/ref.proto";
@@ -22,15 +23,11 @@ service Coordinator {
     rpc SetLastCommittedBlockNumber (BlockRef) returns (google.protobuf.Empty) {};
     rpc GetNextBlockNumberToCommit (google.protobuf.Empty) returns (BlockRef) {};
     rpc GetTransactionsStatus(committerpb.TxIDsBatch) returns (committerpb.TxStatusBatch);
-    rpc NumberOfWaitingTransactionsForStatus(google.protobuf.Empty) returns (WaitingTransactions);
+    rpc NoPendingTransactionProcessing(google.protobuf.Empty) returns (google.protobuf.BoolValue);
 }
 
 // A committer's representation of a block in the blockchain.
 message CoordinatorBatch {
     repeated servicepb.TxWithRef txs = 1;       // List of transactions within the block.
     repeated committerpb.TxStatus rejected = 2; // Rejected transactions.
-}
-
-message WaitingTransactions {
-    int32 count = 1;
 }

--- a/api/servicepb/coordinator_grpc.pb.go
+++ b/api/servicepb/coordinator_grpc.pb.go
@@ -18,6 +18,7 @@ import (
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"
 	emptypb "google.golang.org/protobuf/types/known/emptypb"
+	wrapperspb "google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 // This is a compile-time assertion to ensure that this generated file
@@ -26,11 +27,11 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	Coordinator_BlockProcessing_FullMethodName                      = "/servicepb.Coordinator/BlockProcessing"
-	Coordinator_SetLastCommittedBlockNumber_FullMethodName          = "/servicepb.Coordinator/SetLastCommittedBlockNumber"
-	Coordinator_GetNextBlockNumberToCommit_FullMethodName           = "/servicepb.Coordinator/GetNextBlockNumberToCommit"
-	Coordinator_GetTransactionsStatus_FullMethodName                = "/servicepb.Coordinator/GetTransactionsStatus"
-	Coordinator_NumberOfWaitingTransactionsForStatus_FullMethodName = "/servicepb.Coordinator/NumberOfWaitingTransactionsForStatus"
+	Coordinator_BlockProcessing_FullMethodName                = "/servicepb.Coordinator/BlockProcessing"
+	Coordinator_SetLastCommittedBlockNumber_FullMethodName    = "/servicepb.Coordinator/SetLastCommittedBlockNumber"
+	Coordinator_GetNextBlockNumberToCommit_FullMethodName     = "/servicepb.Coordinator/GetNextBlockNumberToCommit"
+	Coordinator_GetTransactionsStatus_FullMethodName          = "/servicepb.Coordinator/GetTransactionsStatus"
+	Coordinator_NoPendingTransactionProcessing_FullMethodName = "/servicepb.Coordinator/NoPendingTransactionProcessing"
 )
 
 // CoordinatorClient is the client API for Coordinator service.
@@ -41,7 +42,7 @@ type CoordinatorClient interface {
 	SetLastCommittedBlockNumber(ctx context.Context, in *BlockRef, opts ...grpc.CallOption) (*emptypb.Empty, error)
 	GetNextBlockNumberToCommit(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*BlockRef, error)
 	GetTransactionsStatus(ctx context.Context, in *committerpb.TxIDsBatch, opts ...grpc.CallOption) (*committerpb.TxStatusBatch, error)
-	NumberOfWaitingTransactionsForStatus(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*WaitingTransactions, error)
+	NoPendingTransactionProcessing(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*wrapperspb.BoolValue, error)
 }
 
 type coordinatorClient struct {
@@ -95,10 +96,10 @@ func (c *coordinatorClient) GetTransactionsStatus(ctx context.Context, in *commi
 	return out, nil
 }
 
-func (c *coordinatorClient) NumberOfWaitingTransactionsForStatus(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*WaitingTransactions, error) {
+func (c *coordinatorClient) NoPendingTransactionProcessing(ctx context.Context, in *emptypb.Empty, opts ...grpc.CallOption) (*wrapperspb.BoolValue, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
-	out := new(WaitingTransactions)
-	err := c.cc.Invoke(ctx, Coordinator_NumberOfWaitingTransactionsForStatus_FullMethodName, in, out, cOpts...)
+	out := new(wrapperspb.BoolValue)
+	err := c.cc.Invoke(ctx, Coordinator_NoPendingTransactionProcessing_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -113,7 +114,7 @@ type CoordinatorServer interface {
 	SetLastCommittedBlockNumber(context.Context, *BlockRef) (*emptypb.Empty, error)
 	GetNextBlockNumberToCommit(context.Context, *emptypb.Empty) (*BlockRef, error)
 	GetTransactionsStatus(context.Context, *committerpb.TxIDsBatch) (*committerpb.TxStatusBatch, error)
-	NumberOfWaitingTransactionsForStatus(context.Context, *emptypb.Empty) (*WaitingTransactions, error)
+	NoPendingTransactionProcessing(context.Context, *emptypb.Empty) (*wrapperspb.BoolValue, error)
 	mustEmbedUnimplementedCoordinatorServer()
 }
 
@@ -136,8 +137,8 @@ func (UnimplementedCoordinatorServer) GetNextBlockNumberToCommit(context.Context
 func (UnimplementedCoordinatorServer) GetTransactionsStatus(context.Context, *committerpb.TxIDsBatch) (*committerpb.TxStatusBatch, error) {
 	return nil, status.Error(codes.Unimplemented, "method GetTransactionsStatus not implemented")
 }
-func (UnimplementedCoordinatorServer) NumberOfWaitingTransactionsForStatus(context.Context, *emptypb.Empty) (*WaitingTransactions, error) {
-	return nil, status.Error(codes.Unimplemented, "method NumberOfWaitingTransactionsForStatus not implemented")
+func (UnimplementedCoordinatorServer) NoPendingTransactionProcessing(context.Context, *emptypb.Empty) (*wrapperspb.BoolValue, error) {
+	return nil, status.Error(codes.Unimplemented, "method NoPendingTransactionProcessing not implemented")
 }
 func (UnimplementedCoordinatorServer) mustEmbedUnimplementedCoordinatorServer() {}
 func (UnimplementedCoordinatorServer) testEmbeddedByValue()                     {}
@@ -221,20 +222,20 @@ func _Coordinator_GetTransactionsStatus_Handler(srv interface{}, ctx context.Con
 	return interceptor(ctx, in, info, handler)
 }
 
-func _Coordinator_NumberOfWaitingTransactionsForStatus_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+func _Coordinator_NoPendingTransactionProcessing_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(emptypb.Empty)
 	if err := dec(in); err != nil {
 		return nil, err
 	}
 	if interceptor == nil {
-		return srv.(CoordinatorServer).NumberOfWaitingTransactionsForStatus(ctx, in)
+		return srv.(CoordinatorServer).NoPendingTransactionProcessing(ctx, in)
 	}
 	info := &grpc.UnaryServerInfo{
 		Server:     srv,
-		FullMethod: Coordinator_NumberOfWaitingTransactionsForStatus_FullMethodName,
+		FullMethod: Coordinator_NoPendingTransactionProcessing_FullMethodName,
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
-		return srv.(CoordinatorServer).NumberOfWaitingTransactionsForStatus(ctx, req.(*emptypb.Empty))
+		return srv.(CoordinatorServer).NoPendingTransactionProcessing(ctx, req.(*emptypb.Empty))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -259,8 +260,8 @@ var Coordinator_ServiceDesc = grpc.ServiceDesc{
 			Handler:    _Coordinator_GetTransactionsStatus_Handler,
 		},
 		{
-			MethodName: "NumberOfWaitingTransactionsForStatus",
-			Handler:    _Coordinator_NumberOfWaitingTransactionsForStatus_Handler,
+			MethodName: "NoPendingTransactionProcessing",
+			Handler:    _Coordinator_NoPendingTransactionProcessing_Handler,
 		},
 	},
 	Streams: []grpc.StreamDesc{

--- a/docs/coordinator.md
+++ b/docs/coordinator.md
@@ -186,7 +186,7 @@ GetConfigTransaction(ctx context.Context, in *Empty, opts ...grpc.CallOption) (*
   * This API retrieves the latest system configuration transaction by querying a Validator-Committer service, which reads it from the database.
 
 ```go
-NumberOfWaitingTransactionsForStatus(ctx context.Context, in *Empty, opts ...grpc.CallOption) (*WaitingTransactions, error)
+NoPendingTransactionProcessing(ctx context.Context, in *Empty, opts ...grpc.CallOption) (*wrapperspb.BoolValue, error)
 ```
   * This API returns the number of transactions that are currently in the pipeline awaiting a final status.
 

--- a/docs/coordinator.md
+++ b/docs/coordinator.md
@@ -188,7 +188,7 @@ GetConfigTransaction(ctx context.Context, in *Empty, opts ...grpc.CallOption) (*
 ```go
 NoPendingTransactionProcessing(ctx context.Context, in *Empty, opts ...grpc.CallOption) (*wrapperspb.BoolValue, error)
 ```
-  * This API returns the number of transactions that are currently in the pipeline awaiting a final status.
+  * This API returns true when all previously submitted transactions have been processed.
 
 ## 7. Failure and Recovery
 

--- a/docs/sidecar-block-diagram.md
+++ b/docs/sidecar-block-diagram.md
@@ -375,7 +375,7 @@ When the sidecar restarts after a crash, it follows a systematic recovery proces
    └─► Initialize TLS configuration
 
 2. Wait for Coordinator to Become Idle
-   ├─► Query: NumberOfWaitingTransactionsForStatus()
+   ├─► Query: NoPendingTransactionProcessing()
    ├─► Wait until count == 0
    └─► Ensures all in-flight transactions are processed
 

--- a/docs/sidecar-block-diagram.md
+++ b/docs/sidecar-block-diagram.md
@@ -376,7 +376,7 @@ When the sidecar restarts after a crash, it follows a systematic recovery proces
 
 2. Wait for Coordinator to Become Idle
    ├─► Query: NoPendingTransactionProcessing()
-   ├─► Wait until count == 0
+   ├─► Wait until true
    └─► Ensures all in-flight transactions are processed
 
 3. Query Coordinator State

--- a/mock/coordinator.go
+++ b/mock/coordinator.go
@@ -34,7 +34,7 @@ type Coordinator struct {
 	lastCommittedBlock atomic.Pointer[servicepb.BlockRef]
 	nextBlock          atomic.Uint64
 	streamActive       atomic.Bool
-	numTxsInProgress      atomic.Int32
+	numTxsInProgress   atomic.Int32
 	txsStatus          *fifoCache[*committerpb.TxStatus]
 	txsStatusMu        sync.Mutex
 	latency            atomic.Pointer[time.Duration]

--- a/mock/coordinator.go
+++ b/mock/coordinator.go
@@ -19,6 +19,7 @@ import (
 	"google.golang.org/grpc/health"
 	healthgrpc "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/protobuf/types/known/emptypb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	"github.com/hyperledger/fabric-x-committer/api/servicepb"
 	"github.com/hyperledger/fabric-x-committer/utils"
@@ -33,7 +34,7 @@ type Coordinator struct {
 	lastCommittedBlock atomic.Pointer[servicepb.BlockRef]
 	nextBlock          atomic.Uint64
 	streamActive       atomic.Bool
-	numWaitingTxs      atomic.Int32
+	numTxsInProgress      atomic.Int32
 	txsStatus          *fifoCache[*committerpb.TxStatus]
 	txsStatusMu        sync.Mutex
 	latency            atomic.Pointer[time.Duration]
@@ -89,12 +90,13 @@ func (c *Coordinator) GetTransactionsStatus(
 	return &committerpb.TxStatusBatch{Status: status}, nil
 }
 
-// NumberOfWaitingTransactionsForStatus returns the number of transactions waiting to get the final status.
-func (c *Coordinator) NumberOfWaitingTransactionsForStatus(
+// NoPendingTransactionProcessing returns true when all previously submitted
+// transactions have been processed.
+func (c *Coordinator) NoPendingTransactionProcessing(
 	context.Context,
 	*emptypb.Empty,
-) (*servicepb.WaitingTransactions, error) {
-	return &servicepb.WaitingTransactions{Count: c.numWaitingTxs.Load()}, nil
+) (*wrapperspb.BoolValue, error) {
+	return wrapperspb.Bool(c.numTxsInProgress.Load() == 0), nil
 }
 
 // IsStreamActive returns true if the stream from the sidecar is active.
@@ -143,7 +145,7 @@ func (c *Coordinator) receiveBlocks(
 		c.nextBlock.Store(maxBlock + 1)
 
 		logger.Debugf("Received batch with %d transactions", len(block.Txs))
-		c.numWaitingTxs.Add(int32(len(block.Txs))) //nolint:gosec
+		c.numTxsInProgress.Add(int32(len(block.Txs))) //nolint:gosec
 
 		// send to the validation
 		blockQueue.Write(block)
@@ -210,14 +212,14 @@ func (c *Coordinator) sendTxsStatusChunk(
 		return errors.Wrap(err, "failed to send status")
 	}
 	logger.Debugf("Sent back batch with %d TXs", len(b.Status))
-	c.numWaitingTxs.Add(-int32(len(b.Status))) //nolint:gosec
+	c.numTxsInProgress.Add(-int32(len(b.Status))) //nolint:gosec
 	return nil
 }
 
-// SetWaitingTxsCount sets the waiting transactions count. The purpose
-// of this method is to set the count manually for testing purpose.
-func (c *Coordinator) SetWaitingTxsCount(count int32) {
-	c.numWaitingTxs.Store(count)
+// SetTxsInProgress sets the in-progress transaction count. The purpose
+// of this method is to set the count manually for testing purposes.
+func (c *Coordinator) SetTxsInProgress(count int32) {
+	c.numTxsInProgress.Store(count)
 }
 
 // SetDelay sets the duration to wait before sending statuses.

--- a/service/coordinator/coordinator.go
+++ b/service/coordinator/coordinator.go
@@ -86,10 +86,10 @@ type (
 		//       rename vcServiceToDepGraphValidatedTxs to committedOrAbortedTxsNode.
 		vcServiceToDepGraphValidatedTxs chan dependencygraph.TxNodeBatch
 
-		// sender: validator committer manager sends transaction status to this channel. For each validator committer
-		// 	       server, there is a goroutine that sends transaction status to this channel.
-		// receiver: coordinator receives transaction status from this channel and forwards them to the sidecar.
-		vcServiceToCoordinatorTxStatus chan *committerpb.TxStatusBatch
+		// sender: validator committer manager sends transaction status to this queue. For each validator committer
+		// 	       server, there is a goroutine that sends transaction status to this queue.
+		// receiver: coordinator receives transaction status from this queue and forwards them to the sidecar.
+		vcServiceToCoordinatorTxStatus *txStatusQueue
 	}
 )
 
@@ -122,7 +122,7 @@ func NewCoordinatorService(c *Config) *Service {
 		depGraphToSigVerifierFreeTxs:       make(chan dependencygraph.TxNodeBatch, bufSzPerChanForValCommitMgr),
 		sigVerifierToVCServiceValidatedTxs: make(chan dependencygraph.TxNodeBatch, bufSzPerChanForSignVerifierMgr),
 		vcServiceToDepGraphValidatedTxs:    make(chan dependencygraph.TxNodeBatch, bufSzPerChanForValCommitMgr),
-		vcServiceToCoordinatorTxStatus:     make(chan *committerpb.TxStatusBatch, bufSzPerChanForValCommitMgr),
+		vcServiceToCoordinatorTxStatus:     newTxStatusQueue(bufSzPerChanForValCommitMgr),
 	}
 
 	metrics := newPerformanceMetrics()
@@ -280,7 +280,7 @@ func (c *Service) NumberOfWaitingTransactionsForStatus(
 	defer c.streamActive.Unlock()
 
 	return &servicepb.WaitingTransactions{
-		Count: c.numWaitingTxsForStatus.Load() - int32(len(c.queues.vcServiceToCoordinatorTxStatus)), //nolint:gosec
+		Count: c.numWaitingTxsForStatus.Load() - c.queues.vcServiceToCoordinatorTxStatus.readyCount(),
 	}, nil
 }
 
@@ -374,12 +374,12 @@ func (c *Service) sendTxStatus(
 	ctx context.Context,
 	stream servicepb.Coordinator_BlockProcessingServer,
 ) error {
-	txsStatus := channel.NewReader(ctx, c.queues.vcServiceToCoordinatorTxStatus)
 	for {
-		txStatus, ctxAlive := txsStatus.Read()
-		if !ctxAlive {
+		txStatus, ok := c.queues.vcServiceToCoordinatorTxStatus.read(ctx)
+		if !ok {
 			return nil
 		}
+
 		c.numWaitingTxsForStatus.Add(-int32(len(txStatus.Status))) //nolint:gosec
 
 		if err := stream.Send(txStatus); err != nil {
@@ -414,6 +414,6 @@ func (c *Service) monitorQueues(ctx context.Context) {
 		promutil.SetGauge(m.sigverifierInputTxBatchQueueSize, len(q.depGraphToSigVerifierFreeTxs))
 		promutil.SetGauge(m.sigverifierOutputValidatedTxBatchQueueSize, len(q.sigVerifierToVCServiceValidatedTxs))
 		promutil.SetGauge(m.vcserviceOutputValidatedTxBatchQueueSize, len(q.vcServiceToDepGraphValidatedTxs))
-		promutil.SetGauge(m.vcserviceOutputTxStatusBatchQueueSize, len(q.vcServiceToCoordinatorTxStatus))
+		promutil.SetGauge(m.vcserviceOutputTxStatusBatchQueueSize, q.vcServiceToCoordinatorTxStatus.len())
 	}
 }

--- a/service/coordinator/coordinator.go
+++ b/service/coordinator/coordinator.go
@@ -19,6 +19,7 @@ import (
 	"google.golang.org/grpc/health"
 	healthgrpc "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/protobuf/types/known/emptypb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	"github.com/hyperledger/fabric-x-committer/api/servicepb"
 	"github.com/hyperledger/fabric-x-committer/service/coordinator/dependencygraph"
@@ -57,7 +58,7 @@ type (
 		// multiple concurrent streams could lead to unreliable status delivery.
 		streamActive sync.RWMutex
 
-		numWaitingTxsForStatus *atomic.Int32
+		numTxsInProgress *atomic.Int32
 
 		txBatchIDToDepGraph uint64
 
@@ -94,10 +95,9 @@ type (
 )
 
 var (
-	// ErrActiveStreamWaitingTransactions is returned when NumberOfWaitingTransactionsForStatus is called
+	// ErrActiveStreamPendingTxProcessing is returned when NoPendingTransactionProcessing is called
 	// while a stream is active. This value cannot be reliably determined in this state.
-	ErrActiveStreamWaitingTransactions = errors.New("cannot determine number of waiting transactions for " +
-		"status while stream is active")
+	ErrActiveStreamPendingTxProcessing = errors.New("cannot check pending transaction processing while stream is active")
 
 	// ErrExistingStreamOrConflictingOp indicates that a stream cannot be created because a stream already exists
 	// or a conflicting gRPC API call is being made concurrently.
@@ -170,7 +170,7 @@ func NewCoordinatorService(c *Config) *Service {
 		config:                 c,
 		metrics:                metrics,
 		initializationDone:     channel.NewReady(),
-		numWaitingTxsForStatus: &atomic.Int32{},
+		numTxsInProgress: &atomic.Int32{},
 		txBatchIDToDepGraph:    1,
 		healthcheck:            serve.DefaultHealthCheckService(),
 	}
@@ -269,30 +269,31 @@ func (c *Service) GetTransactionsStatus(
 	return c.validatorCommitterMgr.getTransactionsStatus(ctx, q)
 }
 
-// NumberOfWaitingTransactionsForStatus returns the number of transactions waiting to get the final status.
-func (c *Service) NumberOfWaitingTransactionsForStatus(
+// NoPendingTransactionProcessing returns true when all previously submitted
+// transactions have been processed and the sidecar can safely reconnect.
+func (c *Service) NoPendingTransactionProcessing(
 	context.Context,
 	*emptypb.Empty,
-) (*servicepb.WaitingTransactions, error) {
+) (*wrapperspb.BoolValue, error) {
 	if !c.streamActive.TryLock() {
-		return nil, grpcerror.WrapFailedPrecondition(ErrActiveStreamWaitingTransactions)
+		return nil, grpcerror.WrapFailedPrecondition(ErrActiveStreamPendingTxProcessing)
 	}
 	defer c.streamActive.Unlock()
 
-	// When the sidecar stream is inactive, numWaitingTxsForStatus is not decremented
+	// When the sidecar stream is inactive, numTxsInProgress is not decremented
 	// because sendTxStatus cannot forward statuses. However, VC continues producing
 	// statuses into the queue. To compute the number of TXs still being processed
 	// (i.e., not yet computed by VC), we subtract readyCount (statuses already
-	// produced but not yet consumed by sendTxStatus) from numWaitingTxsForStatus.
-	// The difference is never negative because numWaitingTxsForStatus is always
+	// produced but not yet consumed by sendTxStatus) from numTxsInProgress.
+	// The difference is never negative because numTxsInProgress is always
 	// greater than or equal to readyCount: every status in the queue was previously
-	// counted in numWaitingTxsForStatus at block receipt, and numWaitingTxsForStatus
+	// counted in numTxsInProgress at block receipt, and numTxsInProgress
 	// is only decremented after sendTxStatus consumes from the queue.
 	// When the difference is zero, all previously submitted TXs have been processed
 	// and the sidecar can safely reconnect.
-	return &servicepb.WaitingTransactions{
-		Count: c.numWaitingTxsForStatus.Load() - c.queues.vcServiceToCoordinatorTxStatus.readyCount(),
-	}, nil
+	return wrapperspb.Bool(
+		c.numTxsInProgress.Load() == c.queues.vcServiceToCoordinatorTxStatus.readyCount(),
+	), nil
 }
 
 // BlockProcessing receives a stream of blocks from the client and processes them.
@@ -354,7 +355,7 @@ func (c *Service) receiveAndProcessBlock(
 		// still be forwarded to downstream components for complete processing.
 
 		promutil.AddToCounter(c.metrics.transactionReceivedTotal, len(blk.Txs)+len(blk.Rejected))
-		c.numWaitingTxsForStatus.Add(int32(len(blk.Txs) + len(blk.Rejected))) //nolint:gosec
+		c.numTxsInProgress.Add(int32(len(blk.Txs) + len(blk.Rejected))) //nolint:gosec
 
 		if len(blk.Txs) > 0 {
 			// TODO: make it configurable.
@@ -391,7 +392,7 @@ func (c *Service) sendTxStatus(
 			return nil
 		}
 
-		c.numWaitingTxsForStatus.Add(-int32(len(txStatus.Status))) //nolint:gosec
+		c.numTxsInProgress.Add(-int32(len(txStatus.Status))) //nolint:gosec
 
 		if err := stream.Send(txStatus); err != nil {
 			return errors.Wrap(err, "failed to send transaction status batch to the sidecar")

--- a/service/coordinator/coordinator.go
+++ b/service/coordinator/coordinator.go
@@ -97,7 +97,9 @@ type (
 var (
 	// ErrActiveStreamPendingTxProcessing is returned when NoPendingTransactionProcessing is called
 	// while a stream is active. This value cannot be reliably determined in this state.
-	ErrActiveStreamPendingTxProcessing = errors.New("cannot check pending transaction processing while stream is active")
+	ErrActiveStreamPendingTxProcessing = errors.New(
+		"cannot check pending transaction processing while stream is active",
+	)
 
 	// ErrExistingStreamOrConflictingOp indicates that a stream cannot be created because a stream already exists
 	// or a conflicting gRPC API call is being made concurrently.
@@ -162,17 +164,17 @@ func NewCoordinatorService(c *Config) *Service {
 	)
 
 	return &Service{
-		dependencyMgr:          depMgr,
-		signatureVerifierMgr:   svMgr,
-		validatorCommitterMgr:  vcMgr,
-		policyMgr:              policyMgr,
-		queues:                 queues,
-		config:                 c,
-		metrics:                metrics,
-		initializationDone:     channel.NewReady(),
-		numTxsInProgress: &atomic.Int32{},
-		txBatchIDToDepGraph:    1,
-		healthcheck:            serve.DefaultHealthCheckService(),
+		dependencyMgr:         depMgr,
+		signatureVerifierMgr:  svMgr,
+		validatorCommitterMgr: vcMgr,
+		policyMgr:             policyMgr,
+		queues:                queues,
+		config:                c,
+		metrics:               metrics,
+		initializationDone:    channel.NewReady(),
+		numTxsInProgress:      &atomic.Int32{},
+		txBatchIDToDepGraph:   1,
+		healthcheck:           serve.DefaultHealthCheckService(),
 	}
 }
 
@@ -285,12 +287,17 @@ func (c *Service) NoPendingTransactionProcessing(
 	// statuses into the queue. To compute the number of TXs still being processed
 	// (i.e., not yet computed by VC), we subtract readyCount (statuses already
 	// produced but not yet consumed by sendTxStatus) from numTxsInProgress.
-	// The difference is never negative because numTxsInProgress is always
-	// greater than or equal to readyCount: every status in the queue was previously
-	// counted in numTxsInProgress at block receipt, and numTxsInProgress
-	// is only decremented after sendTxStatus consumes from the queue.
-	// When the difference is zero, all previously submitted TXs have been processed
-	// and the sidecar can safely reconnect.
+	//
+	// numTxsInProgress is a superset of readyCount: every status tracked by
+	// readyCount was previously counted in numTxsInProgress at block receipt,
+	// and numTxsInProgress is only decremented after sendTxStatus consumes from
+	// the queue (which decrements readyCount first). The two values are not read
+	// atomically, but numTxsInProgress is frozen while the stream is inactive
+	// (only receiveAndProcessBlock and sendTxStatus modify it, and both require
+	// an active stream). So the result is never negative.
+	//
+	// When numTxsInProgress equals readyCount, all previously submitted TXs
+	// have been processed and the sidecar can safely reconnect.
 	return wrapperspb.Bool(
 		c.numTxsInProgress.Load() == c.queues.vcServiceToCoordinatorTxStatus.readyCount(),
 	), nil

--- a/service/coordinator/coordinator.go
+++ b/service/coordinator/coordinator.go
@@ -282,7 +282,7 @@ func (c *Service) NoPendingTransactionProcessing(
 	}
 	defer c.streamActive.Unlock()
 
-	// When the sidecar stream is inactive, numTxsInProgress is not decremented
+	// When the sidecar stream is inactive, numTxsInProgress is not updated
 	// because sendTxStatus cannot forward statuses. However, VC continues producing
 	// statuses into the queue. To compute the number of TXs still being processed
 	// (i.e., not yet computed by VC), we subtract readyCount (statuses already

--- a/service/coordinator/coordinator.go
+++ b/service/coordinator/coordinator.go
@@ -279,6 +279,17 @@ func (c *Service) NumberOfWaitingTransactionsForStatus(
 	}
 	defer c.streamActive.Unlock()
 
+	// When the sidecar stream is inactive, numWaitingTxsForStatus is not decremented
+	// because sendTxStatus cannot forward statuses. However, VC continues producing
+	// statuses into the queue. To compute the number of TXs still being processed
+	// (i.e., not yet computed by VC), we subtract readyCount (statuses already
+	// produced but not yet consumed by sendTxStatus) from numWaitingTxsForStatus.
+	// The difference is never negative because numWaitingTxsForStatus is always
+	// greater than or equal to readyCount: every status in the queue was previously
+	// counted in numWaitingTxsForStatus at block receipt, and numWaitingTxsForStatus
+	// is only decremented after sendTxStatus consumes from the queue.
+	// When the difference is zero, all previously submitted TXs have been processed
+	// and the sidecar can safely reconnect.
 	return &servicepb.WaitingTransactions{
 		Count: c.numWaitingTxsForStatus.Load() - c.queues.vcServiceToCoordinatorTxStatus.readyCount(),
 	}, nil

--- a/service/coordinator/coordinator_test.go
+++ b/service/coordinator/coordinator_test.go
@@ -331,49 +331,33 @@ func TestCoordinatorServiceValidTx(t *testing.T) {
 	require.Equal(t, uint64(2), nextBlock.Number)
 }
 
-func TestCoordinatorServiceRejectedTx(t *testing.T) {
+func TestCoordinatorServiceRejectedTxAndWaitingStatusCount(t *testing.T) {
 	t.Parallel()
-	env := newCoordinatorTestEnv(t, &testConfig{numSigService: 2, numVcService: 2, mockVcService: true})
-	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Minute)
-	t.Cleanup(cancel)
-	env.startServiceAndOpenStream(ctx, t)
+	env := newCoordinatorTestEnv(t, &testConfig{numSigService: 1, numVcService: 1, mockVcService: true})
 
-	env.createNamespaces(t, 0, "1")
+	// Seven transactions are still waiting for sidecar-visible final status. Five of
+	// those statuses are already queued in two batches. One queued status is a
+	// rejected transaction, proving rejected statuses are counted in the same unit
+	// as committed statuses.
+	env.coordinator.numWaitingTxsForStatus.Store(7)
 
-	preMetricsValue := test.GetIntMetricValue(t, env.coordinator.metrics.transactionReceivedTotal)
-
-	err := env.csStream.Send(&servicepb.CoordinatorBatch{
-		Rejected: []*committerpb.TxStatus{
-			{
-				Ref:    committerpb.NewTxRef("rejected", 1, 0),
-				Status: committerpb.Status_MALFORMED_UNSUPPORTED_ENVELOPE_PAYLOAD,
-			},
+	require.True(t, env.coordinator.queues.vcServiceToCoordinatorTxStatus.write(t.Context(), &committerpb.TxStatusBatch{
+		Status: []*committerpb.TxStatus{
+			committerpb.NewTxStatus(committerpb.Status_COMMITTED, "queued-1", 2, 0),
+			committerpb.NewTxStatus(committerpb.Status_COMMITTED, "queued-2", 2, 1),
 		},
-	})
+	}))
+	require.True(t, env.coordinator.queues.vcServiceToCoordinatorTxStatus.write(t.Context(), &committerpb.TxStatusBatch{
+		Status: []*committerpb.TxStatus{
+			committerpb.NewTxStatus(committerpb.Status_MALFORMED_UNSUPPORTED_ENVELOPE_PAYLOAD, "queued-rejected", 2, 2),
+			committerpb.NewTxStatus(committerpb.Status_COMMITTED, "queued-4", 2, 3),
+			committerpb.NewTxStatus(committerpb.Status_COMMITTED, "queued-5", 2, 4),
+		},
+	}))
+
+	waitingTxs, err := env.coordinator.NumberOfWaitingTransactionsForStatus(t.Context(), nil)
 	require.NoError(t, err)
-	test.EventuallyIntMetric(
-		t, preMetricsValue+1, env.coordinator.metrics.transactionReceivedTotal,
-		1*time.Second, 100*time.Millisecond,
-	)
-
-	env.requireStatus(ctx, t, []*committerpb.TxStatus{
-		committerpb.NewTxStatus(committerpb.Status_MALFORMED_UNSUPPORTED_ENVELOPE_PAYLOAD, "rejected", 1, 0),
-	}, nil)
-
-	test.RequireIntMetricValue(t, 1, env.coordinator.metrics.transactionCommittedTotal.WithLabelValues(
-		committerpb.Status_MALFORMED_UNSUPPORTED_ENVELOPE_PAYLOAD.String(),
-	))
-	test.RequireIntMetricValue(t, preMetricsValue, env.coordinator.metrics.transactionCommittedTotal.WithLabelValues(
-		committerpb.Status_COMMITTED.String(),
-	))
-
-	_, err = env.coordinator.SetLastCommittedBlockNumber(ctx, &servicepb.BlockRef{Number: 1})
-	require.NoError(t, err)
-
-	nextBlock, err := env.coordinator.GetNextBlockNumberToCommit(ctx, nil)
-	require.NoError(t, err)
-	require.NotNil(t, nextBlock)
-	require.Equal(t, uint64(2), nextBlock.Number)
+	require.Equal(t, int32(2), waitingTxs.GetCount())
 }
 
 func TestCoordinatorServiceDependentOrderedTxs(t *testing.T) {
@@ -553,7 +537,7 @@ func TestQueueSize(t *testing.T) {
 	q.depGraphToSigVerifierFreeTxs <- dependencygraph.TxNodeBatch{}
 	q.sigVerifierToVCServiceValidatedTxs <- dependencygraph.TxNodeBatch{}
 	q.vcServiceToDepGraphValidatedTxs <- dependencygraph.TxNodeBatch{}
-	q.vcServiceToCoordinatorTxStatus <- &committerpb.TxStatusBatch{}
+	require.True(t, q.vcServiceToCoordinatorTxStatus.write(t.Context(), &committerpb.TxStatusBatch{}))
 
 	require.Eventually(t, func() bool {
 		return test.GetIntMetricValue(t, m.sigverifierInputTxBatchQueueSize) == 1 &&
@@ -565,7 +549,8 @@ func TestQueueSize(t *testing.T) {
 	<-q.depGraphToSigVerifierFreeTxs
 	<-q.sigVerifierToVCServiceValidatedTxs
 	<-q.vcServiceToDepGraphValidatedTxs
-	<-q.vcServiceToCoordinatorTxStatus
+	_, ok := q.vcServiceToCoordinatorTxStatus.read(t.Context())
+	require.True(t, ok)
 
 	require.Eventually(t, func() bool {
 		return test.GetIntMetricValue(t, m.sigverifierInputTxBatchQueueSize) == 0 &&

--- a/service/coordinator/coordinator_test.go
+++ b/service/coordinator/coordinator_test.go
@@ -331,7 +331,7 @@ func TestCoordinatorServiceValidTx(t *testing.T) {
 	require.Equal(t, uint64(2), nextBlock.Number)
 }
 
-func TestCoordinatorServiceRejectedTxAndWaitingStatusCount(t *testing.T) {
+func TestNoPendingTransactionProcessing(t *testing.T) {
 	t.Parallel()
 	env := newCoordinatorTestEnv(t, &testConfig{numSigService: 1, numVcService: 1, mockVcService: true})
 
@@ -339,7 +339,7 @@ func TestCoordinatorServiceRejectedTxAndWaitingStatusCount(t *testing.T) {
 	// those statuses are already queued in two batches. One queued status is a
 	// rejected transaction, proving rejected statuses are counted in the same unit
 	// as committed statuses.
-	env.coordinator.numWaitingTxsForStatus.Store(7)
+	env.coordinator.numTxsInProgress.Store(7)
 
 	require.True(t, env.coordinator.queues.vcServiceToCoordinatorTxStatus.write(t.Context(), &committerpb.TxStatusBatch{
 		Status: []*committerpb.TxStatus{
@@ -355,9 +355,9 @@ func TestCoordinatorServiceRejectedTxAndWaitingStatusCount(t *testing.T) {
 		},
 	}))
 
-	waitingTxs, err := env.coordinator.NumberOfWaitingTransactionsForStatus(t.Context(), nil)
+	idle, err := env.coordinator.NoPendingTransactionProcessing(t.Context(), nil)
 	require.NoError(t, err)
-	require.Equal(t, int32(2), waitingTxs.GetCount())
+	require.False(t, idle.GetValue())
 }
 
 func TestCoordinatorServiceDependentOrderedTxs(t *testing.T) {
@@ -806,9 +806,9 @@ func TestCoordinatorStreamFailureWithSidecar(t *testing.T) {
 
 	env.streamCancel() // simulate the failure of sidecar
 
-	// only when the stream is inactive, we do not get an error for NumberOfWaitingTransactionsForStatus.
+	// only when the stream is inactive, we do not get an error for NoPendingTransactionProcessing.
 	require.Eventually(t, func() bool {
-		_, err := env.client.NumberOfWaitingTransactionsForStatus(ctx, nil)
+		_, err := env.client.NoPendingTransactionProcessing(ctx, nil)
 		return err == nil
 	}, 5*time.Second, 10*time.Millisecond)
 
@@ -938,7 +938,7 @@ func TestWaitingTxsCountReturnsToZeroForBlockWithRejectedTxs(t *testing.T) {
 
 	actualTxsStatus := readTxStatus(t, env.csStream, len(expectedTxsStatus))
 	test.RequireProtoElementsMatch(t, expectedTxsStatus, actualTxsStatus)
-	require.Equal(t, int32(0), env.coordinator.numWaitingTxsForStatus.Load())
+	require.Equal(t, int32(0), env.coordinator.numTxsInProgress.Load())
 }
 
 func TestWaitingTxsCount(t *testing.T) {
@@ -954,7 +954,7 @@ func TestWaitingTxsCount(t *testing.T) {
 	success := channel.Make[bool](ctx, 1)
 	go func() {
 		success.Write(assert.Eventually(t, func() bool {
-			return env.coordinator.numWaitingTxsForStatus.Load() == int32(2)
+			return env.coordinator.numTxsInProgress.Load() == int32(2)
 		}, 1*time.Minute, 100*time.Millisecond))
 	}()
 
@@ -966,10 +966,10 @@ func TestWaitingTxsCount(t *testing.T) {
 	require.True(t, ok, "timed out waiting for tx count")
 	require.True(t, isSuccess)
 
-	count, err := env.client.NumberOfWaitingTransactionsForStatus(t.Context(), nil)
+	result, err := env.client.NoPendingTransactionProcessing(t.Context(), nil)
 	require.Error(t, err)
-	require.Contains(t, err.Error(), ErrActiveStreamWaitingTransactions.Error())
-	require.Nil(t, count)
+	require.Contains(t, err.Error(), ErrActiveStreamPendingTxProcessing.Error())
+	require.Nil(t, result)
 
 	env.sigVerifierGrpcServers.ServersStop[0]()
 	require.Eventually(t, func() bool {
@@ -1001,11 +1001,11 @@ func TestWaitingTxsCount(t *testing.T) {
 	}, 2*time.Second, 100*time.Millisecond)
 
 	require.Eventually(t, func() bool {
-		wTxs, err := env.client.NumberOfWaitingTransactionsForStatus(t.Context(), nil)
+		idle, err := env.client.NoPendingTransactionProcessing(t.Context(), nil)
 		if err != nil {
 			return false
 		}
-		return wTxs.GetCount() == 0
+		return idle.GetValue()
 	}, 2*time.Second, 100*time.Millisecond)
 }
 

--- a/service/coordinator/tx_status_queue.go
+++ b/service/coordinator/tx_status_queue.go
@@ -1,0 +1,66 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package coordinator
+
+import (
+	"context"
+	"sync/atomic"
+
+	"github.com/hyperledger/fabric-x-common/api/committerpb"
+)
+
+type txStatusQueue struct {
+	ch    chan *committerpb.TxStatusBatch
+	count atomic.Int32
+}
+
+func newTxStatusQueue(size int) *txStatusQueue {
+	return &txStatusQueue{
+		ch: make(chan *committerpb.TxStatusBatch, size),
+	}
+}
+
+func (q *txStatusQueue) write(ctx context.Context, batch *committerpb.TxStatusBatch) bool {
+	if ctx.Err() != nil {
+		return false
+	}
+
+	// Count before enqueueing so a fast reader cannot receive and decrement this
+	// batch before it has been counted. If the enqueue is canceled while blocked,
+	// roll the count back below.
+	count := int32(len(batch.Status)) //nolint:gosec
+	q.count.Add(count)
+	select {
+	case <-ctx.Done():
+		q.count.Add(-count)
+		return false
+	case q.ch <- batch:
+		return true
+	}
+}
+
+func (q *txStatusQueue) read(ctx context.Context) (*committerpb.TxStatusBatch, bool) {
+	if ctx.Err() != nil {
+		return nil, false
+	}
+
+	select {
+	case <-ctx.Done():
+		return nil, false
+	case batch := <-q.ch:
+		q.count.Add(-int32(len(batch.Status))) //nolint:gosec
+		return batch, true
+	}
+}
+
+func (q *txStatusQueue) readyCount() int32 {
+	return q.count.Load()
+}
+
+func (q *txStatusQueue) len() int {
+	return len(q.ch)
+}

--- a/service/coordinator/tx_status_queue_test.go
+++ b/service/coordinator/tx_status_queue_test.go
@@ -1,0 +1,115 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package coordinator
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/hyperledger/fabric-x-common/api/committerpb"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTxStatusQueueCount(t *testing.T) {
+	t.Parallel()
+
+	queue := newTxStatusQueue(2)
+	batch1 := txStatusBatch("tx-1", "tx-2")
+	batch2 := txStatusBatch("tx-3", "tx-4", "tx-5")
+
+	require.Zero(t, queue.readyCount())
+	require.Zero(t, queue.len())
+
+	require.True(t, queue.write(t.Context(), batch1))
+	require.Equal(t, int32(2), queue.readyCount())
+	require.Equal(t, 1, queue.len())
+
+	require.True(t, queue.write(t.Context(), batch2))
+	require.Equal(t, int32(5), queue.readyCount())
+	require.Equal(t, 2, queue.len())
+
+	readBatch, ok := queue.read(t.Context())
+	require.True(t, ok)
+	require.Same(t, batch1, readBatch)
+	require.Equal(t, int32(3), queue.readyCount())
+	require.Equal(t, 1, queue.len())
+
+	readBatch, ok = queue.read(t.Context())
+	require.True(t, ok)
+	require.Same(t, batch2, readBatch)
+	require.Zero(t, queue.readyCount())
+	require.Zero(t, queue.len())
+}
+
+func TestTxStatusQueueCanceledContext(t *testing.T) {
+	t.Parallel()
+
+	t.Run("write does not increment", func(t *testing.T) {
+		t.Parallel()
+
+		queue := newTxStatusQueue(1)
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+
+		require.False(t, queue.write(ctx, txStatusBatch("tx-1", "tx-2")))
+		require.Zero(t, queue.readyCount())
+		require.Zero(t, queue.len())
+	})
+
+	t.Run("read does not decrement", func(t *testing.T) {
+		t.Parallel()
+
+		queue := newTxStatusQueue(1)
+		batch := txStatusBatch("tx-1", "tx-2")
+		require.True(t, queue.write(t.Context(), batch))
+
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+
+		readBatch, ok := queue.read(ctx)
+		require.False(t, ok)
+		require.Nil(t, readBatch)
+		require.Equal(t, int32(2), queue.readyCount())
+		require.Equal(t, 1, queue.len())
+	})
+}
+
+func TestTxStatusQueueCanceledBlockedWriteRollsBackCount(t *testing.T) {
+	t.Parallel()
+
+	queue := newTxStatusQueue(1)
+	require.True(t, queue.write(t.Context(), txStatusBatch("tx-1")))
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	done := make(chan bool, 1)
+
+	// The second write blocks because the queue is full. Its statuses are counted
+	// before enqueueing so a reader cannot decrement before the writer increments.
+	// Canceling the context should roll that provisional count back.
+	go func() {
+		done <- queue.write(ctx, txStatusBatch("tx-2", "tx-3"))
+	}()
+
+	require.Eventually(t, func() bool {
+		return queue.readyCount() == 3 && queue.len() == 1
+	}, time.Second, 10*time.Millisecond)
+
+	cancel()
+	require.False(t, <-done)
+	require.Equal(t, int32(1), queue.readyCount())
+	require.Equal(t, 1, queue.len())
+}
+
+func txStatusBatch(txIDs ...string) *committerpb.TxStatusBatch {
+	statuses := make([]*committerpb.TxStatus, len(txIDs))
+	for i, txID := range txIDs {
+		statuses[i] = committerpb.NewTxStatus(committerpb.Status_COMMITTED, txID, 1, uint32(i))
+	}
+	return &committerpb.TxStatusBatch{Status: statuses}
+}

--- a/service/coordinator/validator_committer_manager.go
+++ b/service/coordinator/validator_committer_manager.go
@@ -37,10 +37,9 @@ type (
 	// 3. Forwarding the validated transactions node to the dependency graph manager.
 	// 4. Forwarding the status of the transactions to the coordinator.
 	validatorCommitterManager struct {
-		config              *validatorCommitterManagerConfig
-		commonClient        servicepb.ValidationAndCommitServiceClient
-		validatorCommitter  []*validatorCommitter
-		txsStatusBufferSize int
+		config             *validatorCommitterManagerConfig
+		commonClient       servicepb.ValidationAndCommitServiceClient
+		validatorCommitter []*validatorCommitter
 		// ready indicates that the validatorCommitter array is initialized.
 		ready *channel.Ready
 	}
@@ -62,7 +61,7 @@ type (
 		clientConfig                   *connection.MultiClientConfig
 		incomingTxsForValidationCommit <-chan dependencygraph.TxNodeBatch
 		outgoingValidatedTxsNode       chan<- dependencygraph.TxNodeBatch
-		outgoingTxsStatus              chan<- *committerpb.TxStatusBatch
+		outgoingTxsStatus              *txStatusQueue
 		metrics                        *perfMetrics
 		policyMgr                      *policyManager
 	}
@@ -71,9 +70,8 @@ type (
 func newValidatorCommitterManager(c *validatorCommitterManagerConfig) *validatorCommitterManager {
 	logger.Info("Initializing new ValidatorCommitterManager")
 	return &validatorCommitterManager{
-		config:              c,
-		txsStatusBufferSize: cap(c.outgoingTxsStatus),
-		ready:               channel.NewReady(),
+		config: c,
+		ready:  channel.NewReady(),
 	}
 }
 
@@ -127,7 +125,7 @@ func (vcm *validatorCommitterManager) run(ctx context.Context) error {
 					eCtx,
 					txBatchQueue,
 					channel.NewWriter(eCtx, c.outgoingValidatedTxsNode),
-					channel.NewWriter(eCtx, c.outgoingTxsStatus),
+					c.outgoingTxsStatus,
 				)
 			})
 		})
@@ -206,7 +204,7 @@ func (vc *validatorCommitter) sendTransactionsAndForwardStatus(
 	ctx context.Context,
 	inputTxBatch channel.ReaderWriter[dependencygraph.TxNodeBatch],
 	outputValidatedTxsNode channel.Writer[dependencygraph.TxNodeBatch],
-	outputTxsStatus channel.Writer[*committerpb.TxStatusBatch],
+	outputTxsStatus *txStatusQueue,
 ) error {
 	defer vc.metrics.vcservicesConnection.Disconnected(vc.conn.CanonicalTarget())
 
@@ -232,7 +230,7 @@ func (vc *validatorCommitter) sendTransactionsAndForwardStatus(
 		//       transaction from the stream and removing it from txBeingValidated, if the stream context is
 		//       canceled before we can write to these two channels, the validation results are lost forever.
 		//       Similarly, the first argument, i.e., context should not be stream context.
-		return vc.receiveStatusAndForwardToOutput(stream, outputValidatedTxsNode, outputTxsStatus)
+		return vc.receiveStatusAndForwardToOutput(ctx, stream, outputValidatedTxsNode, outputTxsStatus)
 	})
 
 	return utils.ProcessErr(g.Wait(), "sendTransactionsAndForwardStatus run failed")
@@ -300,9 +298,10 @@ func splitAndSendToVC(
 }
 
 func (vc *validatorCommitter) receiveStatusAndForwardToOutput(
+	ctx context.Context,
 	stream servicepb.ValidationAndCommitService_StartValidateAndCommitStreamClient,
 	outputTxsNode channel.Writer[dependencygraph.TxNodeBatch],
-	outputTxsStatus channel.Writer[*committerpb.TxStatusBatch],
+	outputTxsStatus *txStatusQueue,
 ) error {
 	for {
 		txsStatus, err := stream.Recv()
@@ -339,8 +338,8 @@ func (vc *validatorCommitter) receiveStatusAndForwardToOutput(
 		//       this is not an issue. If the sidecar becomes bottlenecked and cannot receive
 		//       the statuses quickly, the gRPC flow control will activate and slow down the
 		//       whole system, allowing the sidecar to catch up.
-		if ok := outputTxsStatus.Write(txsStatus); !ok {
-			return errors.Wrap(outputTxsStatus.Context().Err(), "context ended")
+		if ok := outputTxsStatus.write(ctx, txsStatus); !ok {
+			return errors.Wrap(ctx.Err(), "context ended")
 		}
 		logger.Debugf("Forwarded batch with %d TX statuses back to coordinator", len(txsStatus.Status))
 

--- a/service/coordinator/validator_committer_manager_test.go
+++ b/service/coordinator/validator_committer_manager_test.go
@@ -38,7 +38,7 @@ type vcMgrTestEnv struct {
 	validatorCommitterManager *validatorCommitterManager
 	inputTxs                  chan dependencygraph.TxNodeBatch
 	outputTxs                 chan dependencygraph.TxNodeBatch
-	outputTxsStatus           chan *committerpb.TxStatusBatch
+	outputTxsStatus           *txStatusQueue
 	mockVcService             *mock.VcService
 	mockVCGrpcServers         *test.Servers
 	sigVerTestEnv             *svMgrTestEnv
@@ -51,7 +51,7 @@ func newVcMgrTestEnv(t *testing.T, numVCService int) *vcMgrTestEnv {
 
 	inputTxs := make(chan dependencygraph.TxNodeBatch, 10)
 	outputTxs := make(chan dependencygraph.TxNodeBatch, 10)
-	outputTxsStatus := make(chan *committerpb.TxStatusBatch, 10)
+	outputTxsStatus := newTxStatusQueue(10)
 
 	vcm := newValidatorCommitterManager(
 		&validatorCommitterManagerConfig{
@@ -121,7 +121,7 @@ func TestValidatorCommitterManagerX(t *testing.T) {
 		outTxs := <-env.outputTxs
 		require.ElementsMatch(t, txBatch, outTxs)
 
-		outTxsStatus := <-env.outputTxsStatus
+		outTxsStatus := env.readOutputTxsStatus(t)
 
 		test.RequireProtoElementsMatch(t, expectedTxsStatus, outTxsStatus.Status)
 
@@ -150,10 +150,10 @@ func TestValidatorCommitterManagerX(t *testing.T) {
 		outTxs = append(outTxs, <-env.outputTxs...)
 		require.ElementsMatch(t, txBatches, outTxs)
 
-		outTxsStatus = <-env.outputTxsStatus
-		status := <-env.outputTxsStatus
+		outTxsStatus = env.readOutputTxsStatus(t)
+		status := env.readOutputTxsStatus(t)
 		outTxsStatus.Status = append(outTxsStatus.Status, status.Status...)
-		status = <-env.outputTxsStatus
+		status = env.readOutputTxsStatus(t)
 		outTxsStatus.Status = append(outTxsStatus.Status, status.Status...)
 		test.RequireProtoElementsMatch(t, expectedTxsStatus, outTxsStatus.Status)
 
@@ -180,8 +180,8 @@ func TestValidatorCommitterManagerX(t *testing.T) {
 			outputTxBatch1 := <-env.outputTxs
 			outputTxBatch2 := <-env.outputTxs
 
-			outTxsStatus1 := <-env.outputTxsStatus
-			outTxsStatus2 := <-env.outputTxsStatus
+			outTxsStatus1 := env.readOutputTxsStatus(t)
+			outTxsStatus2 := env.readOutputTxsStatus(t)
 
 			require.ElementsMatch(
 				t,
@@ -244,7 +244,7 @@ func TestValidatorCommitterManagerX(t *testing.T) {
 		}
 		env.inputTxs <- txBatch
 
-		outTxsStatus := <-env.outputTxsStatus
+		outTxsStatus := env.readOutputTxsStatus(t)
 
 		require.Len(t, outTxsStatus.Status, 2)
 		expectedConfig := committerpb.NewTxStatus(committerpb.Status_COMMITTED, "create config", 100, 63)
@@ -305,7 +305,7 @@ func TestValidatorCommitterManagerRecovery(t *testing.T) {
 
 	actualTxsStatus := make([]*committerpb.TxStatus, 0, numTxs)
 	for range 2 {
-		result := <-env.outputTxsStatus
+		result := env.readOutputTxsStatus(t)
 		actualTxsStatus = append(actualTxsStatus, result.Status...)
 	}
 	test.RequireProtoElementsMatch(t, expectedTxsStatus, actualTxsStatus)
@@ -327,6 +327,13 @@ func TestValidatorCommitterManagerRecovery(t *testing.T) {
 	require.Never(t, func() bool {
 		return test.GetIntMetricValue(t, txProcessedTotalMetric) > txTotal
 	}, 2*time.Second, 1*time.Second)
+}
+
+func (e *vcMgrTestEnv) readOutputTxsStatus(t *testing.T) *committerpb.TxStatusBatch {
+	t.Helper()
+	batch, ok := e.outputTxsStatus.read(t.Context())
+	require.True(t, ok)
+	return batch
 }
 
 func createInputTxsNodeForTest(t *testing.T, numTxs, valueSize int, blkNum uint64) (

--- a/service/sidecar/sidecar.go
+++ b/service/sidecar/sidecar.go
@@ -687,14 +687,14 @@ func wrapQueryError(err error) error {
 
 func waitForIdleCoordinator(ctx context.Context, client servicepb.CoordinatorClient) error {
 	for {
-		waitingTxs, err := client.NumberOfWaitingTransactionsForStatus(ctx, nil)
+		idle, err := client.NoPendingTransactionProcessing(ctx, nil)
 		if err != nil {
-			return logAndWrapCoordinatorError(err, "failed to get number of waiting transactions from coordinator")
+			return logAndWrapCoordinatorError(err, "failed to check pending transaction processing from coordinator")
 		}
-		if waitingTxs.Count == 0 {
+		if idle.GetValue() {
 			return nil
 		}
-		logger.Infof("Waiting for coordinator to complete processing [%d] pending transactions", waitingTxs.Count)
+		logger.Info("Waiting for coordinator to complete processing pending transactions")
 		time.Sleep(100 * time.Millisecond)
 	}
 }

--- a/service/sidecar/sidecar_test.go
+++ b/service/sidecar/sidecar_test.go
@@ -390,7 +390,7 @@ func TestSidecarRecovery(t *testing.T) {
 	tempBlockStore.close()
 
 	t.Log("4. Make coordinator not idle to ensure sidecar is waiting")
-	env.coordinator.SetWaitingTxsCount(10)
+	env.coordinator.SetTxsInProgress(10)
 
 	t.Log("5. Restart the sidecar service and ledger service")
 	env.startSidecarServiceAndClientAndNotificationStream(ctx2, t, 11, test.InsecureTLSConfig)
@@ -401,7 +401,7 @@ func TestSidecarRecovery(t *testing.T) {
 	}, 3*time.Second, 1*time.Second)
 
 	t.Log("7. Make coordinator idle")
-	env.coordinator.SetWaitingTxsCount(0)
+	env.coordinator.SetTxsInProgress(0)
 
 	t.Log("8. Blockstore would recover lost blocks")
 	ensureAtLeastHeight(t, env.sidecar.blockStore, 11)

--- a/service/vc/validator_committer_service.go
+++ b/service/vc/validator_committer_service.go
@@ -61,8 +61,6 @@ type ValidatorCommitterService struct {
 	// streams were allowed concurrently, transaction status might not reach the client
 	// reliably, as we are not currently associating requests and their corresponding responses
 	// (i.e., status updates) with specific streams.
-	// Further, when isStreamActive is active, NoPendingTransactionProcessing would return an
-	// error as this gRPC api can be called only when the stream is inactive.
 	isStreamActive atomic.Bool
 	ready          *channel.Ready
 }

--- a/service/vc/validator_committer_service.go
+++ b/service/vc/validator_committer_service.go
@@ -61,7 +61,7 @@ type ValidatorCommitterService struct {
 	// streams were allowed concurrently, transaction status might not reach the client
 	// reliably, as we are not currently associating requests and their corresponding responses
 	// (i.e., status updates) with specific streams.
-	// Further, when isStreamActive is active, NumberOfWaitingTransactionsForStatus would return an
+	// Further, when isStreamActive is active, NoPendingTransactionProcessing would return an
 	// error as this gRPC api can be called only when the stream is inactive.
 	isStreamActive atomic.Bool
 	ready          *channel.Ready


### PR DESCRIPTION
#### Type of change

- Bug fix
 
#### Description

Track VC-produced transaction statuses separately from the status queue length so NumberOfWaitingTransactionsForStatus does not count statuses that are already ready to be sent back to the sidecar.

Use a txStatusQueue to count statuses before enqueueing and roll the count back if a blocked enqueue is canceled. This avoids a race where a fast reader could decrement the count before the writer increments it.

Simplify queue handling by removing impossible nil/closed-channel cases and keep tests focused on count accounting and context cancellation.

#### Related issues

 - resolves #612 
