### PR TITLE
[bob] Reduce initial context from 25K to 19K

### DIFF
--- a/.bob/commands/pr-review.md
+++ b/.bob/commands/pr-review.md
@@ -29,6 +29,16 @@ You are Bob, an AI PR reviewer for the Fabric-X Committer project. Follow these 
 
 The user says something like: "Bob, review this PR — <link>". Extract the PR number and repository, then follow the review process below.
 
+### Code Review Standards
+
+Reviews use three priority levels:
+
+- **Major**: Critical issues affecting functionality, performance, or maintainability (must be addressed)
+- **Minor**: Code style, naming, or best practices (should be addressed)
+- **Nit**: Typos, formatting, minor preferences (optional)
+
+Always be polite and constructive in reviews. Use "we" instead of "you" to frame issues as team problems.
+
 ## File Reference Convention
 
 `@filename` means **read that file** before proceeding (e.g., `@guidelines.md`). This is required context.

--- a/.bob/rules/01-project-guidelines.md
+++ b/.bob/rules/01-project-guidelines.md
@@ -24,7 +24,7 @@ The system consists of four main microservices that communicate via gRPC:
 - **Language**: Go 1.26
 - **Communication**: gRPC with Protocol Buffers
 - **Database**: PostgreSQL or YugabyteDB (for state storage)
-- **Testing**: Standard Go testing with Docker-based integration tests
+- **Testing**: Standard Go testing with binaries integration tests and Docker-based integration tests
 - **Build**: Make-based build system with Docker support
 
 ## Building and Running
@@ -40,43 +40,7 @@ The system consists of four main microservices that communicate via gRPC:
 ```bash
 # Build all binaries locally
 make build
-
-# Build in Docker container (useful for consistent builds)
-make build-with-docker
-
-# Build for specific OS/architecture
-make build os=linux arch=amd64
-
-# Build release binaries for multiple architectures
-make build-release
 ```
-
-### Testing
-
-```bash
-# Run unit tests (excludes integration and container tests)
-make test
-
-# Run integration tests
-make test-integration
-
-# Run tests with coverage
-make test-cover
-
-# Run specific package tests
-make test-package-<package-name>
-
-# Run container tests (requires Docker images)
-make test-container
-```
-
-#### Database Tests
-
-- Some tests require a database. The test harness automatically manages YugabyteDB Docker containers.
-- Use `make kill-test-docker` to clean up containers after testing.
-- It is best to use a local DB deployment by exporting `export DB_DEPLOYMENT=local`.
-- The database is usually already running. Verify using `docker ps` and check `sc_test_postgres_unit_tests`.
-- If it is not running, the database can be deployed manually using `scripts/get-and-start-postgres.sh`
 
 ### Running Services
 
@@ -120,19 +84,9 @@ The project uses `github.com/cockroachdb/errors` for comprehensive error handlin
 
 - avoid callbacks when possible
 - avoid code duplication
-- Collate methods of the same struct togather
+- Collate methods of the same struct together
 - Order the methods such that the method user is before the method declaration
-- Address lint issues - run `make lint`
-
-### Code Review Standards
-
-Reviews use three priority levels:
-
-- **Major**: Critical issues affecting functionality, performance, or maintainability (must be addressed)
-- **Minor**: Code style, naming, or best practices (should be addressed)
-- **Nit**: Typos, formatting, minor preferences (optional)
-
-Always be polite and constructive in reviews. Use "we" instead of "you" to frame issues as team problems.
+- Address lint issues - run `make lint` or `make lint-go` for Go code linting only.
 
 ### Performance Considerations
 
