### PR TITLE
[skills] Add development skill for writing new Go code

### DIFF
--- a/.bob/skills/development/SKILL.md
+++ b/.bob/skills/development/SKILL.md
@@ -1,0 +1,339 @@
+---
+name: development
+description: >-
+  Conventions for writing NEW Go code in the Fabric-X Committer repo: code
+  organization/ordering, concurrency (errgroup + context-aware channels), Go
+  1.26 idioms, error handling, logging, and service/config/metrics structure.
+  Use this skill BEFORE writing or modifying any Go source in this repository —
+  adding a service, component, function, gRPC handler, or config field, or
+  refactoring existing code — so the new code matches established patterns and
+  passes `make lint`. For test-only work use the `tests` skill; for reviewing a
+  PR use `pr-review`.
+---
+
+# Developing in Fabric-X Committer
+
+This skill tells you how to write new Go code that looks like it was already
+here. Follow it whenever you add or change production Go source.
+
+**Scope split** — write tests using the `tests` skill (it owns table-tests,
+`t.Parallel`, metrics helpers). Review PRs with the `pr-review` skill. This skill
+covers *authoring* production code.
+
+**Authoritative sources in the repo** (read them when a topic needs depth):
+- `guidelines.md` — the simplicity philosophy and error-handling policy.
+- `docs/core-concurrency-pattern.md` — the errgroup + context-aware channel doctrine.
+- `.golangci.yml` — every linter that gates your PR (see the cheat sheet at the end).
+- `references/service-construction.md` (in this skill) — the full blueprint for a new
+  service/component: struct, lifecycle, gRPC handlers, config pipeline, metrics, wiring.
+
+## The prime directive: simplicity over cleverness
+
+`guidelines.md` is emphatic and the whole codebase reflects it. Before adding any
+abstraction, stop:
+
+- **No premature interfaces.** Return and pass concrete `*T`. Interfaces are only for
+  genuinely pluggable seams (e.g. `serve.Service`, DB adapters). The `ireturn` linter
+  blocks most interface returns.
+- **Generics only for reusable `utils/`-style plumbing** (`channel.ReaderWriter[T]`,
+  `SyncMap[K,V]`, `retry.ExecuteWithResult[T]`). Core service logic uses concrete types.
+- **No functions-as-arguments / callbacks.** If logic must be pluggable, define an
+  interface and pass a concrete implementation (Strategy pattern). Closures are fine
+  *inside* one function; don't pass them across API boundaries.
+- **Explicit and a few lines longer beats compact and clever.** Guard clauses, early
+  returns, intermediate variables. Max ~3 levels of nesting; `gocognit` caps complexity
+  at 15.
+
+## Step 0 — reuse before you write
+
+Grep `utils/` before implementing anything infrastructural. Re-inventing these is the
+most common review rejection:
+
+| Need | Use | Package |
+|------|-----|---------|
+| Spawn goroutines & wait | `errgroup.WithContext` | `golang.org/x/sync/errgroup` |
+| Move data over a channel safely | `channel.NewReader/NewWriter/Make` | `utils/channel` |
+| Signal / wait for readiness | `channel.NewReady` | `utils/channel` |
+| Bounded in-flight work (semaphore) | `Slots` | `utils/slots.go` |
+| Typed concurrent map | `SyncMap[K,V]` | `utils/sync_map.go` |
+| Create/originate/wrap errors | `errors.New/Newf/Wrap/Wrapf` | `github.com/cockroachdb/errors` |
+| Convert error → gRPC status | `grpcerror.Wrap*` | `utils/grpcerror` |
+| Dial gRPC peers | `connection.NewSingleConnection` / `NewLoadBalancedConnection` / `NewConnectionPerEndpoint` | `utils/connection` |
+| Retry / keep a loop alive | `retry.Sustain`, `retry.WaitForCondition` | `utils/retry` |
+| Run a service + gRPC/HTTP servers | `serve.StartAndServe` | `utils/serve` |
+| Prometheus metrics | `monitoring.Provider` + `promutil.*` | `utils/monitoring` |
+| Package logger | `flogging.MustGetLogger` | `fabric-lib-go/common/flogging` |
+
+**Test fixtures** — test code has its own reuse discipline: don't hand-roll crypto, TLS, or
+block fixtures. Full picture is in the `tests` skill; the key helpers:
+
+| Need | Use | Package |
+|------|-----|---------|
+| In-process service / DB / mock harnesses | `test.RunServiceForTest`, `testdb.PrepareTestEnv`, `mock.*` | `utils/test`, `utils/testdb`, `mock/` (this repo) |
+| Proto assertions | `test.RequireProtoEqual` / `RequireProtoElementsMatch` | `utils/test` (this repo) |
+| MSP / identity / Fabric config-block fixtures | `testcrypto.CreateOrExtendConfigBlockWithCrypto`, `ConfigBlock`, `PrepareBlockHeaderAndMetadata`, `GetPeersIdentities` / `GetConsenterIdentities` / `GetSigningIdentities` / `GetPeersMspDirs` | `github.com/hyperledger/fabric-x-common/utils/testcrypto` |
+| Test TLS CAs & cert/key pairs | `tlsgen.NewCA()`, `CA`, `CertKeyPair` | `github.com/hyperledger/fabric-x-common/common/crypto/tlsgen` |
+| Generate crypto material | `cryptogen` | `github.com/hyperledger/fabric-x-common/tools/cryptogen` |
+
+## Code organization
+
+This is where new code most often diverges from the repo. Match these exactly.
+
+### Caller before callee (top-down reading order)
+
+Place a function **above** the functions it calls, so a reader meets each function
+before its dependencies. This is the single most consistent rule in the codebase.
+
+Model file: `service/vc/committer.go` reads `newCommitter` → `run` → `commit` →
+`commitTransactions` → its helpers, each defined below its caller.
+
+```go
+// service/vc/committer.go:50 — run() sits directly above the commit() it calls
+func (c *transactionCommitter) run(ctx context.Context, db *database, numWorkers int) error {
+	g, eCtx := errgroup.WithContext(ctx)
+	for range numWorkers {
+		g.Go(func() error { return c.commit(eCtx, db) }) // callee defined next
+	}
+	return g.Wait()
+}
+
+func (c *transactionCommitter) commit(ctx context.Context, db *database) error { /* ... */ }
+```
+
+### Group methods by struct
+
+Keep all methods of one type contiguous; the constructor `newXxx` leads the block, then
+its methods. Don't interleave two types' methods by chance.
+
+**Exception:** when two types collaborate tightly in one file, top-down call order
+(above) wins over strict grouping — order by the processing flow
+(`service/sidecar/notify.go` does this deliberately).
+
+### Don't fragment into tiny single-use helpers — but do manage complexity
+
+Default to one cohesive function; don't extract a helper just to name a step that runs from
+a single place. Extract when the logic is **reused** or names a genuinely distinct step.
+
+The exception is complexity: `gocognit` caps a function at 15. When a function grows past
+that, **prefer breaking it into helpers to bring the complexity down** over leaving an
+unreadable monolith — extracting for complexity's sake is fine even if the helper is called
+once. Reach for `//nolint:gocognit // <reason>` only when the logic is genuinely cohesive
+and does not split cleanly (e.g. the ~130-line `prepare` at `service/vc/preparer.go:133`).
+In test code, `gocognit` is sometimes simply suppressed with a scoped `//nolint`.
+
+For logic shared *within* one function, use a local closure
+(`service/vc/validator_committer_service.go:317` `sendLargeBatch`), not a method.
+
+### File layout template
+
+Every `.go` file follows this order (model: `service/coordinator/coordinator.go`):
+
+1. Apache-2.0 header — the `/* ... */` block comment (the `goheader` linter requires it):
+   ```go
+   /*
+   Copyright IBM Corp. All Rights Reserved.
+
+   SPDX-License-Identifier: Apache-2.0
+   */
+   ```
+2. `package` clause.
+3. `import (...)` — three blank-line-separated groups: stdlib, third-party, then internal
+   `github.com/hyperledger/fabric-x-committer/...` (`goimports` local-prefixes enforces this).
+4. `var logger = flogging.MustGetLogger("<name>")` in the package's primary file.
+5. `const (...)` block (defaults, SQL templates).
+6. Type declarations, usually a single grouped `type ( ... )` block, main struct first with a doc comment.
+7. `var (...)` of sentinel errors named `ErrXxx`, each with a doc comment.
+8. Constructor `NewXxx`/`newXxx`.
+9. Exported lifecycle methods (`Run`, `WaitForReady`, `RegisterService`), then internal
+   methods in caller-before-callee order.
+10. Free helper functions at the bottom.
+
+### Split a package into role-named files
+
+`config.go` (Config + `Default*` consts), `metrics.go` (`perfMetrics` + `newXxxMetrics`),
+`<service>.go` (the server, constructor, lifecycle, gRPC handlers), then one file per
+pipeline component/manager (`preparer.go`, `validator.go`, `committer.go`, `database.go`).
+Keep files moderate (~200–750 lines); give a large concern its own file. Tests are
+co-located as `<file>_test.go`; shared exported test helpers go in `test_exports.go`.
+
+## Concurrency
+
+Read `docs/core-concurrency-pattern.md` once. The rules:
+
+### errgroup is the default for spawning + waiting
+
+Use `errgroup.WithContext(ctx)`, spawn with `g.Go(func() error {...})`, block on
+`g.Wait()`. **Do not** hand-roll `sync.WaitGroup`, and **do not** use channels to signal
+completion — that is errgroup's job. Bound parallelism with a fixed worker count in a
+`for range n` loop (the codebase does not use `errgroup.SetLimit`).
+
+```go
+g, eCtx := errgroup.WithContext(ctx)
+for range numWorkers {
+	g.Go(func() error { return c.commit(eCtx, db) })
+}
+return g.Wait()
+```
+
+- Pass the group context (`eCtx`/`gCtx`) into goroutines, **not** the parent `ctx`.
+- Guard long-running loops with `for ctx.Err() == nil` or `select { case <-ctx.Done(): }`.
+- When any goroutine's exit must tear down the rest, wrap with `ctx, cancel :=
+  context.WithCancel(ctx); defer cancel()` and `defer cancel()` inside each `g.Go`.
+- A goroutine with nothing to return still uses errgroup and `return nil` (or `ctx.Err()`).
+- Wrap the result at the boundary: `utils.ProcessErr(g.Wait(), "...")` or `errors.Wrap(g.Wait(), "...")`.
+
+**`sync.WaitGroup` is a narrow exception:** use it only when you must wait for *every*
+goroutine even after one fails (errgroup cancels siblings on first error). If so, prefer
+the Go 1.25 method form `wg.Go(func(){...})` and collect errors with `errors.Join` — see
+`utils/deliverorderer/orderer.go:448`.
+
+### Channels carry data, never "done" — and always through the wrapper
+
+Raw channels are for data flow between pipeline stages. Never `select` on a raw channel
+plus `ctx.Done()` by hand; wrap it in `channel.NewReader`/`NewWriter`/`Make` so the
+operation releases immediately on cancellation and the system never hangs on shutdown
+(76+ call sites; rationale in `utils/channel/reader_writer.go:14`).
+
+```go
+incoming := channel.NewReader(ctx, c.incomingValidatedTransactions)
+outgoing := channel.NewWriter(ctx, c.outgoingTransactionsStatus)
+for {
+	vTx, ok := incoming.Read()
+	if !ok { return nil } // ctx done or channel closed
+	// ...
+	outgoing.Write(txsStatus)
+}
+```
+
+Do not `for range aChannel` in production code — use the wrapper's `Read()` loop instead.
+
+### Readiness and shutdown
+
+Signal readiness with `channel.NewReady()` (`SignalReady` / `WaitForReady(ctx)` /
+`Reset`), not a bare channel or bool. Make `Stop`/`Close` idempotent with `sync.Once`.
+Use `context.AfterFunc(ctx, fn)` for cancel-driven teardown (the standard primitive here).
+Reach for `atomic` for counters/flags/pointers, `Mutex`/`RWMutex` for compound state, and
+`TryLock` to reject a second concurrent stream (`grpcerror.WrapFailedPrecondition`).
+
+## Modern Go idioms (1.26)
+
+The codebase is aggressively modern. **Prefer** in new code:
+
+- `slices.*` — `Contains`, `Index`, `Clone`, `SortFunc`, `Sorted`, `Backward`, `Delete`,
+  and `Collect` to consume iterators.
+- `maps.*` consumed via `slices.Collect(maps.Values(m))` / `slices.Sorted(maps.Keys(m))`;
+  `maps.Clone`, `maps.Copy`.
+- Built-in `min` / `max` (pervasive), e.g. `min(high, max(low, v))`.
+- Range-over-integer: `for range n` / `for i := range n` (the `intrange` linter pushes this).
+- `iter.Seq` / `iter.Seq2` for custom iterators (`utils/sync_map.go`).
+- `errors.Join` — especially to combine a retry sentinel with a cause:
+  `errors.Join(retry.ErrBackOff, err)`.
+- `context.AfterFunc`, and `context.WithCancelCause` / `context.Cause` where a cancel
+  reason matters.
+- `any` — **never** `interface{}` (only generated `.pb.go` uses the latter).
+- Generics for `utils/`-style reusable helpers; concrete types for service logic.
+
+**Absent — don't assume idiomatic; introduce only with a clear reason:** `clear()`,
+`sync.OnceFunc`/`OnceValue` (use plain `sync.Once`), `cmp.Or`, `context.WithoutCancel`,
+`log/slog` (use `flogging`), and `slices.Sort`/`Equal`/`Compact`.
+
+## Error handling
+
+Uses `github.com/cockroachdb/errors` (the `depguard` linter bans `github.com/pkg/errors`).
+
+**Decision rule:**
+1. **Originate or first cross into our code** (a new condition, or an error from a DB
+   driver / gRPC `Recv` / marshal) → `errors.New` / `errors.Newf` / `errors.Wrap` /
+   `errors.Wrapf`. This captures the stack trace at the origin.
+2. **Add context while propagating** an error that already carries a trace →
+   `fmt.Errorf("context: %w", err)`. Always `%w`, never `%v`/`%s` (the `errorlint` linter
+   enforces this). This adds a message without a redundant second trace.
+3. **Return errors up the stack; do not log mid-stack.** Log once, at the boundary.
+
+```go
+if len(query.TxIds) == 0 {
+	return nil, grpcerror.WrapInvalidArgument(errors.New("query is empty"))
+}
+txIDsStatus, err := vc.db.readStatusWithHeight(ctx, txIDs)
+if err != nil {
+	logger.Errorf("%+v", err)                    // log full trace, once, at the boundary
+	return nil, grpcerror.WrapInternalError(err) // convert to a gRPC status code
+}
+```
+
+**At gRPC handlers**, convert every returned error through a `grpcerror.Wrap*` helper —
+never leak a raw internal error (stack traces must not cross the wire). Available
+(`utils/grpcerror/wrap.go`, all nil-safe): `WrapInternalError`, `WrapInvalidArgument`,
+`WrapCancelled`, `WrapFailedPrecondition`, `WrapUnimplemented`, `WrapNotFound`,
+`WrapResourceExhaustedOrCancelled(ctx, err)`, `WrapWithContext(err, ctx)`. Map sentinels
+to codes with an `errors.Is` chain (`service/query/query_service.go:382`).
+
+**Sentinel errors:** declare `var ErrXxx = errors.New("...")` with a doc comment in a
+`var (...)` block; compare with `errors.Is`, never `==` (the `errname` linter enforces the
+`ErrXxx` / lowercase `xxxError` naming). For a custom error type, implement `Unwrap()` so
+`errors.Is`/`As` traverse it.
+
+## Logging
+
+One unexported package-level logger via Fabric's zap-based `flogging`; no `New()`, no
+per-struct logger, no logger passed as an argument:
+
+```go
+var logger = flogging.MustGetLogger("coordinator")
+```
+
+Use the printf-style methods `Debugf` / `Infof` / `Warnf` / `Errorf` (structured
+key-value fields are not used here). `Debugf` for per-tx / hot-path detail, `Infof` for
+lifecycle, `Warnf` (sparingly) for recoverable conditions, `Errorf("%+v", err)` at
+boundaries. No `Fatal`/`Panic` in services — return an error. Bracket IDs and numbers as
+`[%s]` / `[%d]`.
+
+## Building a service or component
+
+For anything larger than a function — a new service, gRPC server, manager, or pipeline
+stage — read `references/service-construction.md`. It covers the full blueprint with
+citations: the `serve.Service` interface (`Run`/`WaitForReady`/`RegisterService`), the
+struct + `NewXxxService` constructor (open I/O in `Run`, not the constructor), gRPC
+handler style, the config pipeline (`mapstructure`/`validate` tags → viper defaults →
+sample YAML → decoder hooks), Prometheus metrics via `monitoring.Provider`, connection
+wiring, `serve.StartAndServe` bootstrap, and a step-by-step checklist.
+
+Quick essentials:
+- Constructors return concrete `*T` with **no error** for pure in-memory wiring; return
+  `(*T, error)` only when the constructor does I/O (e.g. `newDatabase`).
+- Pass wide dependency lists as a `*xxxConfig` struct, not many positional args (the
+  `revive` `argument-limit` is 4).
+- Config structs use `mapstructure:"kebab-case"` + `validate:"..."` tags — **no `yaml`
+  tags**. Every field needs a `Default*` const and a `v.SetDefault(...)` in
+  `cmd/config/viper.go`, plus an entry in the sample YAML under `cmd/config/samples/`.
+- Adding a `loadgen` `workload.Profile` field also means updating
+  `loadgen_shared.yaml.tmpl` and the env-override test.
+
+## Before you finish
+
+Before you consider the change done (see `CLAUDE.md` and the Makefile):
+
+- `make lint` (or `make lint-go`) — must pass with no errors.
+- **Do not run the full `make test` locally — it takes too long.** Run only the relevant
+  unit and integration tests for the packages you touched (e.g.
+  `go test ./service/vc/... -run TestXxx`), then rely on CI for the full suite and monitor
+  it. Add tests per the `tests` skill.
+- If you changed metrics, run `make generate-metrics-doc`.
+- If you changed `.proto`, run `make proto`.
+
+**Enforced-linter cheat sheet** (from `.golangci.yml`) — write to these up front so lint
+passes the first time:
+
+- `goheader` — Apache-2.0 `/* */` header on every file.
+- `gofumpt` + `goimports` — formatting and 3-group import ordering (run `make lint`, it fixes most).
+- `lll` / `revive line-length-limit` — 120-column lines.
+- `intrange` — use `for range n`. `ireturn` — don't return interfaces. `errname` — `ErrXxx`.
+- `errorlint` — `fmt.Errorf` must use `%w`. `depguard` — no `github.com/pkg/errors`.
+- `gocognit` ≤ 15, `maintidx`, `dupl` — keep functions simple and non-duplicated (or justify with a scoped `//nolint:<linter> // reason`).
+- `revive argument-limit` 4, `function-result-limit` 3 — use a config/param struct or grouped returns beyond these.
+- `godot` — doc comments end with a period (does not apply to log strings).
+- `containedctx` / `fatcontext` — don't store a `context.Context` in a struct (rare, justified exceptions carry `//nolint:containedctx`).
+- `prealloc`, `unparam`, `wastedassign`, `unconvert`, `forcetypeassert`, `nilerr` — the usual correctness/efficiency nits.
+
+`//nolint` must be specific (`//nolint:gocognit // <reason>`) — the `nolintlint` linter
+requires the linter name and the codebase expects a reason.

