### PR TITLE
[coordinator] fix deadlock waiting for pending transactions

### DIFF
--- a/docs/coordinator.md
+++ b/docs/coordinator.md
@@ -188,7 +188,7 @@ GetConfigTransaction(ctx context.Context, in *Empty, opts ...grpc.CallOption) (*
 ```go
 NoPendingTransactionProcessing(ctx context.Context, in *Empty, opts ...grpc.CallOption) (*wrapperspb.BoolValue, error)
 ```
-  * This API returns true when all previously submitted transactions have been processed.
+  * This API returns true when all previously submitted transactions have been processed. It is polled by the Sidecar during recovery, while no block-processing stream is active. Because the Validator-Committer keeps producing statuses into the coordinator's bounded status queue even when no stream is draining it, each call drains and discards any queued statuses. This frees the blocked Validator-Committer writers so processing can complete; discarding is safe because the statuses are already durable in the state database and the Sidecar recovers them from there. Without this drain, a backlog larger than the queue capacity would deadlock the recovery handshake.
 
 ## 7. Failure and Recovery
 

--- a/service/coordinator/coordinator.go
+++ b/service/coordinator/coordinator.go
@@ -272,7 +272,45 @@ func (c *Service) GetTransactionsStatus(
 }
 
 // NoPendingTransactionProcessing returns true when all previously submitted
-// transactions have been processed and the sidecar can safely reconnect.
+// transactions have been processed (validated and committed by the VC) and the
+// sidecar can safely reconnect. It is polled by the sidecar's
+// waitForIdleCoordinator during recovery, while no stream is active.
+//
+// Draining the status queue here is what breaks the deadlock described in
+// issue #616. The status queue (vcServiceToCoordinatorTxStatus) is filled by the
+// VC on the coordinator's lifetime context, but drained only by sendTxStatus,
+// which lives and dies with the sidecar stream. While the stream is inactive,
+// nothing drains the queue, yet the VC keeps forwarding statuses for the
+// in-flight transactions. Once the queue fills, the VC writers block on it. If
+// the number of in-flight transactions exceeds the queue capacity, readyCount
+// plateaus below numTxsInProgress and can never catch up, so the equality below
+// would never hold. The result is a circular wait: the sidecar cannot start a
+// new stream (and thus resume draining) until this call reports idle, but this
+// call cannot report idle until the VC — which is blocked on the full queue —
+// finishes. By draining the queue on every call we free space for the blocked
+// VC writers, let them finish producing, and let numTxsInProgress settle.
+//
+// Discarding the drained statuses is safe: the VC produces a status only after
+// the transaction is durably committed to the state DB, and the sidecar always
+// recovers statuses from the DB (via GetTransactionsStatus), never from this
+// queue. So while the stream is inactive these queued statuses have no consumer
+// and can be dropped.
+//
+// Accounting/invariants:
+//   - numTxsInProgress is a superset of readyCount: every status counted in
+//     readyCount was previously counted in numTxsInProgress at block receipt, and
+//     numTxsInProgress is decremented only when a status leaves the queue (by
+//     sendTxStatus or by the drain below, both of which decrement readyCount by
+//     the same amount). Draining therefore preserves numTxsInProgress >=
+//     readyCount >= 0, so the result is never negative.
+//   - Holding streamActive makes this mutually exclusive with the queue's only
+//     other reader, sendTxStatus (which runs under BlockProcessing's lock), and
+//     with receiveAndProcessBlock. VC writers may still run concurrently; that is
+//     safe because count is atomic and channels support concurrent send/receive.
+//   - After draining, readyCount is ~0, so the equality reduces to
+//     numTxsInProgress == 0, i.e. every submitted transaction has produced (and
+//     we have consumed) its status. When that holds the queue is empty, so a
+//     reconnecting stream starts clean with no stale statuses.
 func (c *Service) NoPendingTransactionProcessing(
 	context.Context,
 	*emptypb.Empty,
@@ -282,22 +320,8 @@ func (c *Service) NoPendingTransactionProcessing(
 	}
 	defer c.streamActive.Unlock()
 
-	// When the sidecar stream is inactive, numTxsInProgress is not updated
-	// because sendTxStatus cannot forward statuses. However, VC continues producing
-	// statuses into the queue. To compute the number of TXs still being processed
-	// (i.e., not yet computed by VC), we subtract readyCount (statuses already
-	// produced but not yet consumed by sendTxStatus) from numTxsInProgress.
-	//
-	// numTxsInProgress is a superset of readyCount: every status tracked by
-	// readyCount was previously counted in numTxsInProgress at block receipt,
-	// and numTxsInProgress is only decremented after sendTxStatus consumes from
-	// the queue (which decrements readyCount first). The two values are not read
-	// atomically, but numTxsInProgress is frozen while the stream is inactive
-	// (only receiveAndProcessBlock and sendTxStatus modify it, and both require
-	// an active stream). So the result is never negative.
-	//
-	// When numTxsInProgress equals readyCount, all previously submitted TXs
-	// have been processed and the sidecar can safely reconnect.
+	c.numTxsInProgress.Add(-c.queues.vcServiceToCoordinatorTxStatus.drain())
+
 	return wrapperspb.Bool(
 		c.numTxsInProgress.Load() == c.queues.vcServiceToCoordinatorTxStatus.readyCount(),
 	), nil

--- a/service/coordinator/coordinator_test.go
+++ b/service/coordinator/coordinator_test.go
@@ -12,6 +12,8 @@ import (
 	"math"
 	"slices"
 	"strconv"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -318,9 +320,9 @@ func TestNoPendingTransactionProcessing(t *testing.T) {
 	env := newCoordinatorTestEnv(t, &testConfig{numSigService: 1, numVcService: 1})
 
 	// Seven transactions are still waiting for sidecar-visible final status. Five of
-	// those statuses are already queued in two batches. One queued status is a
-	// rejected transaction, proving rejected statuses are counted in the same unit
-	// as committed statuses.
+	// those statuses have already been produced by the VC and queued in two batches.
+	// One queued status is a rejected transaction, proving rejected statuses are
+	// counted in the same unit as committed statuses.
 	env.coordinator.numTxsInProgress.Store(7)
 
 	require.True(t, env.coordinator.queues.vcServiceToCoordinatorTxStatus.write(t.Context(), &committerpb.TxStatusBatch{
@@ -337,9 +339,60 @@ func TestNoPendingTransactionProcessing(t *testing.T) {
 		},
 	}))
 
+	// The stream is inactive, so the call drains and discards the 5 queued statuses,
+	// decrementing numTxsInProgress from 7 to 2. Two transactions still have no
+	// status yet (the VC has not produced them), so the coordinator is not idle.
 	idle, err := env.coordinator.NoPendingTransactionProcessing(t.Context(), nil)
 	require.NoError(t, err)
 	require.False(t, idle.GetValue())
+	require.Equal(t, int32(2), env.coordinator.numTxsInProgress.Load())
+	require.Zero(t, env.coordinator.queues.vcServiceToCoordinatorTxStatus.readyCount())
+}
+
+// TestNoPendingTransactionProcessingDrainsWhenStreamInactive reproduces the
+// deadlock described in issue #616. While the sidecar stream is inactive, the VC
+// keeps producing statuses into the bounded vcServiceToCoordinatorTxStatus queue,
+// but sendTxStatus (its only drainer) is gone with the stream. If the number of
+// in-flight transactions exceeds the queue capacity, the VC writers block on the
+// full queue, readyCount can never catch up to numTxsInProgress, and the idle
+// handshake never completes. NoPendingTransactionProcessing must therefore drain
+// the queue on each call so the VC keeps making progress and the coordinator
+// eventually reports idle. Without the drain, the polling loop below never
+// converges and the test times out.
+func TestNoPendingTransactionProcessingDrainsWhenStreamInactive(t *testing.T) {
+	t.Parallel()
+
+	const (
+		inFlight = 20
+		queueCap = 2 // Far smaller than inFlight, so the VC writer is forced to block.
+	)
+
+	c := &Service{
+		queues:           &channels{vcServiceToCoordinatorTxStatus: newTxStatusQueue(queueCap)},
+		numTxsInProgress: &atomic.Int32{},
+	}
+	c.numTxsInProgress.Store(inFlight)
+
+	// Simulate the VC forwarding one status per in-flight transaction. With a
+	// queue capacity of 2 and no active stream draining it, this goroutine blocks
+	// until NoPendingTransactionProcessing drains the queue.
+	var wg sync.WaitGroup
+	wg.Go(func() {
+		for i := range inFlight {
+			c.queues.vcServiceToCoordinatorTxStatus.write(t.Context(), txStatusBatch(strconv.Itoa(i)))
+		}
+	})
+
+	// Poll exactly like the sidecar's waitForIdleCoordinator.
+	require.Eventually(t, func() bool {
+		idle, err := c.NoPendingTransactionProcessing(t.Context(), nil)
+		require.NoError(t, err)
+		return idle.GetValue()
+	}, 5*time.Second, 10*time.Millisecond)
+
+	wg.Wait()
+	require.Zero(t, c.numTxsInProgress.Load())
+	require.Zero(t, c.queues.vcServiceToCoordinatorTxStatus.readyCount())
 }
 
 func TestCoordinatorServiceDependentOrderedTxs(t *testing.T) {

--- a/service/coordinator/tx_status_queue.go
+++ b/service/coordinator/tx_status_queue.go
@@ -61,6 +61,33 @@ func (q *txStatusQueue) readyCount() int32 {
 	return q.count.Load()
 }
 
+// drain removes and discards every batch currently buffered in the queue,
+// decrementing the ready count accordingly, and returns the total number of
+// statuses discarded. It never blocks: it stops as soon as the channel is empty.
+//
+// This is used only while the sidecar stream is inactive (see
+// Service.NoPendingTransactionProcessing). Discarding is safe because a status
+// is produced by the VC only after the transaction has been durably committed to
+// the state DB, and the sidecar recovers statuses from the DB (never from this
+// queue). It is also necessary: the VC keeps producing statuses into this queue
+// regardless of the stream, so without a drain a large backlog fills the queue,
+// blocks the VC writers, and deadlocks the idle handshake.
+//
+// The caller must hold streamActive so that this does not race the queue's other
+// reader, sendTxStatus.
+func (q *txStatusQueue) drain() int32 {
+	var discarded int32
+	for {
+		select {
+		case batch := <-q.ch:
+			discarded += int32(len(batch.Status)) //nolint:gosec
+		default:
+			q.count.Add(-discarded)
+			return discarded
+		}
+	}
+}
+
 func (q *txStatusQueue) len() int {
 	return len(q.ch)
 }

--- a/service/coordinator/tx_status_queue_test.go
+++ b/service/coordinator/tx_status_queue_test.go
@@ -106,6 +106,36 @@ func TestTxStatusQueueCanceledBlockedWriteRollsBackCount(t *testing.T) {
 	require.Equal(t, 1, queue.len())
 }
 
+func TestTxStatusQueueDrain(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty queue drains nothing", func(t *testing.T) {
+		t.Parallel()
+
+		queue := newTxStatusQueue(2)
+		require.Zero(t, queue.drain())
+		require.Zero(t, queue.readyCount())
+		require.Zero(t, queue.len())
+	})
+
+	t.Run("drain removes all queued statuses and reports the count", func(t *testing.T) {
+		t.Parallel()
+
+		queue := newTxStatusQueue(2)
+		require.True(t, queue.write(t.Context(), txStatusBatch("tx-1", "tx-2")))
+		require.True(t, queue.write(t.Context(), txStatusBatch("tx-3", "tx-4", "tx-5")))
+		require.Equal(t, int32(5), queue.readyCount())
+		require.Equal(t, 2, queue.len())
+
+		require.Equal(t, int32(5), queue.drain())
+		require.Zero(t, queue.readyCount())
+		require.Zero(t, queue.len())
+
+		// Draining again is a no-op.
+		require.Zero(t, queue.drain())
+	})
+}
+
 func txStatusBatch(txIDs ...string) *committerpb.TxStatusBatch {
 	statuses := make([]*committerpb.TxStatus, len(txIDs))
 	for i, txID := range txIDs {


### PR DESCRIPTION
#### Type of change

- Bug fix

#### Description

While the sidecar stream is inactive, the VC keeps filling the coordinator's
bounded status queue, but its only drainer (`sendTxStatus`) is gone with the
stream. If the in-flight backlog exceeds the queue capacity, the VC blocks on the
full queue and recovery deadlocks: the sidecar won't reconnect until
`NoPendingTransactionProcessing` reports idle, which can't happen while the VC is
blocked.

Fix by draining and discarding queued statuses in `NoPendingTransactionProcessing`
(polled during recovery). This unblocks the VC so it can finish. Discarding is
safe — statuses are durable in the state DB and recovered via
`GetTransactionsStatus`, never from this queue.

Adds a regression test reproducing the deadlock.

#### Related issues

 - resolves #616