### PR TITLE
[loadgen] Use UnwrapEnvelopeLite instead of UnwrapEnvelope in the Sidecar Receiver

### DIFF
--- a/loadgen/adapters/sidecar_receiver.go
+++ b/loadgen/adapters/sidecar_receiver.go
@@ -124,12 +124,12 @@ func mapToStatusBatch(block *common.Block) []metrics.TxStatus {
 
 	statusBatch := make([]metrics.TxStatus, 0, blockSize)
 	for i, data := range block.Data.Data {
-		_, channelHeader, err := serialization.UnwrapEnvelope(data)
+		envLite, err := serialization.UnwrapEnvelopeLite(data)
 		if err != nil {
 			logger.Warnf("Failed to unmarshal envelope: %v", err)
 			continue
 		}
-		if common.HeaderType(channelHeader.Type) == common.HeaderType_CONFIG {
+		if common.HeaderType(envLite.HeaderType) == common.HeaderType_CONFIG {
 			// We can ignore config transactions as we only count data transactions.
 			continue
 		}
@@ -138,7 +138,7 @@ func mapToStatusBatch(block *common.Block) []metrics.TxStatus {
 			status = committerpb.Status(statusCodes[i])
 		}
 		statusBatch = append(statusBatch, metrics.TxStatus{
-			TxID:   channelHeader.TxId,
+			TxID:   envLite.TxID,
 			Status: status,
 		})
 	}


### PR DESCRIPTION
#### Type of change

- Improvement (performance)
 
#### Description

* Refactor `sidecar_receiver.go` to use UnwrapEnvelopeLite instead of UnwrapEnvelope for improved performance in the load generator.
