### PR TITLE
[verifier] add SnapshotEndorsement/CheckpointEndorsement policy parsing and wiring

### DIFF
--- a/service/verifier/policy/policy.go
+++ b/service/verifier/policy/policy.go
@@ -22,17 +22,18 @@ import (
 	"github.com/hyperledger/fabric-x-committer/utils/signature"
 )
 
-const (
-	// maxNamespaceIDLength defines the maximum number of characters allowed for namespace IDs.
-	// PostgreSQL limits identifiers to NAMEDATALEN-1, where NAMEDATALEL=64.
-	// The namespace tables have the prefix 'ns_', thus there are 60 characters remaining.
-	// See: https://www.postgresql.org/docs/current/sql-syntax-lexical.html
-	maxNamespaceIDLength = 60
+// maxNamespaceIDLength defines the maximum number of characters allowed for namespace IDs.
+// PostgreSQL limits identifiers to NAMEDATALEN-1, where NAMEDATALEL=64.
+// The namespace tables have the prefix 'ns_', thus there are 60 characters remaining.
+// See: https://www.postgresql.org/docs/current/sql-syntax-lexical.html
+const maxNamespaceIDLength = 60
 
-	// lifecycleEndorsementPolicyPath is the channel policy path for lifecycle operations.
-	// This ImplicitMeta policy evaluates org-level Endorsement policies via the MSP.
-	lifecycleEndorsementPolicyPath = "/Channel/Application/LifecycleEndorsement"
-)
+// SystemNamespacePolicy pairs a system namespace ID with the channel policy path that
+// authorizes transactions in that namespace, per the config block.
+type SystemNamespacePolicy struct {
+	NamespaceID string
+	PolicyPath  string
+}
 
 var (
 	// validNamespaceID describes the allowed characters in a namespace ID.
@@ -47,6 +48,14 @@ var (
 
 	// ErrInvalidNamespaceID is returned when the namespace ID cannot be parsed.
 	ErrInvalidNamespaceID = errors.New("invalid namespace ID")
+
+	// SystemNamespacePolicies lists every system namespace whose authorization policy is
+	// resolved directly from the config block bundle, rather than from ns__meta.
+	SystemNamespacePolicies = []SystemNamespacePolicy{
+		{NamespaceID: committerpb.MetaNamespaceID, PolicyPath: "/Channel/Application/LifecycleEndorsement"},
+		{NamespaceID: committerpb.SnapshotNamespaceID, PolicyPath: "/Channel/Application/SnapshotEndorsement"},
+		{NamespaceID: committerpb.CheckpointNamespaceID, PolicyPath: "/Channel/Application/CheckpointEndorsement"},
+	}
 )
 
 // GetUpdatesFromNamespace translates a namespace TX to policy updates.
@@ -109,7 +118,9 @@ func UnmarshalNamespacePolicy(policyBytes []byte) (*applicationpb.NamespacePolic
 // validateNamespaceIDInPolicy checks that a given namespace fulfills namespace naming conventions.
 func validateNamespaceIDInPolicy(nsID string) error {
 	// If it matches one of the system's namespaces it is invalid.
-	if nsID == committerpb.MetaNamespaceID || nsID == committerpb.ConfigNamespaceID {
+	switch nsID {
+	case committerpb.MetaNamespaceID, committerpb.ConfigNamespaceID,
+		committerpb.SnapshotNamespaceID, committerpb.CheckpointNamespaceID:
 		return ErrInvalidNamespaceID
 	}
 
@@ -132,7 +143,8 @@ func ValidateNamespaceID(nsID string) error {
 }
 
 // ValidateConfigTx validates that a config transaction envelope can be parsed into a valid bundle
-// with a LifecycleEndorsement policy.
+// with all the config-block channel policies the verifier depends on
+// (see [SystemNamespacePolicies]).
 func ValidateConfigTx(value []byte) error {
 	envelope, err := protoutil.UnmarshalEnvelope(value)
 	if err != nil {
@@ -142,15 +154,20 @@ func ValidateConfigTx(value []byte) error {
 	if err != nil {
 		return errors.Wrap(err, "error parsing config")
 	}
-	_, err = ParseLifecycleEndorsementPolicy(bundle)
-	return err
+	for _, snp := range SystemNamespacePolicies {
+		if _, err = ParseChannelPolicy(bundle, snp.PolicyPath); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
-// ParseLifecycleEndorsementPolicy extracts the LifecycleEndorsement policy from the channel config bundle.
-func ParseLifecycleEndorsementPolicy(bundle *channelconfig.Bundle) (*signature.NsVerifier, error) {
-	p, ok := bundle.PolicyManager().GetPolicy(lifecycleEndorsementPolicyPath)
+// ParseChannelPolicy resolves a channel policy at the given PolicyManager path and wraps it
+// as a namespace verifier. The path itself is used to identify the policy in error messages.
+func ParseChannelPolicy(bundle *channelconfig.Bundle, path string) (*signature.NsVerifier, error) {
+	p, ok := bundle.PolicyManager().GetPolicy(path)
 	if !ok {
-		return nil, errors.New("LifecycleEndorsement policy not found in channel config")
+		return nil, errors.Newf("policy not found in channel config: %s", path)
 	}
 	return signature.NewNsVerifierFromChannelPolicy(p), nil
 }

--- a/service/verifier/policy/policy_test.go
+++ b/service/verifier/policy/policy_test.go
@@ -99,6 +99,7 @@ func TestParsePolicyItem(t *testing.T) {
 		"", "abc_$", "a-", "go!", "My Namespace", "my name", "ABC_D", "new\nline",
 		"____too_long_namespace_namespace_id_0123456789_0123456789_012",
 		committerpb.MetaNamespaceID, committerpb.ConfigNamespaceID,
+		committerpb.SnapshotNamespaceID, committerpb.CheckpointNamespaceID,
 	} {
 		t.Run(fmt.Sprintf("invalid ns: '%s'", ns), func(t *testing.T) {
 			t.Parallel()
@@ -116,58 +117,63 @@ func TestParsePolicyItem(t *testing.T) {
 	})
 }
 
-func TestParseLifecycleEndorsementPolicy(t *testing.T) {
+// TestParseChannelPolicy covers the config-block channel policies resolved by the
+// verifier (see [SystemNamespacePolicies]): LifecycleEndorsement (-> _meta),
+// SnapshotEndorsement (-> _snapshot), and CheckpointEndorsement (-> _checkpoint).
+// All entries share the same resolution logic (ParseChannelPolicy), so they are
+// exercised through one table-driven test reusing the production namespace/path table.
+func TestParseChannelPolicy(t *testing.T) {
 	t.Parallel()
 
-	t.Run("valid bundle returns verifier", func(t *testing.T) {
-		t.Parallel()
-		bundle, cryptoPath := createTestBundle(t)
+	for _, snp := range SystemNamespacePolicies {
+		t.Run(snp.NamespaceID+": valid bundle returns verifier", func(t *testing.T) {
+			t.Parallel()
+			bundle, cryptoPath := createTestBundle(t)
 
-		verifier, err := ParseLifecycleEndorsementPolicy(bundle)
-		require.NoError(t, err)
-		require.NotNil(t, verifier)
+			nsVerifier, err := ParseChannelPolicy(bundle, snp.PolicyPath)
+			require.NoError(t, err)
+			require.NotNil(t, nsVerifier)
 
-		// Verify it accepts a valid MSP endorsement.
-		endorser := workload.NewPolicyEndorserFromMsp(t, cryptoPath)
-		require.NoError(t, err)
+			endorser := workload.NewPolicyEndorserFromMsp(t, cryptoPath)
 
-		tx := &applicationpb.Tx{
-			Namespaces: []*applicationpb.TxNamespace{{
-				NsId:        committerpb.MetaNamespaceID,
-				BlindWrites: []*applicationpb.Write{{Key: []byte("test")}},
-			}},
-		}
-		endorsements, err := endorser.EndorseTxNs("tx-1", tx, 0)
-		require.NoError(t, err)
-		tx.Endorsements = []*applicationpb.Endorsements{endorsements}
-
-		require.NoError(t, verifier.VerifyNs("tx-1", tx, 0))
-	})
-
-	t.Run("rejects invalid endorsement", func(t *testing.T) {
-		t.Parallel()
-		bundle, _ := createTestBundle(t)
-
-		verifier, err := ParseLifecycleEndorsementPolicy(bundle)
-		require.NoError(t, err)
-
-		// Use a valid Identity proto but from an unknown MSP,
-		// so the MSP manager can deserialize it but the policy won't be satisfied.
-		tx := &applicationpb.Tx{
-			Namespaces: []*applicationpb.TxNamespace{{
-				NsId:        committerpb.MetaNamespaceID,
-				BlindWrites: []*applicationpb.Write{{Key: []byte("test")}},
-			}},
-			Endorsements: []*applicationpb.Endorsements{{
-				EndorsementsWithIdentity: []*applicationpb.EndorsementWithIdentity{{
-					Identity:    msppb.NewIdentity("unknown-org", []byte("unknown-cert")),
-					Endorsement: []byte("bad-sig"),
+			tx := &applicationpb.Tx{
+				Namespaces: []*applicationpb.TxNamespace{{
+					NsId:        snp.NamespaceID,
+					BlindWrites: []*applicationpb.Write{{Key: []byte("test")}},
 				}},
-			}},
-		}
+			}
+			endorsements, err := endorser.EndorseTxNs("tx-1", tx, 0)
+			require.NoError(t, err)
+			tx.Endorsements = []*applicationpb.Endorsements{endorsements}
 
-		require.Error(t, verifier.VerifyNs("tx-1", tx, 0))
-	})
+			require.NoError(t, nsVerifier.VerifyNs("tx-1", tx, 0))
+		})
+
+		t.Run(snp.NamespaceID+": rejects invalid endorsement", func(t *testing.T) {
+			t.Parallel()
+			bundle, _ := createTestBundle(t)
+
+			nsVerifier, err := ParseChannelPolicy(bundle, snp.PolicyPath)
+			require.NoError(t, err)
+
+			// Use a valid Identity proto but from an unknown MSP,
+			// so the MSP manager can deserialize it but the policy won't be satisfied.
+			tx := &applicationpb.Tx{
+				Namespaces: []*applicationpb.TxNamespace{{
+					NsId:        snp.NamespaceID,
+					BlindWrites: []*applicationpb.Write{{Key: []byte("test")}},
+				}},
+				Endorsements: []*applicationpb.Endorsements{{
+					EndorsementsWithIdentity: []*applicationpb.EndorsementWithIdentity{{
+						Identity:    msppb.NewIdentity("unknown-org", []byte("unknown-cert")),
+						Endorsement: []byte("bad-sig"),
+					}},
+				}},
+			}
+
+			require.Error(t, nsVerifier.VerifyNs("tx-1", tx, 0))
+		})
+	}
 }
 
 func TestValidateConfigTx(t *testing.T) {

--- a/service/verifier/verify.go
+++ b/service/verifier/verify.go
@@ -87,11 +87,13 @@ func createVerifiers(
 	idDeserializer := bundle.MSPManager()
 	newPolicies := make(map[string]*signature.NsVerifier)
 	if update.Config != nil {
-		nsVerifier, err := policy.ParseLifecycleEndorsementPolicy(bundle)
-		if err != nil {
-			return nil, errors.Join(ErrUpdatePolicies, err)
+		for _, snp := range policy.SystemNamespacePolicies {
+			nsVerifier, err := policy.ParseChannelPolicy(bundle, snp.PolicyPath)
+			if err != nil {
+				return nil, errors.Join(ErrUpdatePolicies, err)
+			}
+			newPolicies[snp.NamespaceID] = nsVerifier
 		}
-		newPolicies[committerpb.MetaNamespaceID] = nsVerifier
 	}
 	if update.NamespacePolicies != nil {
 		for _, pd := range update.NamespacePolicies.Policies {

--- a/service/verifier/verify_test.go
+++ b/service/verifier/verify_test.go
@@ -1,0 +1,57 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package verifier
+
+import (
+	"testing"
+
+	"github.com/hyperledger/fabric-lib-go/bccsp/factory"
+	"github.com/hyperledger/fabric-x-common/api/applicationpb"
+	"github.com/hyperledger/fabric-x-common/common/channelconfig"
+	"github.com/hyperledger/fabric-x-common/protoutil"
+	"github.com/hyperledger/fabric-x-common/utils/testcrypto"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger/fabric-x-committer/api/servicepb"
+	"github.com/hyperledger/fabric-x-committer/service/verifier/policy"
+)
+
+// TestCreateVerifiersSystemNamespaces guards createVerifiers's config-update branch:
+// every namespace listed in policy.SystemNamespacePolicies must get its own freshly
+// parsed verifier. A refactor that drops or skips an entry from that loop would not
+// fail to compile -- the missing namespace would simply be absent from newVerifiers,
+// and updatePolicies's carry-forward logic would silently keep serving the *previous*
+// verifier for that namespace instead. This test catches that by name.
+func TestCreateVerifiersSystemNamespaces(t *testing.T) {
+	t.Parallel()
+
+	configBlock, err := testcrypto.CreateOrExtendConfigBlockWithCrypto(t.TempDir(), &testcrypto.ConfigBlock{
+		PeerOrganizationCount: 1,
+	})
+	require.NoError(t, err)
+
+	envelope, err := protoutil.UnmarshalEnvelope(configBlock.Data.Data[0])
+	require.NoError(t, err)
+	bundle, err := channelconfig.NewBundleFromEnvelope(envelope, factory.GetDefault())
+	require.NoError(t, err)
+
+	update := &servicepb.VerifierUpdates{
+		Config: &applicationpb.ConfigTransaction{
+			Envelope: configBlock.Data.Data[0],
+		},
+	}
+
+	newVerifiers, err := createVerifiers(update, bundle)
+	require.NoError(t, err)
+
+	require.Len(t, newVerifiers, len(policy.SystemNamespacePolicies))
+	for _, snp := range policy.SystemNamespacePolicies {
+		nsVerifier, ok := newVerifiers[snp.NamespaceID]
+		require.True(t, ok, "expected a verifier for namespace %q", snp.NamespaceID)
+		require.NotNil(t, nsVerifier)
+	}
+}


### PR DESCRIPTION
#### Type of change

- New feature
 
#### Description

- policy.ParseChannelPolicy(bundle, path) resolves a named channel policy from the PolicyManager. policy.SystemNamespacePolicies lists the {NamespaceID, PolicyPath} pairs for all three config-block policies (_meta/LifecycleEndorsement, _snapshot/SnapshotEndorsement, _checkpoint/CheckpointEndorsement) so callers loop over one table instead of three near-identical named wrappers.
- createVerifiers's config-update branch loops SystemNamespacePolicies, replacing three copy-pasted parse blocks.
- ValidateConfigTx loops the same table, so a config tx missing any of the three policies (not just LifecycleEndorsement) is now rejected at ingest time instead of only failing later inside the verifier.
- validateNamespaceIDInPolicy now also rejects committerpb. SnapshotNamespaceID/CheckpointNamespaceID for ordinary ns__meta namespace-policy updates, closing the gap where an operator/attacker could otherwise overwrite the config-block-derived _snapshot/ _checkpoint verifiers via an ordinary _meta transaction.
- verifyRequest already does exact-key lookup (verifiers[ns.NsId]), which already covers _snapshot/_checkpoint; no change needed (T033).

Tests:
- policy_test.go: TestParseChannelPolicy is table-driven over SystemNamespacePolicies (lifecycle/snapshot/checkpoint share one test, placed where the old lifecycle-only test used to live); TestParsePolicyItem's invalid-namespace cases extended with _snapshot/_checkpoint.
- verify_test.go: TestCreateVerifiersConfigNamespaces asserts createVerifiers produces exactly the namespaces listed in SystemNamespacePolicies after a config update, guarding the shared loop against silently dropping an entry.

#### Additional details (Optional)

Negative case (policy absent in config block) deferred for ValidateConfigTx/ParseChannelPolicy unit tests: fabric-x-common's test config generator doesn't yet support omitting these policies from generated bundles. Track as follow-up issue if needed.

#### Related issues

 - resolve #656