--- a/.bob/skills/development/SKILL.md
+++ b/.bob/skills/development/SKILL.md
@@ -320,6 +320,10 @@ Before you consider the change done (see `CLAUDE.md` and the Makefile):
   it. Add tests per the `tests` skill.
 - If you changed metrics, run `make generate-metrics-doc`.
 - If you changed `.proto`, run `make proto`.
+- **Audit docs & config for staleness.** After the above pass, dispatch a subagent to
+  run the `doc-audit` skill (keeps this context clean). It auto-fixes the generated docs
+  and reports any prose, agent-instruction, skill, config-sample, or `.tmpl` template
+  your change made obsolete — apply the **Review** suggestions it returns.
 
 **Enforced-linter cheat sheet** (from `.golangci.yml`) — write to these up front so lint
 passes the first time:

--- a/.bob/skills/development/references/service-construction.md
+++ b/.bob/skills/development/references/service-construction.md
@@ -1,0 +1,311 @@
+# Building a service or component
+
+Read this when adding a new service, gRPC server, manager, or pipeline component.
+All patterns are verified across `coordinator`, `vc`, `verifier`, and `sidecar`.
+Cite the model files rather than guessing.
+
+## Table of contents
+
+1. [The `serve.Service` interface](#1-the-serveservice-interface)
+2. [Service struct + constructor](#2-service-struct--constructor)
+3. [Lifecycle: `Run` / `WaitForReady` / `RegisterService`](#3-lifecycle)
+4. [gRPC handler style](#4-grpc-handler-style)
+5. [Config structs and the loading pipeline](#5-config-structs-and-the-loading-pipeline)
+6. [Metrics](#6-metrics)
+7. [Dependency wiring](#7-dependency-wiring)
+8. [Server bootstrap](#8-server-bootstrap)
+9. [New-service checklist](#9-new-service-checklist)
+
+---
+
+## 1. The `serve.Service` interface
+
+A full-lifecycle service implements three methods (`utils/serve/start_serve.go:31`):
+
+```go
+type Service interface {
+	Registerer                              // RegisterService(Servers)
+	Run(ctx context.Context) error          // run until ctx is done
+	WaitForReady(ctx context.Context) bool  // false if ctx ends before ready
+}
+```
+
+You never create a `grpc.Server` yourself — you implement this interface and hand the
+service to `serve.StartAndServe` (see [§8](#8-server-bootstrap)).
+
+## 2. Service struct + constructor
+
+The struct embeds the generated `servicepb.Unimplemented<X>Server`, and holds `*Config`,
+a metrics struct, a `*health.Server`, internal channels/queues, and a `*channel.Ready`.
+Name the constructor `New<Xxx>Service(config)` (the verifier uses plain `New`).
+
+```go
+// service/verifier/verifier_server.go:28
+type Server struct {
+	servicepb.UnimplementedVerifierServer
+	config      *Config
+	metrics     *metrics
+	healthcheck *health.Server
+}
+
+func New(config *Config) *Server {
+	return &Server{
+		config:      config,
+		metrics:     newMonitoring(),
+		healthcheck: serve.DefaultHealthCheckService(),
+	}
+}
+```
+
+Rules:
+- The constructor does **pure in-memory wiring** (channels, metrics, healthcheck). It does
+  **not** open DB or gRPC connections — those happen in `Run`.
+- Return concrete `*T` with **no error** for in-memory wiring. Return `(*T, error)` only
+  when construction does I/O (e.g. `newDatabase(ctx, cfg, metrics) (*database, error)`,
+  `service/vc/database.go:76`, or `sidecar.New` which parses orderer params eagerly).
+- Unexported components use lowercase `newXxx` and log `logger.Info("Initializing
+  new<Xxx>")` as the first line.
+- The body returns a keyed struct literal, one `field: value,` per line.
+
+Model files: `service/coordinator/coordinator.go:110`,
+`service/vc/validator_committer_service.go:72`, `service/sidecar/sidecar.go:85`.
+
+## 3. Lifecycle
+
+### `Run(ctx) error`
+
+Opens resources (with `defer close`), signals ready, fans out workers under an errgroup,
+and blocks on `g.Wait()`:
+
+```go
+// service/vc/validator_committer_service.go:107 (condensed)
+func (vc *ValidatorCommitterService) Run(ctx context.Context) error {
+	db, err := newDatabase(ctx, vc.config.Database, vc.metrics)
+	if err != nil {
+		return err
+	}
+	defer db.close()
+	vc.db = db
+
+	vc.ready.SignalReady()
+	defer vc.ready.Reset()
+
+	g, eCtx := errgroup.WithContext(ctx)
+	g.Go(func() error { vc.monitorQueues(eCtx); return nil })
+	// ... more g.Go(...) worker pools ...
+	if err := g.Wait(); err != nil {
+		return err
+	}
+	return nil
+}
+```
+
+- There is **no separate `Close`/`Stop` on the service** — cleanup is `defer`-based inside
+  `Run`; server-side shutdown is owned by `serve.Servers`.
+- A service with nothing to start just blocks on ctx and returns
+  (`service/verifier/verifier_server.go:52`).
+- A service that must tear down peers on any goroutine's exit wraps with
+  `ctx, cancel := context.WithCancel(ctx); defer cancel()`
+  (`service/coordinator/coordinator.go:184`, `service/sidecar/sidecar.go:141`).
+- Resilient background loops use `retry.Sustain(ctx, profile, op)`
+  (`service/sidecar/sidecar.go:160`).
+
+### `WaitForReady(ctx) bool`
+
+Delegate to a `*channel.Ready`:
+
+```go
+func (vc *ValidatorCommitterService) WaitForReady(ctx context.Context) bool {
+	return vc.ready.WaitForReady(ctx)
+}
+```
+
+A composite service gates its own readiness on sub-managers being ready first
+(`service/coordinator/coordinator.go:218`).
+
+### `RegisterService(serve.Servers)`
+
+Register the gRPC service, the health server, and the monitoring HTTP endpoint. Identical
+shape across all services — no nil checks needed (`NewServers` always builds both servers):
+
+```go
+// service/coordinator/coordinator.go:242
+func (c *Service) RegisterService(s serve.Servers) {
+	servicepb.RegisterCoordinatorServer(s.GRPC, c)
+	healthgrpc.RegisterHealthServer(s.GRPC, c.healthcheck)
+	monitoring.RegisterMonitoringServer(s.HTTP, c.metrics.Provider)
+}
+```
+
+## 4. gRPC handler style
+
+At the boundary: validate input, log full errors, convert every returned error through a
+`grpcerror.Wrap*` helper. Never return a raw internal error.
+
+```go
+// service/vc/validator_committer_service.go:210
+func (vc *ValidatorCommitterService) GetTransactionsStatus(
+	ctx context.Context, query *committerpb.TxIDsBatch,
+) (*committerpb.TxStatusBatch, error) {
+	if len(query.TxIds) == 0 {
+		return nil, grpcerror.WrapInvalidArgument(errors.New("query is empty"))
+	}
+	txIDsStatus, err := vc.db.readStatusWithHeight(ctx, txIDs)
+	if err != nil {
+		logger.Errorf("%+v", err)
+		return nil, grpcerror.WrapInternalError(err)
+	}
+	return &committerpb.TxStatusBatch{Status: txIDsStatus}, nil
+}
+```
+
+**Streaming handlers:** guard a single active stream with `TryLock` (or an atomic CAS)
+returning `WrapFailedPrecondition`, then run send/receive loops in an errgroup bound to
+`stream.Context()`, wrapping `Recv`/`Send` errors with `errors.Wrap`.
+
+```go
+// service/coordinator/coordinator.go:335
+if !c.streamActive.TryLock() {
+	return grpcerror.WrapFailedPrecondition(ErrExistingStreamOrConflictingOp)
+}
+defer c.streamActive.Unlock()
+```
+
+Models: `service/vc/validator_committer_service.go:266` (stream + CAS guard),
+`service/verifier/verifier_server.go:71` (per-stream executor).
+
+## 5. Config structs and the loading pipeline
+
+Per-service `config.go` defines `Config` with `mapstructure:"kebab-case"` +
+`validate:"..."` tags. **No `yaml` tags.** Durations are plain `time.Duration` (decoded
+from strings like `"5s"` by a decoder hook). Endpoints use `connection.Endpoint`; client
+deps use `connection.MultiClientConfig` / `ClientConfig`. Nested optional sub-configs are
+pointers tagged `validate:"required"`. Serving knobs (server/monitoring endpoints, TLS,
+keepalive, rate-limit) live in `serve.Config`, **not** the service config.
+
+```go
+// service/coordinator/config.go:17
+type Config struct {
+	Verifier           connection.MultiClientConfig `mapstructure:"verifier"`
+	ValidatorCommitter connection.MultiClientConfig `mapstructure:"validator-committer"`
+	DependencyGraph    *DependencyGraphConfig       `mapstructure:"dependency-graph" validate:"required"`
+	ChannelBufferSizePerGoroutine int          `mapstructure:"per-channel-buffer-size-per-goroutine" validate:"required,gt=0"`
+	QueueMonitorSamplingTime      time.Duration `mapstructure:"queue-monitor-sampling-time" validate:"required,gt=0"`
+}
+
+const (
+	DefaultServerPort             = 6001
+	DefaultDatabaseMaxConnections = 20
+)
+```
+
+The full pipeline (keep every stage in sync when adding a field):
+
+```
+Config struct (mapstructure) → viper default → sample YAML → env var → decoder hook → docs
+```
+
+- Register defaults in `cmd/config/viper.go` via `v.SetDefault("kebab.key", Default*)`;
+  env vars use prefix `SC_<SERVICE>_` with `-`/`.`→`_`.
+- `readYamlAndSetupLogging[T]` (`cmd/config/app_config.go:90`) reads YAML, applies the
+  `SC_<SVC>_YAML` override, and unmarshals + `validate.Struct`s three structs: logging,
+  `serve.Config`, and your `T`.
+- Custom decode hooks (`time.Duration`, byte sizes, `Endpoint`, `serve.ServerConfig`) live
+  in `cmd/config/config_decoder.go`.
+- Add a sample under `cmd/config/samples/`; comment the **why/implications**, not just the
+  what. For `loadgen` `workload.Profile` fields, also update `loadgen_shared.yaml.tmpl` and
+  the env-override test.
+
+## 6. Metrics
+
+`metrics.go` defines a `perfMetrics` struct that **embeds `*monitoring.Provider`** and
+holds typed prometheus fields. `newXxxMetrics()` calls `monitoring.NewProvider()` then
+`p.NewCounter/NewGauge/NewHistogram(...)` (each auto-registers). Give every metric
+`Namespace`/`Subsystem`/`Name`/`Help`. Update metrics at runtime only through `promutil`
+helpers (`AddToCounter`, `SetGauge`, `Observe`), never raw prometheus calls.
+
+```go
+// service/vc/metrics.go:15
+var buckets = []float64{.0001, .001, .002, .003, .004, .005, .01, .03, .05, .1, .3, .5, 1}
+
+type perfMetrics struct {
+	*monitoring.Provider
+	transactionReceivedTotal      prometheus.Counter
+	preparerInputQueueSize        prometheus.Gauge
+	preparerTxBatchLatencySeconds prometheus.Histogram
+}
+
+func newVCServiceMetrics() *perfMetrics {
+	p := monitoring.NewProvider()
+	return &perfMetrics{
+		Provider: p,
+		transactionReceivedTotal: p.NewCounter(prometheus.CounterOpts{
+			Namespace: "vcservice", Subsystem: "grpc",
+			Name: "received_transaction_total", Help: "Number of transactions received.",
+		}),
+	}
+}
+```
+
+Reuse `monitoring.ThroughputMetrics` / `ConnectionMetrics` bundles where they fit
+(`utils/monitoring/metrics.go`). Run `make generate-metrics-doc` after changes.
+
+## 7. Dependency wiring
+
+Pass dependencies as config. Open connections **in `Run`**, using the `utils/connection`
+dialers, and always `defer connection.CloseConnectionsLog(conn...)`:
+
+```go
+// service/coordinator/validator_committer_manager.go:96
+commonConn, err := connection.NewLoadBalancedConnection(c.clientConfig)
+if err != nil {
+	return fmt.Errorf("failed to create connection to validator persisters: %w", err)
+}
+defer connection.CloseConnectionsLog(commonConn)
+vcm.commonClient = servicepb.NewValidationAndCommitServiceClient(commonConn)
+```
+
+- `NewSingleConnection` — one peer; `NewLoadBalancedConnection` — round-robin over
+  endpoints; `NewConnectionPerEndpoint` — one conn per peer.
+- Managers receive deps via a dedicated `*xxxManagerConfig` struct (channels, clientConfig,
+  metrics, policyManager), wired in the service constructor.
+
+## 8. Server bootstrap
+
+Hand your `serve.Service` to `serve.StartAndServe(ctx, service, serverConfig...)`. It runs
+`service.Run` in an errgroup, gates on `WaitForReady` with `ServiceStartupTimeout`, then
+constructs and serves the gRPC + HTTP servers in the same group — every `g.Go` does
+`defer cancel()` so any exit tears down the whole service
+(`utils/serve/start_serve.go:68`).
+
+Command wiring (cobra → read config → construct → serve),
+`cmd/committer/start_cmd.go:59`:
+
+```go
+var service serve.Service
+switch c := conf.(type) {
+case *coordinator.Config:
+	service = coordinator.NewCoordinatorService(c)
+case *vc.Config:
+	service = vc.NewValidatorCommitterService(ctx, c)
+case *verifier.Config:
+	service = verifier.New(c)
+}
+return serve.StartAndServe(ctx, service, serverConfig)
+```
+
+## 9. New-service checklist
+
+1. `service/<name>/config.go` — `Config` (mapstructure + validate tags), `Default*` consts.
+   Serving knobs go in `serve.Config`, not here.
+2. `service/<name>/metrics.go` — `perfMetrics` embedding `*monitoring.Provider`;
+   `new<X>Metrics()` using `p.New*`.
+3. `service/<name>/<name>.go` — struct embedding `Unimplemented<X>Server` +
+   `config`/`metrics`/`healthcheck`/`ready`; `New<X>Service(cfg)`; `Run` / `WaitForReady`
+   / `RegisterService`; gRPC handlers using `grpcerror.Wrap*`. Package logger at top.
+4. `cmd/config/viper.go` — register every default with `v.SetDefault`.
+5. `cmd/config/app_config.go` — `Read<X>YamlAndSetupLogging` via `readYamlAndSetupLogging[<X>.Config]`.
+6. `cmd/committer/config.go` + `start_cmd.go` — add the service to config dispatch and the
+   `startService` switch → `serve.StartAndServe`.
+7. Sample YAML under `cmd/config/samples/`. Run `make lint`, `make test`, and
+   `make generate-metrics-doc`.

--- a/.bob/skills/doc-audit/SKILL.md
+++ b/.bob/skills/doc-audit/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: doc-audit
+description: >-
+  Audit the repository's documentation, agent instructions, other skills, config
+  samples, and config templates for staleness introduced by a code change — every
+  *.md, *.yaml/*.yml, and *.tmpl file. Use AFTER finishing any development task that
+  touched Go code, config fields, CLI flags, metrics, make targets, scripts, or
+  file/package layout, and whenever the user asks to "check the docs", "audit the
+  docs", or "did I make anything obsolete?". It auto-fixes the repo's generated docs
+  (metrics reference, CLI help, loadgen sample tree) and reports likely-stale prose,
+  agent instructions, skills, and config templates with file:line and a suggested
+  edit. Runs well on a dispatched subagent to keep the parent context clean. It
+  only audits EXISTING files for staleness a code change introduced — do not use
+  it to author or edit documentation (writing a new doc, adding a section,
+  rewriting prose). For writing new Go code use the `development` skill; for
+  tests use `tests`; for PR review use `pr-review`.
+---
+
+# Auditing docs, config, and agent instructions after a change
+
+A development task can quietly invalidate documentation, agent-instruction files,
+other skills, config samples, or config templates: a renamed config field, a moved
+package, a removed CLI flag, a changed make target. This skill audits the whole
+`*.md` / `*.yaml` / `*.tmpl` corpus against the change that just landed.
+
+**Half of this is already deterministic and gated by `make lint`.** Do not reinvent
+it — orchestrate it (Tier A), then spend real effort on the semantic gap nothing
+checks (Tier B).
+
+## Run this on a subagent
+
+Prefer dispatching this skill to a subagent: the corpus grep and the `make build`
+noise would otherwise flood the parent context. The subagent's **only** deliverable
+is the report in the [Report](#report) format below — grounded in the diff, not in
+conversation history — so it hands back cleanly.
+
+## Step 1 — Establish the change set
+
+Everything the audit checks is keyed off the actual diff. Do not audit from memory.
+
+```bash
+base=$(git merge-base main HEAD)
+git diff --stat "$base"   # files touched since branching from main, incl. uncommitted work
+git diff "$base"          # the full diff (committed on this branch + working tree)
+```
+
+`git diff "$base"` covers "branch-vs-main **plus** working tree" in one command. When
+you are on `main`, `base` equals `HEAD`, so it degrades to the uncommitted diff — the
+correct fallback.
+
+From the diff, extract the change vocabulary you will grep for in Step 3:
+
+- **Config fields** — added/renamed/removed `mapstructure:"..."` tags in `*.go`.
+- **CLI flags / commands** — changes under `cmd/` (cobra commands, flag names).
+- **Symbols** — renamed/removed exported and unexported funcs, types, methods.
+- **Paths** — moved/renamed/deleted files and packages.
+- **Service names** — sidecar / coordinator / verifier / vc / query / loadgen / mock.
+- **Metrics** — changes in any `service/*/metrics.go`.
+- **`workload.Profile` fields** — changes under `loadgen/workload/`.
+- **Make targets / scripts** — changes to `Makefile` or `scripts/`.
+
+## Step 2 — Tier A: mechanical checks (auto-fix derived docs)
+
+Always run the full set, regardless of what the diff touched.
+
+```bash
+make build                                                 # needed by the CLI & sample-tree checks
+make check-metrics-doc check-cli-doc check-sample-tree     # read-only; each prints a diff on drift
+go test ./cmd/config/...                                   # every samples/*.yaml must load
+```
+
+For any **check that fails**, run its generator to fix the derived doc in place, then
+record it under **Auto-fixed**:
+
+| Failing check | Fix command | Regenerated file |
+|---|---|---|
+| `check-metrics-doc` | `make generate-metrics-doc` | `docs/metrics_reference.md` |
+| `check-cli-doc` | `make generate-cli-doc` | `docs/cli/committer.md` |
+| `check-sample-tree` | `make generate-sample-tree` | `docs/loadgen-artifacts.md` |
+
+`go test ./cmd/config/...` is **report-only**: a failure means a `cmd/config/samples/*.yaml`
+no longer matches its config struct. That is a code/config bug for the developer — put
+it under **Must-fix**, do not try to "regenerate" a sample.
+
+## Step 3 — Tier B: semantic sweep (report, do not edit)
+
+The judgment pass over the corpus that no tool checks: prose docs, agent-instruction
+files, other skills, block diagrams, and the `.tmpl` config templates (nothing renders
+templates in CI against the config structs, so a renamed field silently rots them).
+
+For each changed artifact from Step 1, grep the corpus and judge each hit against this
+reference map. **Ground every finding in the diff — no speculative findings.**
+
+| Change in code | Files that can go stale |
+|---|---|
+| Config field (`mapstructure` tag) | `cmd/config/samples/*.yaml`, `cmd/config/templates/*.yaml.tmpl`, service docs in `docs/`, the `development` skill's config-pipeline note |
+| CLI flag / command | `docs/cli/committer.md` (Tier A), `docs/setup.md`, `README.md`, `docs/deployment-guide.md`, `docker/README.md` |
+| Service / package / file / symbol | `docs/*.md` prose + `docs/*-block-diagram.md`, `CLAUDE.md`, `AGENTS.md`, `.bob/rules/*.md`, `.bob/skills/*/SKILL.md` (skills cite exact paths/symbols — e.g. the `development` skill's reuse table and `references/service-construction.md`) |
+| Metric | `docs/metrics_reference.md` (Tier A) |
+| `workload.Profile` field | `cmd/config/samples/loadgen.yaml`, `cmd/config/templates/loadgen_shared.yaml.tmpl`, `docs/loadgen-artifacts.md` (Tier A), and the env-override test |
+| Make target / script / dev workflow | `CLAUDE.md`, `AGENTS.md`, `docs/setup.md`, any skill that names the command |
+
+Grep the whole corpus, not just `docs/`:
+
+```bash
+git grep -n "<old-name>" -- '*.md' '*.yaml' '*.yml' '*.tmpl'
+```
+
+For each hit ask: does the change make this reference **false, obsolete, or incomplete**
+(e.g. a new required config field missing from a sample/template, a renamed flag, a
+deleted file still cited)? If yes, it is a finding.
+
+## Report
+
+Return one Markdown report, these four sections, in this order. Omit a section only if
+it is empty (but always emit **Clean** when there are no findings at all).
+
+```markdown
+## doc-audit report
+
+### Auto-fixed
+- `docs/metrics_reference.md` — regenerated via `make generate-metrics-doc` (metric `xxx_total` renamed).
+
+### Must-fix
+- `cmd/config/samples/vc.yaml` — fails to load: unknown field `old-name` (renamed to `new-name` in service/vc/config.go). Update the sample.
+
+### Review
+- `docs/validator-committer.md:88` — references `resource-limits.max-workers-for-x`, renamed to `...max-workers-for-y`. Suggested edit: rename the key in the config block.
+- `cmd/config/templates/vc.yaml.tmpl:14` — templates the removed field `min-transaction-batch-size`. Suggested edit: drop the line.
+
+### Clean
+- No stale references found for: <list the changed artifacts you checked and cleared>.
+```
+
+## Guardrails
+
+- **Never edit** prose, agent-instruction, skill, or `.tmpl` files. Tier A regenerates
+  *derived* docs only; everything else is a suggested edit in the report.
+- **Diff-grounded only.** Every finding must trace to a specific change in Step 1's
+  diff. Do not report pre-existing doc issues unrelated to this change.
+- **State uncertainty.** If you cannot confirm a reference is stale, mark it
+  "⚠️ possible" in **Review** rather than asserting it.
+- **No silent scope cuts.** If you skip part of the corpus (e.g. `make build` fails so
+  Tier A could not run), say so explicitly in the report.

--- a/.bob/skills/pr-review/SKILL.md
+++ b/.bob/skills/pr-review/SKILL.md
@@ -45,6 +45,14 @@ Run `gh auth status`. If it fails, respond ONLY with:
 Before starting any review, read:
 - `@guidelines.md` — coding standards, review comment labels, simplicity principles
 - `@docs/core-concurrency-pattern.md` — required concurrency patterns
+- `@.claude/skills/development/SKILL.md` — the conventions for writing NEW code (code
+  ordering/caller-before-callee, errgroup + context-aware channels, error handling, Go 1.26
+  idioms, and reuse of `utils/` + `fabric-x-common` helpers). New or changed code that
+  deviates from this skill is a review finding — cite the specific convention it breaks.
+- `@.claude/skills/tests/SKILL.md` — the testing conventions (table-driven + `t.Parallel`,
+  `require` over `assert`, `require.Eventually`/`EventuallyWithT` over sleeps, `t.Helper`/
+  `t.Cleanup`, `test_exports.go`, metrics helpers, and reuse of `testcrypto`/`tlsgen`
+  fixtures). Judge changed test code against this skill and flag deviations.
 
 ## Cognitive Discipline (Hallucination Prevention)
 
@@ -367,7 +375,7 @@ Verify against `@docs/core-concurrency-pattern.md`:
 
 ### 6. Error Information Disclosure
 
-- ✅ `logger.ErrorStackTrace(err)` for internal logging; `grpcerror.WrapInternalError(err)` for clients
+- ✅ `logger.Errorf("%+v", err)` for internal logging (the `%+v` verb renders the stack trace); `grpcerror.WrapInternalError(err)` for clients
 - ❌ Flag handlers returning raw `err`; error messages containing file paths, hostnames, or connection strings
 
 ### 7. Protobuf Backward Compatibility

--- a/.bob/skills/tests/SKILL.md
+++ b/.bob/skills/tests/SKILL.md
@@ -39,6 +39,18 @@ This document provides specific guidelines for writing and running tests in the 
 - Use `require.ErrorContains()` instead of `require.Error()` and then `require.Contains()`
 - Address lint issues - run `make lint`
 
+## Reusing Test Fixtures & Helpers
+
+Don't hand-roll crypto, TLS, config-block, or service/DB setup — reuse existing helpers:
+
+- **In-process harnesses (this repo):** `test.RunServiceForTest` / `test.ServeForTest` ([`utils/test/serve.go`](../../utils/test/serve.go)), `testdb.PrepareTestEnv` + `testdb.RunTestMain` (`utils/testdb`), and the hand-written mocks in `mock/`.
+- **Proto assertions (this repo):** `test.RequireProtoEqual` / `test.RequireProtoElementsMatch` (`utils/test/require_proto.go`) — never compare protos with `require.Equal`. Both accept `require.TestingT`, so they also work inside `require.EventuallyWithT`.
+- **MSP / identity / Fabric config blocks:** `github.com/hyperledger/fabric-x-common/utils/testcrypto` — `CreateOrExtendConfigBlockWithCrypto`, `ConfigBlock`, `PrepareBlockHeaderAndMetadata`, `GetPeersIdentities` / `GetConsenterIdentities` / `GetSigningIdentities` / `GetPeersMspDirs` / `GetConsenterMspDirs`.
+- **TLS test material:** `github.com/hyperledger/fabric-x-common/common/crypto/tlsgen` — `tlsgen.NewCA()`, `CA`, `CertKeyPair`.
+- **Generate crypto material:** `github.com/hyperledger/fabric-x-common/tools/cryptogen`.
+
+For authoring the production code these tests cover, use the `development` skill.
+
 ## Table-Driven Tests Structure
 
 ### DO NOT Use Nested Test Groups

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,9 +55,8 @@ Configuration samples are available in `cmd/config/samples/`.
 
 ## Development Conventions
 
-Follow the **`development` skill** (`.claude/skills/development/SKILL.md`) whenever you write
-or change Go code — it is the authoritative, detailed source for these conventions and keeps
-them in one place. In brief:
+Follow the **`development` skill** whenever you write or change Go code — it is the
+authoritative, detailed source for these conventions and keeps them in one place. In brief:
 
 - **Simplicity first** — concrete types over interfaces, generics only for `utils/`-style
   plumbing, no callbacks/functions-as-arguments, explicit over clever (`guidelines.md`).
@@ -133,7 +132,7 @@ Detailed architectural documentation is available in the `docs/` directory:
 
 ### Adding a New Service
 
-See `.claude/skills/development/references/service-construction.md` for the full blueprint
+See the `development` skill's service-construction reference for the full blueprint
 (struct + constructor, `serve.Service` lifecycle, gRPC handlers, config pipeline, metrics,
 wiring) with a step-by-step checklist. High level:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,32 +55,21 @@ Configuration samples are available in `cmd/config/samples/`.
 
 ## Development Conventions
 
-### Code Philosophy: Simplicity First
+Follow the **`development` skill** (`.claude/skills/development/SKILL.md`) whenever you write
+or change Go code — it is the authoritative, detailed source for these conventions and keeps
+them in one place. In brief:
 
-This project strongly emphasizes **simple, readable code over clever abstractions**. Key principles from `guidelines.md`:
+- **Simplicity first** — concrete types over interfaces, generics only for `utils/`-style
+  plumbing, no callbacks/functions-as-arguments, explicit over clever (`guidelines.md`).
+- **Error handling** — `errors.New/Newf/Wrap/Wrapf` (`cockroachdb/errors`) at the origin,
+  `fmt.Errorf("...%w", err)` to add context, `logger.Errorf("%+v", err)` at boundaries, and
+  `utils/grpcerror` at gRPC edges.
+- **Code organization** — collate a struct's methods together; place a method above the
+  functions it calls (caller before callee).
+- **Reuse `utils/` and `fabric-x-common` helpers**; run `make lint` (or `make lint-go`).
 
-1. **Avoid Premature Abstraction**: Don't introduce interfaces, generics, or complex patterns unless there's a clear, compelling need
-2. **Minimize Interfaces**: Use concrete types by default; interfaces only for truly pluggable architectures
-3. **Limit Generics**: Use sparingly for simple utility functions; avoid for core business logic
-4. **Avoid Function Arguments**: Don't pass functions as callbacks; prefer interfaces with the Strategy Pattern if pluggability is needed
-5. **Explicit Over Clever**: Favor explicit, slightly longer code over compact but hard-to-understand solutions
-
-### Error Handling
-
-The project uses `github.com/cockroachdb/errors` for comprehensive error handling:
-
-1. **Capture Stack Traces at Origin**: Use `errors.New`, `errors.Newf`, `errors.Wrap`, or `errors.Wrapf` when first encountering an error
-2. **Add Context Without Duplicating Traces**: Use `fmt.Errorf` with `%w` to add context while preserving the original stack trace
-3. **Log Full Details at Exit Points**: Use `logger.ErrorStackTrace(err)` at service boundaries (e.g., gRPC handlers)
-4. **Convert to gRPC Errors**: At gRPC boundaries, convert internal errors to appropriate status codes using helpers in `utils/grpcerror`
-
-#### Code Guidelines
-
-- avoid callbacks when possible
-- avoid code duplication
-- Collate methods of the same struct together
-- Order the methods such that the method user is before the method declaration
-- Address lint issues - run `make lint` or `make lint-go` for Go code linting only.
+See the skill for concurrency (`errgroup` + `utils/channel`), Go 1.26 idioms,
+service/config/metrics structure, and the full linter cheat sheet.
 
 ### Performance Considerations
 
@@ -144,6 +133,10 @@ Detailed architectural documentation is available in the `docs/` directory:
 
 ### Adding a New Service
 
+See `.claude/skills/development/references/service-construction.md` for the full blueprint
+(struct + constructor, `serve.Service` lifecycle, gRPC handlers, config pipeline, metrics,
+wiring) with a step-by-step checklist. High level:
+
 1. Define protobuf service in `api/servicepb/`
 2. Generate code: `make proto`
 3. Implement service in `service/<name>/`
@@ -182,7 +175,7 @@ Before submitting a PR:
 - [ ] Tests cover key functionality and edge cases
 - [ ] Documentation/comments explain complex logic
 - [ ] `make lint` passes without errors
-- [ ] `make test` passes all tests
+- [ ] Relevant unit/integration tests pass locally (don't run the full `make test` locally — too slow); rely on CI for the full suite and monitor it
 - [ ] Benchmarks run if performance-critical code changed
 
 ## Getting Help

--- a/guidelines.md
+++ b/guidelines.md
@@ -186,13 +186,13 @@ package and standard Go practices for clarity and detailed diagnostics.
 
 3.  **Log Full Error Details at Exit Points:** At the boundaries or exit points of logical operations
     (e.g., within a gRPC handler just before returning a response, or finishing a background task), log the 
-    complete error details. This *must* include the full stack trace. Use a dedicated logging function like
-    `logger.ErrorStackTrace(err)` which is designed to extract and format the stack trace contained
+    complete error details. This *must* include the full stack trace. Use `logger.Errorf("%+v", err)`:
+    the `%+v` verb extracts and formats the stack trace contained
     within the `cockroachdb/errors` error object.
 
 4.  **Handle Errors at gRPC Boundaries:** You cannot directly return stack traces over a gRPC connection.
     Instead, after logging the detailed internal error (as per point 3), convert the error into an 
-    appropriate gRPC status code. Use helper functions, preferably located in `utils/gprcerror`, to map 
+    appropriate gRPC status code. Use helper functions, preferably located in `utils/grpcerror`, to map 
     internal error types or conditions to standard gRPC codes (e.g., `codes.Internal` for unexpected 
     server errors, `codes.InvalidArgument` for validation failures, `codes.NotFound`, etc.). This provides
     the client with a meaningful, standardized error without exposing internal implementation details
@@ -202,9 +202,9 @@ package and standard Go practices for clarity and detailed diagnostics.
         func (s *server) MyGRPCHandler(ctx context.Context, req *pb.Request) (*pb.Response, error) {
             res, err := s.service.DoSomething(ctx, req.Data)
             if err != nil {
-                logger.ErrorStackTrace(err) // Log the full error + stack trace internally
+                logger.Errorf("%+v", err) // Log the full error + stack trace internally
                 // Convert to gRPC status error for the client
-                return nil, gprcerror.WrapInternalError(err) 
+                return nil, grpcerror.WrapInternalError(err) 
             }
             return &pb.Response{Result: res}, nil
         }


### PR DESCRIPTION
#### Type of change

- New feature
- Documentation update

#### Description

- Add a `development` skill capturing this repo's conventions for writing new Go
  code: code ordering (caller-before-callee, struct grouping, inline single-use
  helpers), concurrency (`errgroup` + `utils/channel` wrappers), Go 1.26 idioms,
  error handling, and logging — plus a `references/service-construction.md`
  blueprint for services/config/metrics.
- Add a `doc-audit` skill: after a development task it audits every
  `*.md`/`*.yaml`/`*.tmpl` file for staleness the change introduced. Tier A runs the
  repo's existing generated-doc checks (`check-metrics-doc` / `check-cli-doc` /
  `check-sample-tree`) and regenerates them on drift, and flags config samples that no
  longer load; Tier B is a diff-scoped grep-and-judge sweep over docs, agent
  instructions, other skills, config samples, and config templates, reporting
  `file:line` with a suggested fix (report-only — it never edits prose). It is wired
  into the `development` skill's "Before you finish" checklist (dispatched on a
  subagent to keep context clean) and is also manually invocable.
- Wire the skill set together: `pr-review` now reads the `development` and `tests`
  skills and flags deviations as findings; `tests` gains a "Reusing Test Fixtures &
  Helpers" section (repo harnesses + `fabric-x-common` `testcrypto`/`tlsgen`).
- Fix stale references in `AGENTS.md` and `guidelines.md`: `logger.ErrorStackTrace(err)`
  does not exist — the real idiom is `logger.Errorf("%+v", err)`; also correct the
  `gprcerror` -> `grpcerror` typo in `guidelines.md`.
- Trim `AGENTS.md`'s now-duplicated convention prose to a summary that points at the
  `development` skill as the source of truth.

#### Additional details (Optional)

The `development` skill was validated with a with-skill vs. baseline comparison across 6
coding tasks; the skill improved adherence on the subtle conventions a capable baseline
still missed (context-aware `channel.NewReader/Writer`, `%+v` boundary logging).

The `doc-audit` skill was validated with a triggering A/B (20 realistic queries, recall
1.0 on should-trigger cases) and a with-skill vs. skill-free-baseline benchmark on
config-rename scenarios: both configurations detected all introduced staleness, with the
skill adding deterministic generated-doc coverage and a structured, non-destructive
report.