@@ -145,8 +99,7 @@ Always be polite and constructive in reviews. Use "we" instead of "you" to frame
 
 ```
 /
-├── api/                    # Protocol Buffer definitions
-│   └── servicepb/         # Service protobuf files
+├── api/                   # Protocol Buffer definitions
 ├── cmd/                   # Main applications
 │   ├── committer/         # Main committer service
 │   ├── loadgen/           # Load generation tool
@@ -197,9 +150,7 @@ Detailed architectural documentation is available in the `docs/` directory:
 
 6. **Protocol Buffers**: Changes to `.proto` files require regeneration: `make proto`
 
-7. **Linting**: Run `make lint` before submitting PRs. The project uses golangci-lint with strict rules.
-
-8. **Code Ownership**: Check `CODEOWNERS` file for component ownership. Code owners must review changes to their areas.
+7. **Code Ownership**: Check `CODEOWNERS` file for component ownership. Code owners must review changes to their areas.
 
 ## Common Development Tasks
 
@@ -249,7 +200,6 @@ Before submitting a PR:
 ## Getting Help
 
 - Review detailed service documentation in `docs/`
-- Check `guidelines.md` for coding standards and philosophy
 - Examine existing code for patterns and conventions
 - Run `make` to see all available build targets
 

--- a/.bob/skills/tests/SKILL.md
+++ b/.bob/skills/tests/SKILL.md
@@ -4,9 +4,14 @@ Copyright IBM Corp. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 -->
 
+---
+name: tests
+description: Write and/or run unit and integration tests, ensuring high code coverage and reliability.
+---
+
 # Testing Code Guidelines
 
-This document provides specific guidelines for writing tests in the fabric-x-committer project.
+This document provides specific guidelines for writing and running tests in the fabric-x-committer project.
 
 - **High Coverage Expected**: Strive for comprehensive test coverage, but focus on meaningful scenarios
 - **Minimize Mocks**: Use mocks sparingly; prefer testing with real dependencies when practical
@@ -14,6 +19,14 @@ This document provides specific guidelines for writing tests in the fabric-x-com
     - `test-core-db`: Components that directly interact with the database
     - `test-requires-db`: Components that depend on the database layer
     - `test-no-db`: Pure logic tests with no database dependency
+
+#### Running Database Tests
+
+- Some tests require a database. The test harness automatically manages YugabyteDB Docker containers.
+- Use `make kill-test-docker` to clean up containers after testing.
+- It is best to use a local DB deployment by exporting `export DB_DEPLOYMENT=local`.
+- The database is usually already running. Verify using `docker ps` and check `sc_test_postgres_unit_tests`.
+- If it is not running, the database can be deployed manually using `scripts/get-and-start-postgres.sh`
 
 #### Testing Code Guidelines
 
@@ -340,10 +353,10 @@ require.Greater(t, count, 500)
 ### Metrics Testing Best Practices
 
 1. **Use Appropriate Helper**: Choose the right helper based on timing requirements:
-   - [`test.RequireIntMetricValue()`](../../utils/test/metrics.go:99) for synchronous operations where the metric should already have the expected value
-   - [`test.EventuallyIntMetric()`](../../utils/test/metrics.go:105) for asynchronous operations where the metric will reach the expected value after some time
-   - [`test.GetIntMetricValue()`](../../utils/test/metrics.go:92) for capturing baseline values or when using with `require.Eventually()` for complex conditions
-   - [`test.GetMetricValue()`](../../utils/test/metrics.go:69) for float metrics (histograms, summaries) or when you need the raw float value
+    - [`test.RequireIntMetricValue()`](../../utils/test/metrics.go:99) for synchronous operations where the metric should already have the expected value
+    - [`test.EventuallyIntMetric()`](../../utils/test/metrics.go:105) for asynchronous operations where the metric will reach the expected value after some time
+    - [`test.GetIntMetricValue()`](../../utils/test/metrics.go:92) for capturing baseline values or when using with `require.Eventually()` for complex conditions
+    - [`test.GetMetricValue()`](../../utils/test/metrics.go:69) for float metrics (histograms, summaries) or when you need the raw float value
 
 2. **Capture Baseline Values**: When testing incremental changes, capture the metric value before the operation:
    ```go
@@ -366,12 +379,12 @@ require.Greater(t, count, 500)
    ```
 
 4. **Use Appropriate Wait Times**: For [`test.EventuallyIntMetric()`](../../utils/test/metrics.go:105):
-   - Unit tests: 1-5 seconds wait, 10-100ms tick
-   - Integration tests: 5-60 seconds wait, 100ms-1s tick
-   - Examples from codebase:
-     - Fast operations: `5*time.Second, 10*time.Millisecond`
-     - Normal operations: `5*time.Second, 100*time.Millisecond`
-     - Slow operations: `2*time.Second, 200*time.Millisecond`
+    - Unit tests: 1-5 seconds wait, 10-100ms tick
+    - Integration tests: 5-60 seconds wait, 100ms-1s tick
+    - Examples from codebase:
+        - Fast operations: `5*time.Second, 10*time.Millisecond`
+        - Normal operations: `5*time.Second, 100*time.Millisecond`
+        - Slow operations: `2*time.Second, 200*time.Millisecond`
 
 5. **Test Initial State**: Always verify metrics start at expected initial values:
    ```go

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ docker/runner/out
 .bob/*
 !.bob/rules/
 !.bob/commands/
+!.bob/skills/
 *coverage.profile
 *coverage.html
 


### PR DESCRIPTION
#### Type of change

- Improvement (improvement to code, performance, etc)
 
#### Description

This commit reduces Bob's initial context from 25K tokens to 19K.

- Moving the testing rules to a skill
- Removing some repeating lines
