### PR TITLE
[loadgen] Validate conflict probabilities are in [0,1]

### DIFF
--- a/cmd/config/app_config_test.go
+++ b/cmd/config/app_config_test.go
@@ -457,6 +457,51 @@ func TestReadConfigLoadGen(t *testing.T) {
 	}
 }
 
+// TestLoadGenProbabilityValidation exercises the decode-and-validate path for the
+// loadgen conflict probabilities: values inside the closed interval [0,1] are
+// accepted, values outside are rejected by validation. This also covers the
+// per-dependency probability, which lives inside a slice (validated via "dive").
+func TestLoadGenProbabilityValidation(t *testing.T) {
+	t.Parallel()
+	read := func(t *testing.T, yaml string) error {
+		t.Helper()
+		v := viper.New()
+		require.NoError(t, readYamlConfigsFromIO(v, strings.NewReader(yaml)))
+		return unmarshal(v, &loadgen.ClientConfig{})
+	}
+	invalidSig := func(probability string) string {
+		return "load-profile:\n  conflicts:\n    invalid-signatures: " + probability + "\n"
+	}
+	dependency := func(probability string) string {
+		return "load-profile:\n  conflicts:\n    dependencies:\n" +
+			"      - probability: " + probability + "\n        src: read\n        dst: write\n"
+	}
+
+	for _, tc := range []struct {
+		name    string
+		yaml    string
+		wantErr bool
+	}{
+		{name: "invalid-signatures in range", yaml: invalidSig("0.3")},
+		{name: "invalid-signatures is 1", yaml: invalidSig("1")},
+		{name: "invalid-signatures above 1", yaml: invalidSig("1.5"), wantErr: true},
+		{name: "invalid-signatures below 0", yaml: invalidSig("-0.1"), wantErr: true},
+		{name: "dependency probability in range", yaml: dependency("0.5")},
+		{name: "dependency probability above 1", yaml: dependency("2"), wantErr: true},
+		{name: "dependency probability below 0", yaml: dependency("-1"), wantErr: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := read(t, tc.yaml)
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
 func defaultDBConfig() *statedb.Config {
 	return &statedb.Config{
 		Endpoints:      []*connection.Endpoint{newEndpoint(connection.DefaultHost, statedb.DefaultEndpointPort)},

--- a/loadgen/workload/config.go
+++ b/loadgen/workload/config.go
@@ -91,15 +91,15 @@ type TransactionProfile struct {
 // Note that each of the conflicts' probabilities are independent bernoulli distributions.
 type ConflictProfile struct {
 	// Probability of invalid signatures [0,1] (default: 0)
-	InvalidSignatures Probability `mapstructure:"invalid-signatures" yaml:"invalid-signatures"`
+	InvalidSignatures Probability `mapstructure:"invalid-signatures" yaml:"invalid-signatures" validate:"gte=0,lte=1"`
 	// Dependencies list of dependencies
-	Dependencies []DependencyDescription `mapstructure:"dependencies" yaml:"dependencies"`
+	Dependencies []DependencyDescription `mapstructure:"dependencies" yaml:"dependencies" validate:"dive"`
 }
 
 // DependencyDescription describes a dependency type.
 type DependencyDescription struct {
 	// Probability of the dependency type [0,1] (default: 0)
-	Probability Probability `mapstructure:"probability" yaml:"probability"`
+	Probability Probability `mapstructure:"probability" yaml:"probability" validate:"gte=0,lte=1"`
 	// Gap is the distance between the dependent TXs (min: 1, default: 1)
 	Gap uint64 `mapstructure:"gap" yaml:"gap"`
 	// Src dependency "read", "write", or "read-write"


### PR DESCRIPTION
#### Type of change

- Improvement
 
#### Description

- The loadgen config exposes probability fields — `conflicts.invalid-signatures` and each `conflicts.dependencies[].probability` — that must lie in the closed interval [0,1]. Out-of-range values previously decoded silently and produced nonsensical per-transaction Bernoulli behavior. Reject them at config-load time.
- Annotate `ConflictProfile.InvalidSignatures` and `DependencyDescription.Probability` with `validate:"gte=0,lte=1"`, and the `ConflictProfile.Dependencies` slice with `validate:"dive"` so each element's probability is validated.
- Add `TestLoadGenProbabilityValidation` covering in-range acceptance and out-of-range rejection for both fields (including the sliced dependency).