### PR TITLE
[coordinator] BUGFIX coordinator does not pass metadata to verifier

### DIFF
--- a/cmd/config/templates/loadgen_shared.yaml.tmpl
+++ b/cmd/config/templates/loadgen_shared.yaml.tmpl
@@ -29,6 +29,7 @@ load-profile:
   key:
     size: 32
   transaction:
+    metadata-size: 150
     read-write-count:
       const: 2
   policy:

--- a/service/coordinator/dependencygraph/dependency_graph_test.go
+++ b/service/coordinator/dependencygraph/dependency_graph_test.go
@@ -88,7 +88,7 @@ func TestDependencyGraph(t *testing.T) {
 	depFreeTxs := <-globalDepOutgoingTxs
 	require.Len(t, depFreeTxs, 1)
 	actualT1 := depFreeTxs[0]
-	test.RequireProtoEqual(t, t1.Ref, actualT1.Tx.Ref)
+	test.RequireProtoEqual(t, t1.Ref, actualT1.VCTx.Ref)
 
 	// t1 has 3 dependent transactions, t2, t3, and t4
 	require.Eventually(t, func() bool {
@@ -101,7 +101,7 @@ func TestDependencyGraph(t *testing.T) {
 	depFreeTxs = <-globalDepOutgoingTxs
 	require.Len(t, depFreeTxs, 1)
 	actualT2 := depFreeTxs[0]
-	test.RequireProtoEqual(t, t2.Ref, actualT2.Tx.Ref)
+	test.RequireProtoEqual(t, t2.Ref, actualT2.VCTx.Ref)
 
 	test.RequireIntMetricValue(t, 2, metrics.dependentTransactionsQueueSize)
 
@@ -114,15 +114,15 @@ func TestDependencyGraph(t *testing.T) {
 	depFreeTxs = <-globalDepOutgoingTxs
 	require.Len(t, depFreeTxs, 2)
 	var actualT3, actualT4 *TransactionNode
-	if t3.Ref.TxId == depFreeTxs[0].Tx.Ref.TxId {
+	if t3.Ref.TxId == depFreeTxs[0].VCTx.Ref.TxId {
 		actualT3 = depFreeTxs[0]
 		actualT4 = depFreeTxs[1]
 	} else {
 		actualT3 = depFreeTxs[1]
 		actualT4 = depFreeTxs[0]
 	}
-	test.RequireProtoEqual(t, t3.Ref, actualT3.Tx.Ref)
-	test.RequireProtoEqual(t, t4.Ref, actualT4.Tx.Ref)
+	test.RequireProtoEqual(t, t3.Ref, actualT3.VCTx.Ref)
+	test.RequireProtoEqual(t, t4.Ref, actualT4.VCTx.Ref)
 
 	test.RequireIntMetricValue(t, 0, metrics.dependentTransactionsQueueSize)
 
@@ -165,7 +165,7 @@ func TestDependencyGraph(t *testing.T) {
 	depFreeTxs = <-globalDepOutgoingTxs
 	require.Len(t, depFreeTxs, 1)
 	actualT1 = depFreeTxs[0]
-	test.RequireProtoEqual(t, t1.Ref, actualT1.Tx.Ref)
+	test.RequireProtoEqual(t, t1.Ref, actualT1.VCTx.Ref)
 
 	// t1 has 3 dependent transactions: t2, t3 and t4
 	require.Eventually(t, func() bool {
@@ -178,7 +178,7 @@ func TestDependencyGraph(t *testing.T) {
 	depFreeTxs = <-globalDepOutgoingTxs
 	require.Len(t, depFreeTxs, 1)
 	actualT2 = depFreeTxs[0]
-	test.RequireProtoEqual(t, t2.Ref, actualT2.Tx.Ref)
+	test.RequireProtoEqual(t, t2.Ref, actualT2.VCTx.Ref)
 
 	// t2 has 2 dependent transactions, t3 and t4
 	require.Equal(t, 2, actualT2.dependentTxs.Count())
@@ -189,7 +189,7 @@ func TestDependencyGraph(t *testing.T) {
 	depFreeTxs = <-globalDepOutgoingTxs
 	require.Len(t, depFreeTxs, 1)
 	actualT3 = depFreeTxs[0]
-	test.RequireProtoEqual(t, t3.Ref, actualT3.Tx.Ref)
+	test.RequireProtoEqual(t, t3.Ref, actualT3.VCTx.Ref)
 
 	validatedTxs <- TxNodeBatch{actualT3}
 
@@ -197,7 +197,7 @@ func TestDependencyGraph(t *testing.T) {
 	depFreeTxs = <-globalDepOutgoingTxs
 	require.Len(t, depFreeTxs, 1)
 	actualT4 = depFreeTxs[0]
-	test.RequireProtoEqual(t, t4.Ref, actualT4.Tx.Ref)
+	test.RequireProtoEqual(t, t4.Ref, actualT4.VCTx.Ref)
 
 	validatedTxs <- TxNodeBatch{actualT4}
 

--- a/service/coordinator/dependencygraph/manager_test.go
+++ b/service/coordinator/dependencygraph/manager_test.go
@@ -213,7 +213,7 @@ func TestDependencyGraphManager(t *testing.T) {
 			depFreeTxs := <-outgoingTxs
 			require.Len(t, depFreeTxs, 1)
 			actualT1 := depFreeTxs[0]
-			test.RequireProtoEqual(t, t1.Ref, actualT1.Tx.Ref)
+			test.RequireProtoEqual(t, t1.Ref, actualT1.VCTx.Ref)
 			ensureNoOutputs(t, outgoingTxs)
 
 			validatedTxs <- TxNodeBatch{actualT1}
@@ -222,7 +222,7 @@ func TestDependencyGraphManager(t *testing.T) {
 			depFreeTxs = <-outgoingTxs
 			require.Len(t, depFreeTxs, 1)
 			actualT2 := depFreeTxs[0]
-			test.RequireProtoEqual(t, t2.Ref, actualT2.Tx.Ref)
+			test.RequireProtoEqual(t, t2.Ref, actualT2.VCTx.Ref)
 			ensureNoOutputs(t, outgoingTxs)
 
 			test.RequireIntMetricValue(t, 2, metrics.dependentTransactionsQueueSize)
@@ -233,15 +233,15 @@ func TestDependencyGraphManager(t *testing.T) {
 			depFreeTxs = <-outgoingTxs
 			require.Len(t, depFreeTxs, 2)
 			var actualT3, actualT4 *TransactionNode
-			if t3.Ref.TxId == depFreeTxs[0].Tx.Ref.TxId {
+			if t3.Ref.TxId == depFreeTxs[0].VCTx.Ref.TxId {
 				actualT3 = depFreeTxs[0]
 				actualT4 = depFreeTxs[1]
 			} else {
 				actualT3 = depFreeTxs[1]
 				actualT4 = depFreeTxs[0]
 			}
-			test.RequireProtoEqual(t, t3.Ref, actualT3.Tx.Ref)
-			test.RequireProtoEqual(t, t4.Ref, actualT4.Tx.Ref)
+			test.RequireProtoEqual(t, t3.Ref, actualT3.VCTx.Ref)
+			test.RequireProtoEqual(t, t4.Ref, actualT4.VCTx.Ref)
 			ensureNoOutputs(t, outgoingTxs)
 
 			test.RequireIntMetricValue(t, 0, metrics.dependentTransactionsQueueSize)
@@ -282,7 +282,7 @@ func TestDependencyGraphManager(t *testing.T) {
 			depFreeTxs = <-outgoingTxs
 			require.Len(t, depFreeTxs, 1)
 			actualT1 = depFreeTxs[0]
-			test.RequireProtoEqual(t, t1.Ref, actualT1.Tx.Ref)
+			test.RequireProtoEqual(t, t1.Ref, actualT1.VCTx.Ref)
 			ensureNoOutputs(t, outgoingTxs)
 
 			validatedTxs <- TxNodeBatch{actualT1}
@@ -291,7 +291,7 @@ func TestDependencyGraphManager(t *testing.T) {
 			depFreeTxs = <-outgoingTxs
 			require.Len(t, depFreeTxs, 1)
 			actualT2 = depFreeTxs[0]
-			test.RequireProtoEqual(t, t2.Ref, actualT2.Tx.Ref)
+			test.RequireProtoEqual(t, t2.Ref, actualT2.VCTx.Ref)
 			ensureNoOutputs(t, outgoingTxs)
 
 			validatedTxs <- TxNodeBatch{actualT2}
@@ -300,7 +300,7 @@ func TestDependencyGraphManager(t *testing.T) {
 			depFreeTxs = <-outgoingTxs
 			require.Len(t, depFreeTxs, 1)
 			actualT3 = depFreeTxs[0]
-			test.RequireProtoEqual(t, t3.Ref, actualT3.Tx.Ref)
+			test.RequireProtoEqual(t, t3.Ref, actualT3.VCTx.Ref)
 			ensureNoOutputs(t, outgoingTxs)
 
 			validatedTxs <- TxNodeBatch{actualT3}
@@ -309,7 +309,7 @@ func TestDependencyGraphManager(t *testing.T) {
 			depFreeTxs = <-outgoingTxs
 			require.Len(t, depFreeTxs, 1)
 			actualT4 = depFreeTxs[0]
-			test.RequireProtoEqual(t, t4.Ref, actualT4.Tx.Ref)
+			test.RequireProtoEqual(t, t4.Ref, actualT4.VCTx.Ref)
 			ensureNoOutputs(t, outgoingTxs)
 
 			validatedTxs <- TxNodeBatch{actualT4}

--- a/service/coordinator/dependencygraph/transaction_node.go
+++ b/service/coordinator/dependencygraph/transaction_node.go
@@ -20,8 +20,8 @@ import (
 type (
 	// TransactionNode is a node in the dependency graph.
 	TransactionNode struct {
-		Tx           *servicepb.VcTx
-		Endorsements []*applicationpb.Endorsements
+		VCTx       *servicepb.VcTx
+		VerifierTx *servicepb.TxWithRef
 
 		// dependsOnTxs is a set of transactions that this transaction depends on.
 		// A transaction is eligible for validation once all the transactions
@@ -72,19 +72,19 @@ type (
 // newTransactionNode creates a TX node for coordinator's TX.
 func newTransactionNode(tx *servicepb.TxWithRef) *TransactionNode {
 	return &TransactionNode{
-		Tx: &servicepb.VcTx{
+		VCTx: &servicepb.VcTx{
 			Ref:        tx.Ref,
 			Namespaces: tx.Content.Namespaces,
 		},
-		Endorsements: tx.Content.Endorsements,
-		rwKeys:       readAndWriteKeys(tx.Content.Namespaces),
+		VerifierTx: tx,
+		rwKeys:     readAndWriteKeys(tx.Content.Namespaces),
 	}
 }
 
 // NewRejectedTransactionNode creates a TX node for a rejected TX.
 func NewRejectedTransactionNode(tx *committerpb.TxStatus) *TransactionNode {
 	return &TransactionNode{
-		Tx: &servicepb.VcTx{
+		VCTx: &servicepb.VcTx{
 			Ref:                   tx.Ref,
 			PrelimInvalidTxStatus: &tx.Status,
 		},

--- a/service/coordinator/dependencygraph/transaction_node_test.go
+++ b/service/coordinator/dependencygraph/transaction_node_test.go
@@ -167,8 +167,8 @@ func checkNewTxNode(
 	txNode *TransactionNode,
 ) {
 	t.Helper()
-	test.RequireProtoEqual(t, tx.Ref, txNode.Tx.Ref)
-	test.RequireProtoElementsMatch(t, tx.Content.Namespaces, txNode.Tx.Namespaces)
+	test.RequireProtoEqual(t, tx.Ref, txNode.VCTx.Ref)
+	test.RequireProtoElementsMatch(t, tx.Content.Namespaces, txNode.VCTx.Namespaces)
 	require.True(t, txNode.isDependencyFree())
 	require.ElementsMatch(t, readsWrites.readsOnly, txNode.rwKeys.readsOnly)
 	require.ElementsMatch(t, readsWrites.writesOnly, txNode.rwKeys.writesOnly)

--- a/service/coordinator/signature_verifier_manager.go
+++ b/service/coordinator/signature_verifier_manager.go
@@ -12,7 +12,6 @@ import (
 	"sync"
 
 	"github.com/cockroachdb/errors"
-	"github.com/hyperledger/fabric-x-common/api/applicationpb"
 	"github.com/hyperledger/fabric-x-common/api/committerpb"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
@@ -214,13 +213,7 @@ func (sv *signatureVerifier) sendTransactionsToSVService(
 		request.Update, policyVersion = sv.policyManager.getUpdates(policyVersion)
 
 		for idx, txNode := range txBatch {
-			request.Requests[idx] = &servicepb.TxWithRef{
-				Ref: txNode.Tx.Ref,
-				Content: &applicationpb.Tx{
-					Namespaces:   txNode.Tx.Namespaces,
-					Endorsements: txNode.Endorsements,
-				},
-			}
+			request.Requests[idx] = txNode.VerifierTx
 		}
 
 		if firstBatch {
@@ -326,7 +319,7 @@ func (sv *signatureVerifier) fetchAndDeleteTxBeingValidated(
 		}
 		delete(sv.txBeingValidated, k)
 		if resp.Status != committerpb.Status_COMMITTED {
-			txNode.Tx.PrelimInvalidTxStatus = &resp.Status
+			txNode.VCTx.PrelimInvalidTxStatus = &resp.Status
 		}
 		validatedTxs = append(validatedTxs, txNode)
 	}
@@ -356,6 +349,6 @@ func (sv *signatureVerifier) addTxsBeingValidated(txBatch dependencygraph.TxNode
 	sv.txMu.Lock()
 	defer sv.txMu.Unlock()
 	for _, txNode := range txBatch {
-		sv.txBeingValidated[*servicepb.NewHeightFromTxRef(txNode.Tx.Ref)] = txNode
+		sv.txBeingValidated[*servicepb.NewHeightFromTxRef(txNode.VCTx.Ref)] = txNode
 	}
 }

--- a/service/coordinator/signature_verifier_manager_test.go
+++ b/service/coordinator/signature_verifier_manager_test.go
@@ -196,7 +196,7 @@ func TestSignatureVerifierManagerWithMultipleVerifiers(t *testing.T) {
 	for range numBlocks {
 		select {
 		case txBatch := <-env.outputValidatedTxs:
-			require.ElementsMatch(t, expectedValidatedTxs[txBatch[0].Tx.Ref.BlockNum], txBatch)
+			require.ElementsMatch(t, expectedValidatedTxs[txBatch[0].VCTx.Ref.BlockNum], txBatch)
 		case <-deadline:
 			t.Fatal("Did not receive all blocks from output after timeout")
 		}
@@ -220,21 +220,25 @@ func TestSignatureVerifierManagerWithMultipleVerifiers(t *testing.T) {
 
 func TestSignatureVerifierWithAllInvalidTxs(t *testing.T) {
 	t.Parallel()
-	txBatch := dependencygraph.TxNodeBatch{}
-	expectedValidatedTxs := dependencygraph.TxNodeBatch{}
+	txBatch := make([]*dependencygraph.TransactionNode, 0, 3)
+	expectedValidatedTxs := make([]*dependencygraph.TransactionNode, 0, 3)
 	for i := range 3 {
+		ref := committerpb.NewTxRef("", uint64(i), uint32(i))
 		txNode := &dependencygraph.TransactionNode{
-			Tx: &servicepb.VcTx{
-				Ref: committerpb.NewTxRef("", uint64(i), uint32(i)), //nolint:gosec
+			VCTx: &servicepb.VcTx{Ref: ref},
+			VerifierTx: &servicepb.TxWithRef{
+				Ref:     ref,
+				Content: &applicationpb.Tx{},
 			},
 		}
 		txBatch = append(txBatch, txNode)
 
 		expectedValidatedTxs = append(expectedValidatedTxs, &dependencygraph.TransactionNode{
-			Tx: &servicepb.VcTx{
-				Ref:                   txNode.Tx.Ref,
+			VCTx: &servicepb.VcTx{
+				Ref:                   txNode.VCTx.Ref,
 				PrelimInvalidTxStatus: &sigInvalidTxStatus,
 			},
+			VerifierTx: txNode.VerifierTx,
 		})
 	}
 
@@ -257,9 +261,16 @@ func createTxNodeBatchForTest(
 		}},
 	}}
 	for i := range numTxs {
+		txWithRef := &servicepb.TxWithRef{
+			Ref: committerpb.NewTxRef("", blkNum, uint32(i)),
+			Content: &applicationpb.Tx{
+				Namespaces: ns,
+			},
+		}
 		txNode := &dependencygraph.TransactionNode{
-			Tx: &servicepb.VcTx{
-				Ref:        committerpb.NewTxRef("", blkNum, uint32(i)), //nolint:gosec
+			VerifierTx: txWithRef,
+			VCTx: &servicepb.VcTx{
+				Ref:        txWithRef.Ref,
 				Namespaces: ns,
 			},
 		}
@@ -267,17 +278,18 @@ func createTxNodeBatchForTest(
 		switch i % 2 {
 		case 0:
 			// even number txs are valid.
-			txNode.Endorsements = testsig.CreateEndorsementsForThresholdRule([]byte("dummy"))
+			txNode.VerifierTx.Content.Endorsements = testsig.CreateEndorsementsForThresholdRule([]byte("dummy"))
 			expectedValidatedTxs = append(expectedValidatedTxs, txNode)
 		case 1:
 			// odd number txs are invalid. No signature means invalid transaction.
 			// we need to create a copy of txNode to add expected status.
 			txNodeWithStatus := &dependencygraph.TransactionNode{
-				Tx: &servicepb.VcTx{
-					Ref:                   txNode.Tx.Ref,
+				VCTx: &servicepb.VcTx{
+					Ref:                   txWithRef.Ref,
 					Namespaces:            ns,
 					PrelimInvalidTxStatus: &sigInvalidTxStatus,
 				},
+				VerifierTx: txWithRef,
 			}
 			expectedValidatedTxs = append(expectedValidatedTxs, txNodeWithStatus)
 		}

--- a/service/coordinator/validator_committer_manager.go
+++ b/service/coordinator/validator_committer_manager.go
@@ -250,8 +250,8 @@ func (vc *validatorCommitter) sendTransactionsToVCService(
 		logger.Debugf("New TX node came from dependency graph manager to vc manager")
 		txBatch := make([]*servicepb.VcTx, len(txsNode))
 		for i, txNode := range txsNode {
-			vc.txBeingValidated.Store(txNode.Tx.Ref.TxId, txNode)
-			txBatch[i] = txNode.Tx
+			vc.txBeingValidated.Store(txNode.VCTx.Ref.TxId, txNode)
+			txBatch[i] = txNode.VCTx
 		}
 
 		if firstBatch {
@@ -389,7 +389,7 @@ func (vc *validatorCommitter) getTxsAndUpdatePolicies(txsStatus *committerpb.TxS
 		// Updating policy before sending transaction nodes to the dependency
 		// graph manager to free dependent transactions. Otherwise, dependent transactions
 		// might be validated against a stale policy.
-		vc.policyMgr.updateFromTx(txNode.Tx.Namespaces)
+		vc.policyMgr.updateFromTx(txNode.VCTx.Namespaces)
 	}
 
 	return txsNode, untrackedTxIdx

--- a/service/coordinator/validator_committer_manager_test.go
+++ b/service/coordinator/validator_committer_manager_test.go
@@ -218,7 +218,7 @@ func TestValidatorCommitterManagerX(t *testing.T) {
 
 		txBatch := []*dependencygraph.TransactionNode{
 			{
-				Tx: &servicepb.VcTx{
+				VCTx: &servicepb.VcTx{
 					Ref: committerpb.NewTxRef("create config", 100, 63),
 					Namespaces: []*applicationpb.TxNamespace{{
 						NsId: committerpb.ConfigNamespaceID,
@@ -230,7 +230,7 @@ func TestValidatorCommitterManagerX(t *testing.T) {
 				},
 			},
 			{
-				Tx: &servicepb.VcTx{
+				VCTx: &servicepb.VcTx{
 					Ref: committerpb.NewTxRef("create ns 1", 100, 64),
 					Namespaces: []*applicationpb.TxNamespace{{
 						NsId: committerpb.MetaNamespaceID,
@@ -347,7 +347,7 @@ func createInputTxsNodeForTest(t *testing.T, numTxs, valueSize int, blkNum uint6
 	for i := range numTxs {
 		id := uuid.NewString()
 		txsNode[i] = &dependencygraph.TransactionNode{
-			Tx: &servicepb.VcTx{
+			VCTx: &servicepb.VcTx{
 				Ref: committerpb.NewTxRef(id, blkNum, uint32(i)), //nolint:gosec
 				Namespaces: []*applicationpb.TxNamespace{{
 					BlindWrites: []*applicationpb.Write{{


### PR DESCRIPTION
#### Type of change

- Bug fix
 
#### Description

- The coordinator did not pass the metadata field to the verifier
- This commit modifies the coordinator to store the full TX object, thus, any future changes will automatically pass to the verifier
