### PR TITLE
[loadgen] Allow bare number as const distribution shorthand

### DIFF
--- a/cmd/config/config_decoder.go
+++ b/cmd/config/config_decoder.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hyperledger/fabric-x-common/common/viperutil"
 	"github.com/spf13/viper"
 
+	"github.com/hyperledger/fabric-x-committer/loadgen/workload"
 	"github.com/hyperledger/fabric-x-committer/utils/connection"
 	"github.com/hyperledger/fabric-x-committer/utils/serve"
 )
@@ -42,8 +43,29 @@ const (
 func decoderHook() viper.DecoderConfigOption {
 	return viper.DecodeHook(mapstructure.ComposeDecodeHookFunc(
 		viperutil.StringSliceViaEnvDecodeHook, viperutil.ByteSizeDecodeHook, viperutil.OrdererEndpointDecoder,
-		durationDecoder, serverDecoder, endpointDecoder,
+		durationDecoder, serverDecoder, endpointDecoder, distributionDecoder,
 	))
+}
+
+// distributionDecoder allows a bare number as a shorthand for a const distribution.
+// For example, "read-write-count: 2" is equivalent to "read-write-count: {const: 2}".
+// Non-numeric values (maps, strings, booleans) are left untouched so the full
+// distribution forms (const, uniform, normal, discrete, bernoulli) keep working.
+func distributionDecoder(_, targetType reflect.Type, rawData any) (result any, err error) {
+	if targetType != reflect.TypeFor[workload.Distribution]() {
+		return rawData, nil
+	}
+	rv := reflect.ValueOf(rawData)
+	switch {
+	case rv.CanInt():
+		return workload.Distribution{Const: float64(rv.Int())}, nil
+	case rv.CanUint():
+		return workload.Distribution{Const: float64(rv.Uint())}, nil
+	case rv.CanFloat():
+		return workload.Distribution{Const: rv.Float()}, nil
+	default:
+		return rawData, nil
+	}
 }
 
 func durationDecoder(dataType, targetType reflect.Type, rawData any) (result any, err error) {

--- a/cmd/config/config_decoder_test.go
+++ b/cmd/config/config_decoder_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
 
+	"github.com/hyperledger/fabric-x-committer/loadgen/workload"
 	"github.com/hyperledger/fabric-x-committer/utils/connection"
 	"github.com/hyperledger/fabric-x-committer/utils/serve"
 )
@@ -41,6 +42,73 @@ yaml-orderer-endpoint:
     host: localhost
     port: 5050
 `
+
+// distributionConfig mirrors how a *workload.Distribution field is embedded in
+// the real load-generator configuration (e.g., TransactionProfile.ReadWriteCount).
+type distributionConfig struct {
+	Count *workload.Distribution `mapstructure:"count"`
+}
+
+// TestDistributionShorthand verifies that a bare number is decoded as a const
+// distribution, while the full distribution forms keep working unchanged.
+func TestDistributionShorthand(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name     string
+		yaml     string
+		expected *workload.Distribution
+	}{
+		{
+			name:     "integer shorthand",
+			yaml:     "count: 2",
+			expected: workload.NewConstantDistribution(2),
+		},
+		{
+			name:     "float shorthand",
+			yaml:     "count: 2.5",
+			expected: workload.NewConstantDistribution(2.5),
+		},
+		{
+			name:     "negative shorthand",
+			yaml:     "count: -1",
+			expected: workload.NewConstantDistribution(-1),
+		},
+		{
+			name:     "zero shorthand",
+			yaml:     "count: 0",
+			expected: workload.NewConstantDistribution(0),
+		},
+		{
+			name:     "explicit const form still works",
+			yaml:     "count:\n  const: 2",
+			expected: workload.NewConstantDistribution(2),
+		},
+		{
+			name:     "uniform form still works",
+			yaml:     "count:\n  uniform:\n    min: 0\n    max: 1",
+			expected: workload.NewUniformDistribution(0, 1),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			v := viper.New()
+			require.NoError(t, readYamlConfigsFromIO(v, bytes.NewBufferString(tc.yaml)))
+			conf := new(distributionConfig)
+			require.NoError(t, unmarshal(v, conf))
+			require.Equal(t, tc.expected, conf.Count)
+		})
+	}
+}
+
+// TestDistributionShorthandRejectsNonNumeric ensures a non-numeric scalar is not
+// silently coerced into a const distribution; it surfaces a decode error instead.
+func TestDistributionShorthandRejectsNonNumeric(t *testing.T) {
+	t.Parallel()
+	v := viper.New()
+	require.NoError(t, readYamlConfigsFromIO(v, bytes.NewBufferString("count: abc")))
+	require.Error(t, unmarshal(v, new(distributionConfig)))
+}
 
 func TestParseEndpoint(t *testing.T) {
 	t.Parallel()

--- a/cmd/config/samples/loadgen.yaml
+++ b/cmd/config/samples/loadgen.yaml
@@ -147,6 +147,8 @@ load-profile:
   #   normal: {mean: M, std: S}         - Normal distribution with mean M and std S.
   #   bernoulli: P                      - 1 with probability P, 0 otherwise.
   #   discrete: [{value: V, probability: P}, ...] - Discrete distribution.
+  # As a shorthand, a bare number is treated as a const distribution,
+  # i.e., "read-write-count: 2" is equivalent to "read-write-count: {const: 2}".
   transaction:
     # Size in bytes of the metadata for each transaction (0 means nil value).
     # metadata-size: 0
@@ -155,14 +157,11 @@ load-profile:
     # Size in bytes of the value written for each blind-write operation (0 means nil value).
     # blind-write-value-size: 0
     # Number of read-only operations per transaction.
-    # read-only-count:
-    #   const: 0
-    # Number of read-write operations per transaction.
-    read-write-count:
-      const: 2
+    # read-only-count: 0
+    # Number of read-write operations per transaction (const shorthand).
+    read-write-count: 2
     # Number of blind-write operations per transaction.
-    # write-count:
-    #   const: 0
+    # write-count: 0
   # Policy configuration for transaction endorsement and validation
   policy:
     # Channel ID for which transactions are generated. Must match the target blockchain channel.


### PR DESCRIPTION
#### Type of change

- New feature
 
#### Description

Add a mapstructure decode hook so a bare number is accepted as a shorthand for a const distribution. For example:

    read-write-count: 2

is now equivalent to:

    read-write-count:
      const: 2

The hook targets the workload.Distribution type, so the shorthand applies uniformly to every distribution config field (read/write counts, query-size, min-invalid-keys-portion, dependency gap). Non-numeric values (maps, strings, booleans) are left untouched, so the full distribution forms (const, uniform, normal, discrete, bernoulli) keep working.

#### Additional details (Optional)

- Documented the shorthand in the loadgen sample config and switched the read-write-count example to it, which makes the existing sample-loading test cover the shorthand end-to-end through the real config loader.
- Added decoder unit tests for the shorthand (int/float/negative/zero), regression tests for the explicit forms, and a guard test ensuring a non-numeric scalar surfaces a decode error rather than being coerced.

#### Related issues

 - resolves #673