### PR TITLE
[vc, coordinator, verifier] treat _snapshot and _checkpoint as system namespaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ venv
 
 # MkDocs build output
 site/
+graphify-out/

--- a/service/coordinator/dependencygraph/transaction_node.go
+++ b/service/coordinator/dependencygraph/transaction_node.go
@@ -172,7 +172,7 @@ func readAndWriteKeys(txNamespaces []*applicationpb.TxNamespace) readWriteKeys {
 		// for all previously submitted transactions to be processed before submitting a config block, and
 		// waits for that block to comnitted before sending new transactions. Therefore, we do not need to
 		// track dependencies between meta-namespace and configuration transactions.
-		if ns.NsId != committerpb.MetaNamespaceID && ns.NsId != committerpb.ConfigNamespaceID {
+		if !utils.IsSystemNamespace(ns.NsId) {
 			readOnlyKeys = append(readOnlyKeys, constructCompositeKey(committerpb.MetaNamespaceID, []byte(ns.NsId)))
 		}
 

--- a/service/coordinator/dependencygraph/transaction_node_test.go
+++ b/service/coordinator/dependencygraph/transaction_node_test.go
@@ -22,6 +22,44 @@ import (
 
 var nsID1ForTest = "1"
 
+// TestTransactionNodeSystemNamespaces verifies that system namespaces do not take the
+// normal _meta namespace-version read dependency, mirroring the existing _meta/_config
+// exemption for _snapshot and _checkpoint.
+func TestTransactionNodeSystemNamespaces(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		nsID string
+	}{
+		{name: "meta namespace", nsID: committerpb.MetaNamespaceID},
+		{name: "config namespace", nsID: committerpb.ConfigNamespaceID},
+		{name: "snapshot namespace", nsID: committerpb.SnapshotNamespaceID},
+		{name: "checkpoint namespace", nsID: committerpb.CheckpointNamespaceID},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			tx := createTxForTest(t, 0, tc.nsID, nil, [][]byte{[]byte("k")}, nil)
+			txNode := newTransactionNode(tx)
+
+			metaKey := constructCompositeKey(committerpb.MetaNamespaceID, []byte(tc.nsID))
+			require.NotContains(t, txNode.rwKeys.readsOnly, metaKey,
+				"system namespace %s must not take the _meta namespace-version read dependency", tc.nsID)
+		})
+	}
+}
+
+// TestTransactionNodeApplicationNamespace verifies that an ordinary application namespace
+// still takes the _meta namespace-version read dependency.
+func TestTransactionNodeApplicationNamespace(t *testing.T) {
+	t.Parallel()
+	tx := createTxForTest(t, 0, nsID1ForTest, nil, [][]byte{[]byte("k")}, nil)
+	txNode := newTransactionNode(tx)
+
+	metaKey := constructCompositeKey(committerpb.MetaNamespaceID, []byte(nsID1ForTest))
+	require.Contains(t, txNode.rwKeys.readsOnly, metaKey)
+}
+
 func TestTransactionNode(t *testing.T) {
 	t.Parallel()
 

--- a/service/vc/database_test.go
+++ b/service/vc/database_test.go
@@ -37,7 +37,11 @@ func TestTablesAndMethods(t *testing.T) {
 	require.NoError(t, env.DB.setupSystemTablesAndNamespaces(ctx))
 	env.populateData(t, []string{"a", "b"}, namespaceToWrites{}, nil, nil)
 
-	expectedTables := []string{"metadata", "tx_status", "ns__meta", "ns__config", "ns_a", "ns_b"}
+	expectedTables := []string{
+		"metadata", "tx_status",
+		"ns__meta", "ns__config", "ns__snapshot", "ns__checkpoint",
+		"ns_a", "ns_b",
+	}
 	expectedMethodsPerNamespace := []string{"insert_", "update_", "validate_reads_"}
 	expectedMethods := []string{"insert_tx_status"}
 	for _, table := range expectedTables {

--- a/service/vc/dbinit.go
+++ b/service/vc/dbinit.go
@@ -43,7 +43,12 @@ var (
 	//go:embed create_namespace_tmpl.sql
 	createNamespaceSQLStmt string
 
-	systemNamespaces = []string{committerpb.MetaNamespaceID, committerpb.ConfigNamespaceID}
+	systemNamespaces = []string{
+		committerpb.MetaNamespaceID,
+		committerpb.ConfigNamespaceID,
+		committerpb.SnapshotNamespaceID,
+		committerpb.CheckpointNamespaceID,
+	}
 
 	lastCommittedBlockNumberKey = []byte("last committed block number")
 )

--- a/service/vc/dbinit_test.go
+++ b/service/vc/dbinit_test.go
@@ -22,24 +22,37 @@ func TestDBInit(t *testing.T) {
 	t.Parallel()
 	env := newDatabaseTestEnvWithTablesSetup(t)
 
-	tableName := TableName(committerpb.MetaNamespaceID)
-	keys := [][]byte{[]byte(txs[0]), []byte(txs[1]), []byte(txs[2]), []byte(txs[3])}
-	ret := env.DB.pool.QueryRow(t.Context(), FmtNsID(insertNsStatesSQLTempl, committerpb.MetaNamespaceID), keys, keys)
-	duplicates, err := readArrayResult[[]byte](ret)
-	require.NoError(t, err)
-	require.Empty(t, duplicates)
+	for _, tc := range []struct {
+		name string
+		nsID string
+	}{
+		{name: "meta namespace", nsID: committerpb.MetaNamespaceID},
+		{name: "config namespace", nsID: committerpb.ConfigNamespaceID},
+		{name: "snapshot namespace", nsID: committerpb.SnapshotNamespaceID},
+		{name: "checkpoint namespace", nsID: committerpb.CheckpointNamespaceID},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			tableName := TableName(tc.nsID)
+			keys := [][]byte{[]byte(txs[0]), []byte(txs[1]), []byte(txs[2]), []byte(txs[3])}
+			ret := env.DB.pool.QueryRow(t.Context(), FmtNsID(insertNsStatesSQLTempl, tc.nsID), keys, keys)
+			duplicates, err := readArrayResult[[]byte](ret)
+			require.NoError(t, err)
+			require.Empty(t, duplicates)
 
-	// Validate default values
-	r, err := env.DB.pool.Query(t.Context(), "select * from "+tableName+";")
-	require.NoError(t, err)
-	defer r.Close()
-	for r.Next() {
-		var key, value []byte
-		var version uint64
-		require.NoError(t, r.Scan(&key, &value, &version))
-		require.NotNil(t, key)
-		require.Equal(t, key, value)
-		require.EqualValues(t, 0, version)
+			// Validate default values
+			r, err := env.DB.pool.Query(t.Context(), "select * from "+tableName+";")
+			require.NoError(t, err)
+			defer r.Close()
+			for r.Next() {
+				var key, value []byte
+				var version uint64
+				require.NoError(t, r.Scan(&key, &value, &version))
+				require.NotNil(t, key)
+				require.Equal(t, key, value)
+				require.EqualValues(t, 0, version)
+			}
+		})
 	}
 }
 

--- a/service/vc/preparer.go
+++ b/service/vc/preparer.go
@@ -186,11 +186,10 @@ func (p *transactionPreparer) prepare(ctx context.Context) error { //nolint:goco
 				// duplicate snapshot requests.
 				if nsOperations.NsId == committerpb.SnapshotNamespaceID {
 					// proto.Marshal cannot fail here: SnapshotState{TxRef} is a small, acyclic
-					// message. We still return the error instead of skipping the TX: the preparer
-					// runs deterministically on every committer, so silently dropping this write
-					// would omit the _snapshot row on one replica while others keep it, forking
-					// state. Failing the worker (via errgroup) halts this committer uniformly
-					// rather than diverging.
+					// message. We return the error only for completeness. proto.Marshal is
+					// deterministic, so any failure would occur identically on every committer
+					// and halt them uniformly (via errgroup); there is no risk of one replica
+					// dropping the _snapshot write while others keep it.
 					state, marshalErr := proto.Marshal(&committerpb.SnapshotState{TxRef: tx.Ref})
 					if marshalErr != nil {
 						return errors.Wrapf(marshalErr, "failed to marshal snapshot state for TX %s", tx.Ref.TxId)

--- a/service/vc/preparer.go
+++ b/service/vc/preparer.go
@@ -10,9 +10,11 @@ import (
 	"context"
 	"time"
 
+	"github.com/cockroachdb/errors"
 	"github.com/hyperledger/fabric-x-common/api/applicationpb"
 	"github.com/hyperledger/fabric-x-common/api/committerpb"
 	"golang.org/x/sync/errgroup"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/hyperledger/fabric-x-committer/api/servicepb"
 	"github.com/hyperledger/fabric-x-committer/utils/channel"
@@ -116,8 +118,7 @@ func (p *transactionPreparer) run(ctx context.Context, numWorkers int) error {
 
 	for range numWorkers {
 		g.Go(func() error {
-			p.prepare(eCtx)
-			return nil
+			return p.prepare(eCtx)
 		})
 	}
 
@@ -129,13 +130,13 @@ func (p *transactionPreparer) run(ctx context.Context, numWorkers int) error {
 // the index of invalid transactions when a read is invalid.
 // It sends the prepared transactions to the preparedTxs channel which is an input
 // to the validator.
-func (p *transactionPreparer) prepare(ctx context.Context) { //nolint:gocognit
+func (p *transactionPreparer) prepare(ctx context.Context) error { //nolint:gocognit
 	incomingTransactionBatch := channel.NewReader(ctx, p.incomingTransactionBatch)
 	outgoingPreparedTransactions := channel.NewWriter(ctx, p.outgoingPreparedTransactions)
 	for {
 		txBatch, ok := incomingTransactionBatch.Read()
 		if !ok {
-			return
+			return nil
 		}
 		logger.Debugf("New batch with %d in the preparer.", len(txBatch.Transactions))
 		start := time.Now()
@@ -175,6 +176,35 @@ func (p *transactionPreparer) prepare(ctx context.Context) { //nolint:gocognit
 			for _, nsOperations := range tx.Namespaces {
 				tID := TxID(tx.Ref.TxId)
 				logger.Debugf("Preparing namespace %s in TX with ID %s ", nsOperations.NsId, tx.Ref.TxId)
+
+				// The _snapshot marker TX carries no application reads/writes and takes no
+				// _meta namespace-version dependency. We synthesize a single new write into
+				// the _snapshot namespace so the namespace is forwarded to the committer:
+				// key = tx_id, value = SnapshotState{TxRef}. Only the TxRef is set here; the
+				// committer/hash worker fills in the lifecycle status and clone details. The
+				// nil version makes this a new key, and MVCC on tx_id gives idempotency for
+				// duplicate snapshot requests.
+				if nsOperations.NsId == committerpb.SnapshotNamespaceID {
+					// proto.Marshal cannot fail here: SnapshotState{TxRef} is a small, acyclic
+					// message. We still return the error instead of skipping the TX: the preparer
+					// runs deterministically on every committer, so silently dropping this write
+					// would omit the _snapshot row on one replica while others keep it, forking
+					// state. Failing the worker (via errgroup) halts this committer uniformly
+					// rather than diverging.
+					state, marshalErr := proto.Marshal(&committerpb.SnapshotState{TxRef: tx.Ref})
+					if marshalErr != nil {
+						return errors.Wrapf(marshalErr, "failed to marshal snapshot state for TX %s", tx.Ref.TxId)
+					}
+					prepTxs.addReadWrites(tID, &applicationpb.TxNamespace{
+						NsId: committerpb.SnapshotNamespaceID,
+						ReadWrites: []*applicationpb.ReadWrite{{
+							Key:   []byte(tx.Ref.TxId),
+							Value: state,
+						}},
+					})
+					continue
+				}
+
 				prepTxs.addReadsOnly(tID, nsOperations)
 				prepTxs.addReadWrites(tID, nsOperations)
 				prepTxs.addBlindWrites(tID, nsOperations)
@@ -195,8 +225,10 @@ func (p *transactionPreparer) prepare(ctx context.Context) { //nolint:gocognit
 							Version: &nsOperations.NsVersion,
 						}},
 					})
-				case committerpb.ConfigNamespaceID:
-					// A config TX is independent.
+				case committerpb.ConfigNamespaceID, committerpb.CheckpointNamespaceID:
+					// A config TX is independent. The _checkpoint namespace is a system
+					// namespace: its single ReadWrite is prepared above for checkpoint-specific
+					// handling, but it takes no _meta namespace-version dependency.
 				default:
 					prepTxs.addReadsOnly(tID, &applicationpb.TxNamespace{
 						NsId: committerpb.MetaNamespaceID,

--- a/service/vc/preparer_test.go
+++ b/service/vc/preparer_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hyperledger/fabric-x-common/api/applicationpb"
 	"github.com/hyperledger/fabric-x-common/api/committerpb"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/hyperledger/fabric-x-committer/api/servicepb"
 	"github.com/hyperledger/fabric-x-committer/loadgen/workload"
@@ -652,6 +653,114 @@ func TestPrepareTx(t *testing.T) { //nolint:maintidx // cannot improve.
 	env.txBatch <- tx
 	preparedTxs := <-env.preparedTxs
 	ensurePreparedTx(t, expectedPreparedTxs, preparedTxs)
+}
+
+// TestPrepareSnapshotTx verifies that a _snapshot marker TX takes no _meta namespace-version
+// dependency and is forwarded to the committer as a single new write into the _snapshot
+// namespace (key = tx_id, value = SnapshotState{TxRef}), so the namespace survives the preparer.
+func TestPrepareSnapshotTx(t *testing.T) {
+	t.Parallel()
+	env := newPrepareTestEnv(t)
+
+	tx := &servicepb.VcBatch{
+		Transactions: []*servicepb.VcTx{
+			{
+				Ref: committerpb.NewTxRef(string(txs[0]), 8, 1),
+				Namespaces: []*applicationpb.TxNamespace{
+					{NsId: committerpb.SnapshotNamespaceID, NsVersion: 0},
+				},
+			},
+		},
+	}
+
+	snapshotState, err := proto.Marshal(&committerpb.SnapshotState{
+		TxRef: committerpb.NewTxRef(string(txs[0]), 8, 1),
+	})
+	require.NoError(t, err)
+
+	expectedPreparedTxs := &preparedTransactions{
+		nsToReads: namespaceToReads{},
+		readToTxIDs: readToTransactions{
+			newCmpRead(committerpb.SnapshotNamespaceID, []byte(txs[0]), nil): []TxID{txs[0]},
+		},
+		txIDToNsNonBlindWrites: transactionToWrites{},
+		txIDToNsBlindWrites:    transactionToWrites{},
+		txIDToNsNewWrites: transactionToWrites{
+			txs[0]: namespaceToWrites{
+				committerpb.SnapshotNamespaceID: &namespaceWrites{
+					keys:     [][]byte{[]byte(txs[0])},
+					values:   [][]byte{snapshotState},
+					versions: []uint64{0},
+				},
+			},
+		},
+		invalidTxIDStatus: map[TxID]committerpb.Status{},
+		txIDToHeight: transactionIDToHeight{
+			txs[0]: servicepb.NewHeight(8, 1),
+		},
+	}
+
+	env.txBatch <- tx
+	preparedTxs := <-env.preparedTxs
+	ensurePreparedTx(t, expectedPreparedTxs, preparedTxs)
+	// No _meta namespace-version read must be created for the snapshot TX.
+	require.NotContains(t, preparedTxs.nsToReads, committerpb.MetaNamespaceID)
+}
+
+// TestPrepareCheckpointTx verifies that a _checkpoint TX retains its single versioned
+// ReadWrite for checkpoint-specific handling but takes no _meta namespace-version dependency.
+func TestPrepareCheckpointTx(t *testing.T) {
+	t.Parallel()
+	env := newPrepareTestEnv(t)
+
+	heightKey := servicepb.NewHeight(8, 0).ToBytes()
+	hashValue := []byte("snapshot-hash")
+
+	tx := &servicepb.VcBatch{
+		Transactions: []*servicepb.VcTx{
+			{
+				Ref: committerpb.NewTxRef(string(txs[0]), 9, 1),
+				Namespaces: []*applicationpb.TxNamespace{
+					{
+						NsId:      committerpb.CheckpointNamespaceID,
+						NsVersion: 0,
+						ReadWrites: []*applicationpb.ReadWrite{
+							{Key: heightKey, Version: nil, Value: hashValue},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	expectedPreparedTxs := &preparedTransactions{
+		// A nil-version ReadWrite is treated as a new write; no reads are produced.
+		nsToReads: namespaceToReads{},
+		readToTxIDs: readToTransactions{
+			newCmpRead(committerpb.CheckpointNamespaceID, heightKey, nil): []TxID{txs[0]},
+		},
+		txIDToNsNonBlindWrites: transactionToWrites{},
+		txIDToNsBlindWrites:    transactionToWrites{},
+		txIDToNsNewWrites: transactionToWrites{
+			txs[0]: namespaceToWrites{
+				committerpb.CheckpointNamespaceID: &namespaceWrites{
+					keys:     [][]byte{heightKey},
+					values:   [][]byte{hashValue},
+					versions: []uint64{0},
+				},
+			},
+		},
+		invalidTxIDStatus: map[TxID]committerpb.Status{},
+		txIDToHeight: transactionIDToHeight{
+			txs[0]: servicepb.NewHeight(9, 1),
+		},
+	}
+
+	env.txBatch <- tx
+	preparedTxs := <-env.preparedTxs
+	ensurePreparedTx(t, expectedPreparedTxs, preparedTxs)
+	// No _meta namespace-version read must be created for the checkpoint TX.
+	require.NotContains(t, preparedTxs.nsToReads, committerpb.MetaNamespaceID)
 }
 
 func ensurePreparedTx(t *testing.T, expectedPreparedTxs, actualPreparedTxs *preparedTransactions) {

--- a/service/vc/preparer_test.go
+++ b/service/vc/preparer_test.go
@@ -701,7 +701,8 @@ func TestPrepareSnapshotTx(t *testing.T) {
 	}
 
 	env.txBatch <- tx
-	preparedTxs := <-env.preparedTxs
+	preparedTxs, ok := channel.NewReader(t.Context(), env.preparedTxs).Read()
+	require.True(t, ok)
 	ensurePreparedTx(t, expectedPreparedTxs, preparedTxs)
 	// No _meta namespace-version read must be created for the snapshot TX.
 	require.NotContains(t, preparedTxs.nsToReads, committerpb.MetaNamespaceID)
@@ -757,7 +758,8 @@ func TestPrepareCheckpointTx(t *testing.T) {
 	}
 
 	env.txBatch <- tx
-	preparedTxs := <-env.preparedTxs
+	preparedTxs, ok := channel.NewReader(t.Context(), env.preparedTxs).Read()
+	require.True(t, ok)
 	ensurePreparedTx(t, expectedPreparedTxs, preparedTxs)
 	// No _meta namespace-version read must be created for the checkpoint TX.
 	require.NotContains(t, preparedTxs.nsToReads, committerpb.MetaNamespaceID)

--- a/service/verifier/policy/policy.go
+++ b/service/verifier/policy/policy.go
@@ -19,6 +19,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"github.com/hyperledger/fabric-x-committer/api/servicepb"
+	"github.com/hyperledger/fabric-x-committer/utils"
 	"github.com/hyperledger/fabric-x-committer/utils/signature"
 )
 
@@ -117,10 +118,8 @@ func UnmarshalNamespacePolicy(policyBytes []byte) (*applicationpb.NamespacePolic
 
 // validateNamespaceIDInPolicy checks that a given namespace fulfills namespace naming conventions.
 func validateNamespaceIDInPolicy(nsID string) error {
-	// If it matches one of the system's namespaces it is invalid.
-	switch nsID {
-	case committerpb.MetaNamespaceID, committerpb.ConfigNamespaceID,
-		committerpb.SnapshotNamespaceID, committerpb.CheckpointNamespaceID:
+	// System namespaces cannot be used as ordinary application namespace policies.
+	if utils.IsSystemNamespace(nsID) {
 		return ErrInvalidNamespaceID
 	}
 

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -117,6 +117,25 @@ func IsConfigTx(namespaces []*applicationpb.TxNamespace) bool {
 	return len(namespaces) == 1 && namespaces[0].NsId == committerpb.ConfigNamespaceID
 }
 
+// IsSystemNamespace returns true if the namespace ID is one of the reserved system
+// namespaces (_meta, _config, _snapshot, _checkpoint). System namespaces are handled
+// specially across the pipeline: they cannot be used as ordinary application namespace
+// policies and they do not take the normal _meta namespace-version read dependency.
+//
+// TODO: move this to fabric-x-common alongside the committerpb namespace constants,
+// so all repos share a single system-namespace predicate.
+func IsSystemNamespace(nsID string) bool {
+	switch nsID {
+	case committerpb.MetaNamespaceID,
+		committerpb.ConfigNamespaceID,
+		committerpb.SnapshotNamespaceID,
+		committerpb.CheckpointNamespaceID:
+		return true
+	default:
+		return false
+	}
+}
+
 // RandIntN returns a true random (crypto/rand) number in the range [0, n).
 // If it fails to read the crypto/rand stream, it falls back to a pseudo random number generator.
 func RandIntN(n uint64) uint64 {


### PR DESCRIPTION
#### Type of change

- New feature
 
#### Description

Add committerpb.SnapshotNamespaceID and CheckpointNamespaceID to the systemNamespaces list so their ns_<id> tables are created via the existing namespace bootstrap path, alongside _meta and _config. 

Recognize _snapshot and _checkpoint as first-class system namespaces
across policy validation, the dependency graph, and the VC preparer,
mirroring existing _meta/_config handling.


#### Additional details (Optional)

- Add utils.IsSystemNamespace covering _meta, _config, _snapshot, and
  _checkpoint, and use it in policy validation and dependency-graph
  read-key construction to avoid duplicating the 4-way guard.
- policy: reject _snapshot/_checkpoint as ordinary application namespace
  policies.
- dependencygraph: skip the normal _meta namespace-version read
  dependency for system namespaces.
- vc preparer: skip the _meta dependency for both; forward the _snapshot
  marker TX to the committer as a single new write into the _snapshot
  namespace (key = tx_id, value = SnapshotState{TxRef}); retain the
  single ReadWrite for _checkpoint. Fail the preparer worker rather than
  silently dropping a _snapshot write, since that would fork state across
  deterministic replicas.

#### Related issues

 - resolves #657 and #658 