### PR TITLE
[loadgen] Consolidate workload config; batch build/sign generation pipeline

### DIFF
--- a/cmd/config/app_config_test.go
+++ b/cmd/config/app_config_test.go
@@ -411,14 +411,15 @@ func TestReadConfigLoadGen(t *testing.T) {
 				},
 			},
 			LoadProfile: &workload.Profile{
-				Key: workload.KeyProfile{Size: 32},
 				Block: workload.BlockProfile{
 					MaxSize:       500,
 					MinSize:       10,
 					PreferredRate: time.Second,
 				},
 				Transaction: workload.TransactionProfile{
-					ReadWriteCount: 2,
+					KeySize:           32,
+					ReadWriteCount:    2,
+					InvalidSignatures: 0.1,
 				},
 				Policy: workload.PolicyProfile{
 					ChannelID: "mychannel",
@@ -434,9 +435,6 @@ func TestReadConfigLoadGen(t *testing.T) {
 					}},
 					PeerOrganizationCount: 2,
 					ArtifactsPath:         "/root/artifacts",
-				},
-				Conflicts: workload.ConflictProfile{
-					InvalidSignatures: 0.1,
 				},
 				Seed:    12345,
 				Workers: 1,
@@ -468,10 +466,10 @@ func TestReadConfigLoadGen(t *testing.T) {
 	}
 }
 
-// TestLoadGenProbabilityValidation exercises the decode-and-validate path for the
-// loadgen conflict probabilities: values inside the closed interval [0,1] are
-// accepted, values outside are rejected by validation. This also covers the
-// per-dependency probability, which lives inside a slice (validated via "dive").
+// TestLoadGenProbabilityValidation exercises the decode-and-validate path for the loadgen transaction
+// conflict probabilities: values inside the closed interval [0,1] are accepted, values outside are
+// rejected by validation. This also covers the per-dependency probability, which lives inside a slice
+// (validated via "dive").
 func TestLoadGenProbabilityValidation(t *testing.T) {
 	t.Parallel()
 	read := func(t *testing.T, yaml string) error {
@@ -481,10 +479,10 @@ func TestLoadGenProbabilityValidation(t *testing.T) {
 		return unmarshal(v, &loadgen.ClientConfig{})
 	}
 	invalidSig := func(probability string) string {
-		return "load-profile:\n  conflicts:\n    invalid-signatures: " + probability + "\n"
+		return "load-profile:\n  transaction:\n    invalid-signatures: " + probability + "\n"
 	}
 	dependency := func(probability string) string {
-		return "load-profile:\n  conflicts:\n    dependencies:\n" +
+		return "load-profile:\n  transaction:\n    dependencies:\n" +
 			"      - probability: " + probability + "\n        src: read\n        dst: write\n"
 	}
 

--- a/cmd/config/samples/loadgen.yaml
+++ b/cmd/config/samples/loadgen.yaml
@@ -116,9 +116,6 @@ orderer-client:
 
 # Load profile configuration defining transaction characteristics and generation parameters
 load-profile:
-  key:
-    # Size of generated keys in bytes. Affects transaction payload size and storage requirements.
-    size: 32
   # block describes generate block characteristics
   # (when applying load to the VC or Verifier, blocks are translated to batches).
   # The generated block size is aimed to be max-size, if the generated
@@ -142,6 +139,8 @@ load-profile:
   #   - blind-write (write-count): Writes a key without reading it first.
   # The count for each type is a fixed number of operations per transaction (default: 0).
   transaction:
+    # Size of generated keys in bytes. Affects transaction payload size and storage requirements.
+    key-size: 32
     # Size in bytes of the metadata for each transaction (0 means nil value).
     # metadata-size: 0
     # Size in bytes of the value written for each read-write operation (0 means nil value).
@@ -154,6 +153,20 @@ load-profile:
     read-write-count: 2
     # Number of blind-write operations per transaction.
     # write-count: 0
+    # Fraction of transactions to generate with invalid signatures (0.0 to 1.0).
+    # Used to test signature verification and error handling. 0.1 = 10% invalid.
+    # Independent Bernoulli trial applied per transaction.
+    invalid-signatures: 0.1
+    # Dependencies inject read-write conflicts between transactions to test MVCC validation.
+    # Each dependency type is an independent Bernoulli trial applied per transaction.
+    # 'src' and 'dst' specify the operation types that create the dependency:
+    #   "read", "write", or "read-write" (both read and write the same key).
+    # 'gap' controls the distance (in transaction count) between dependent transactions (min: 1, default: 1).
+    # dependencies:
+    #   - probability: 0.05   # 5% of transactions will have this dependency
+    #     gap: 1              # Dependent transaction is the immediately next one
+    #     src: read-write     # Source transaction reads and writes a key
+    #     dst: read-write     # Destination transaction reads and writes the same key
   # Policy configuration for transaction endorsement and validation
   policy:
     # Channel ID for which transactions are generated. Must match the target blockchain channel.
@@ -204,21 +217,6 @@ load-profile:
     # which will be printed by the loadgen CLI tool.
     # If this path does not exist, or it is empty, the artifacts will be generated into it.
     artifacts-path: /root/artifacts
-  # Conflict and error injection configuration for testing system resilience.
-  conflicts:
-    # Fraction of transactions to generate with invalid signatures (0.0 to 1.0).
-    # Used to test signature verification and error handling. 0.1 = 10% invalid.
-    invalid-signatures: 0.1
-    # Dependencies inject read-write conflicts between transactions to test MVCC validation.
-    # Each dependency type is an independent Bernoulli trial applied per transaction.
-    # 'src' and 'dst' specify the operation types that create the dependency:
-    #   "read", "write", or "read-write" (both read and write the same key).
-    # 'gap' controls the distance (in transaction count) between dependent transactions (min: 1, default: 1).
-    # dependencies:
-    #   - probability: 0.05   # 5% of transactions will have this dependency
-    #     gap: 1              # Dependent transaction is the immediately next one
-    #     src: read-write     # Source transaction reads and writes a key
-    #     dst: read-write     # Destination transaction reads and writes the same key
   # Random seed for reproducible transaction generation. Same seed produces same transaction sequence.
   seed: 12345
   # Number of worker goroutines for parallel transaction generation.

--- a/cmd/config/templates/loadgen_shared.yaml.tmpl
+++ b/cmd/config/templates/loadgen_shared.yaml.tmpl
@@ -26,11 +26,12 @@ server:
 load-profile:
   block:
     max-size: {{ .BlockSize }}
-  key:
-    size: 32
   transaction:
+    key-size: 32
     metadata-size: 150
     read-write-count: 2
+    invalid-signatures: 0
+    dependencies:
   policy:
     channel-id: {{ .Policy.ChannelID }}
     artifacts-path: {{ .Policy.ArtifactsPath }}
@@ -41,9 +42,6 @@ load-profile:
         scheme: {{ $element.Scheme }}
         seed: {{ $element.Seed }}
       {{ end }}
-  conflicts:
-    invalid-signatures: 0
-    dependencies:
   seed: 12345
   workers: {{ .LoadGenWorkers }}
 

--- a/loadgen/client.go
+++ b/loadgen/client.go
@@ -80,7 +80,10 @@ func NewLoadGenClient(conf *ClientConfig) (*Client, error) {
 	}
 
 	// After creating the artifacts, we can create the stream.
-	c.txStream = workload.NewTxStream(conf.LoadProfile, conf.Stream)
+	c.txStream, err = workload.NewTxStream(conf.LoadProfile, conf.Stream)
+	if err != nil {
+		return nil, err
+	}
 
 	c.adapter = adapter
 	conf.Generate = adapters.PhasesIntersect(conf.Generate, adapter.Supports())

--- a/loadgen/client_test_utils.go
+++ b/loadgen/client_test_utils.go
@@ -37,9 +37,9 @@ func DefaultClientConf(t *testing.T) *ClientConfig {
 	t.Helper()
 	return &ClientConfig{
 		LoadProfile: &workload.Profile{
-			Key:   workload.KeyProfile{Size: 32},
 			Block: workload.BlockProfile{MaxSize: defaultBlockSize},
 			Transaction: workload.TransactionProfile{
+				KeySize:        32,
 				ReadWriteCount: 2,
 			},
 			Policy: workload.PolicyProfile{

--- a/loadgen/workload/config.go
+++ b/loadgen/workload/config.go
@@ -34,10 +34,8 @@ type Probability = float64
 // The items order, however, might be affected by other parameters.
 type Profile struct {
 	Block       BlockProfile       `mapstructure:"block" yaml:"block"`
-	Key         KeyProfile         `mapstructure:"key" yaml:"key"`
 	Transaction TransactionProfile `mapstructure:"transaction" yaml:"transaction"`
 	Policy      PolicyProfile      `mapstructure:"policy" yaml:"policy"`
-	Conflicts   ConflictProfile    `mapstructure:"conflicts" yaml:"conflicts"`
 
 	// The seed to generate the seeds for each worker
 	Seed int64 `mapstructure:"seed" yaml:"seed"`
@@ -47,12 +45,6 @@ type Profile struct {
 	// To ensure responsibility of items between runs (e.g., for query)
 	// the number of workers must be preserved.
 	Workers uint32 `mapstructure:"workers" yaml:"workers"`
-}
-
-// KeyProfile describes generated keys characteristics.
-type KeyProfile struct {
-	// Size is the size of the key to generate.
-	Size uint32 `mapstructure:"size" yaml:"size"`
 }
 
 // BlockProfile describes generate block characteristics
@@ -74,22 +66,21 @@ type BlockProfile struct {
 }
 
 // TransactionProfile describes generate TX characteristics.
+// Note that each of the conflict probabilities are independent bernoulli distributions.
 type TransactionProfile struct {
-	// The sizes of the values/metadata to generate (size=0 => value=nil)
-	MetadataSize        uint32 `mapstructure:"metadata-size" yaml:"metadata-size"`
+	// The byte sizes of the generated key/values/metadata (size=0 => nil), ordered key, value, metadata.
+	KeySize             uint32 `mapstructure:"key-size" yaml:"key-size"`
 	ReadWriteValueSize  uint32 `mapstructure:"read-write-value-size" yaml:"read-write-value-size"`
 	BlindWriteValueSize uint32 `mapstructure:"blind-write-value-size" yaml:"blind-write-value-size"`
+	MetadataSize        uint32 `mapstructure:"metadata-size" yaml:"metadata-size"`
+
 	// The number of keys to generate (read ver=nil)
 	ReadOnlyCount uint32 `mapstructure:"read-only-count" yaml:"read-only-count"`
 	// The number of keys to generate (read ver=nil/write)
 	ReadWriteCount uint32 `mapstructure:"read-write-count" yaml:"read-write-count"`
 	// The number of keys to generate (write)
 	BlindWriteCount uint32 `mapstructure:"write-count" yaml:"write-count"`
-}
 
-// ConflictProfile describes the TX conflict characteristics.
-// Note that each of the conflicts' probabilities are independent bernoulli distributions.
-type ConflictProfile struct {
 	// Probability of invalid signatures [0,1] (default: 0)
 	InvalidSignatures Probability `mapstructure:"invalid-signatures" yaml:"invalid-signatures" validate:"gte=0,lte=1"`
 	// Dependencies list of dependencies

--- a/loadgen/workload/conflicts.go
+++ b/loadgen/workload/conflicts.go
@@ -11,8 +11,6 @@ import (
 	"math/rand"
 
 	"github.com/hyperledger/fabric-x-common/api/applicationpb"
-
-	"github.com/hyperledger/fabric-x-committer/utils/testsig"
 )
 
 // Dependency types.
@@ -23,12 +21,6 @@ const (
 )
 
 type (
-	// signTxModifier signs transactions according to the conflicts profile.
-	signTxModifier struct {
-		invalidSignGenerator *bernoulliGenerator
-		invalidSignature     []byte
-	}
-
 	// dependenciesModifier adds dependencies conflicts according to the conflict profile.
 	dependenciesModifier struct {
 		keyGenerator    *ByteArrayGenerator
@@ -51,30 +43,12 @@ type (
 	}
 )
 
-func newSignTxModifier(rnd *rand.Rand, profile *Profile) *signTxModifier {
-	return &signTxModifier{
-		invalidSignGenerator: &bernoulliGenerator{rnd: rnd, probability: profile.Conflicts.InvalidSignatures},
-		invalidSignature:     []byte("dummy"),
-	}
-}
-
-// Modify signs a transaction.
-func (g *signTxModifier) Modify(tx *applicationpb.Tx) {
-	if g.invalidSignGenerator.Next() {
-		// Pre-assigning prevents TxBuilder from re-signing the TX.
-		tx.Endorsements = make([]*applicationpb.Endorsements, len(tx.Namespaces))
-		for i := range len(tx.Namespaces) {
-			tx.Endorsements[i] = testsig.CreateEndorsementsForThresholdRule(g.invalidSignature)[0]
-		}
-	}
-}
-
 func newTxDependenciesModifier(
 	rnd *rand.Rand, profile *Profile,
 ) *dependenciesModifier {
 	return &dependenciesModifier{
-		keyGenerator: &ByteArrayGenerator{Size: profile.Key.Size, Source: rnd},
-		dependencies: Map(profile.Conflicts.Dependencies, func(
+		keyGenerator: &ByteArrayGenerator{Size: profile.Transaction.KeySize, Source: rnd},
+		dependencies: Map(profile.Transaction.Dependencies, func(
 			_ int, value DependencyDescription,
 		) dependencyDesc {
 			return dependencyDesc{

--- a/loadgen/workload/seeder.go
+++ b/loadgen/workload/seeder.go
@@ -20,7 +20,7 @@ func newSeedersAndKeyGens(profile *Profile) ([]seeder, []*ByteArrayGenerator) {
 	s := seeder{seed: rand.New(rand.NewSource(profile.Seed))}
 	keyGens := make([]*ByteArrayGenerator, profile.Workers)
 	for i := range profile.Workers {
-		keyGens[i] = &ByteArrayGenerator{Size: profile.Key.Size, Source: s.nextSeed()}
+		keyGens[i] = &ByteArrayGenerator{Size: profile.Transaction.KeySize, Source: s.nextSeed()}
 	}
 	seeders := make([]seeder, profile.Workers)
 	for i := range profile.Workers {

--- a/loadgen/workload/stream.go
+++ b/loadgen/workload/stream.go
@@ -29,14 +29,18 @@ func NewTxStream(
 	profile *Profile,
 	options *StreamOptions,
 	modifierGenerators ...Generator[Modifier],
-) *TxStream {
+) (*TxStream, error) {
+	gens, err := newIndependentTxGenerators(profile, modifierGenerators...)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create tx generators")
+	}
 	queue := make(chan []*servicepb.LoadGenTx, max(options.BuffersSize, 1))
 	return &TxStream{
 		options:        options,
 		queue:          queue,
-		gens:           newIndependentTxGenerators(profile, modifierGenerators...),
+		gens:           gens,
 		rateController: NewConsumerRateController(options.RateLimit, queue),
-	}
+	}, nil
 }
 
 // Run starts the stream workers.
@@ -45,11 +49,20 @@ func (s *TxStream) Run(ctx context.Context) error {
 	g, gCtx := errgroup.WithContext(ctx)
 	for _, gen := range s.gens {
 		g.Go(func() error {
-			ingestBatchesToQueue(gCtx, s.queue, gen, int(s.options.GenBatch))
-			return nil
+			return s.generateBatches(gCtx, gen)
 		})
 	}
 	return errors.Wrap(g.Wait(), "stream finished")
+}
+
+// generateBatches builds and signs batches from gen and writes them to the stream's queue
+// until the context ends.
+func (s *TxStream) generateBatches(ctx context.Context, gen *IndependentTxGenerator) error {
+	batchSize := max(int(s.options.GenBatch), 1)
+	q := channel.NewWriter(ctx, s.queue)
+	for q.Write(gen.buildAndSignBatch(batchSize)) {
+	}
+	return nil
 }
 
 // AppendBatch appends a batch to the stream.
@@ -72,14 +85,4 @@ func (s *TxStream) SetRate(rate uint64) {
 // generators from the same Stream can be used concurrently.
 func (s *TxStream) MakeGenerator() *ConsumerRateController[*servicepb.LoadGenTx] {
 	return s.rateController.InstantiateWorker()
-}
-
-func ingestBatchesToQueue[T any](ctx context.Context, c chan<- []T, g Generator[T], batchSize int) {
-	batchGen := &MultiGenerator[T]{
-		Gen:   g,
-		Count: max(batchSize, 1),
-	}
-	q := channel.NewWriter(ctx, c)
-	for q.Write(batchGen.Next()) {
-	}
 }

--- a/loadgen/workload/stream_test.go
+++ b/loadgen/workload/stream_test.go
@@ -109,7 +109,7 @@ func BenchmarkGenTx(b *testing.B) {
 
 func requireValidKey(t *testing.T, key []byte, profile *Profile) {
 	t.Helper()
-	require.Len(t, key, int(profile.Key.Size))
+	require.Len(t, key, int(profile.Transaction.KeySize))
 	require.Positive(t, SumInt(key))
 }
 
@@ -248,7 +248,7 @@ func TestGenInvalidSigTx(t *testing.T) {
 	t.Parallel()
 	p := DefaultProfile(1)
 	p.Policy.NamespacePolicies[DefaultGeneratedNamespaceID].Scheme = signature.Ecdsa
-	p.Conflicts.InvalidSignatures = 0.2
+	p.Transaction.InvalidSignatures = 0.2
 
 	c := startTxGeneratorUnderTest(t, p, defaultStreamOptions())
 	g := c.MakeGenerator()
@@ -267,7 +267,7 @@ func TestGenDependentTx(t *testing.T) {
 	t.Parallel()
 	p := DefaultProfile(1)
 	p.Policy.NamespacePolicies[DefaultGeneratedNamespaceID].Scheme = signature.NoScheme
-	p.Conflicts.Dependencies = []DependencyDescription{
+	p.Transaction.Dependencies = []DependencyDescription{
 		{
 			Gap:         1,
 			Src:         "write",

--- a/loadgen/workload/stream_test.go
+++ b/loadgen/workload/stream_test.go
@@ -82,7 +82,8 @@ func BenchmarkGenTx(b *testing.B) {
 	flogging.ActivateSpec("fatal")
 	//nolint:thelper // false positive.
 	genericBench(b, func(b *testing.B, p *Profile) {
-		t := NewTxStream(p, defaultBenchStreamOptions())
+		t, err := NewTxStream(p, defaultBenchStreamOptions())
+		require.NoError(b, err)
 
 		ctx := b.Context()
 		// Start the timer before creating the service: the stream generates
@@ -191,7 +192,8 @@ func startTxGeneratorUnderTest(
 	t *testing.T, profile *Profile, options *StreamOptions, modifierGenerators ...Generator[Modifier],
 ) *TxStream {
 	t.Helper()
-	g := NewTxStream(profile, options, modifierGenerators...)
+	g, err := NewTxStream(profile, options, modifierGenerators...)
+	require.NoError(t, err)
 	test.RunServiceForTest(t.Context(), t, g.Run, nil)
 	return g
 }

--- a/loadgen/workload/test_export.go
+++ b/loadgen/workload/test_export.go
@@ -32,10 +32,10 @@ func GenerateTransactions(tb testing.TB, p *Profile, count int) []*servicepb.Loa
 // DefaultProfile is used for testing and benchmarking.
 func DefaultProfile(workers uint32) *Profile {
 	return &Profile{
-		Key: KeyProfile{Size: 32},
 		// We use a small block to reduce the CPU load during tests.
 		Block: BlockProfile{MaxSize: 10},
 		Transaction: TransactionProfile{
+			KeySize:            32,
 			ReadWriteValueSize: 32,
 			ReadWriteCount:     2,
 		},
@@ -44,9 +44,8 @@ func DefaultProfile(workers uint32) *Profile {
 				DefaultGeneratedNamespaceID: {Scheme: signature.NoScheme},
 			},
 		},
-		Conflicts: ConflictProfile{InvalidSignatures: 0},
-		Seed:      249822374033311501,
-		Workers:   workers,
+		Seed:    249822374033311501,
+		Workers: workers,
 	}
 }
 

--- a/loadgen/workload/test_export.go
+++ b/loadgen/workload/test_export.go
@@ -24,9 +24,10 @@ func GenerateTransactions(tb testing.TB, p *Profile, count int) []*servicepb.Loa
 		p = DefaultProfile(1)
 	}
 	p.Workers = 1
-	g := newIndependentTxGenerators(p)
+	g, err := newIndependentTxGenerators(p)
+	require.NoError(tb, err)
 	require.Len(tb, g, 1)
-	return GenerateArray(g[0], count)
+	return g[0].buildAndSignBatch(count)
 }
 
 // DefaultProfile is used for testing and benchmarking.

--- a/loadgen/workload/tx.go
+++ b/loadgen/workload/tx.go
@@ -13,10 +13,16 @@ import (
 
 	"github.com/hyperledger/fabric-x-committer/api/servicepb"
 	"github.com/hyperledger/fabric-x-committer/utils"
+	"github.com/hyperledger/fabric-x-committer/utils/testsig"
 )
 
+// invalidSignatureBytes is the dummy endorsement stamped on transactions selected to be invalid.
+var invalidSignatureBytes = []byte("dummy")
+
 type (
-	// IndependentTxGenerator generates a new valid TX given key generators.
+	// IndependentTxGenerator generates a new valid TX given key generators. With a non-zero
+	// invalid-signature probability it may instead stamp a dummy endorsement, decided from its own
+	// per-worker random source so the decision is independent of the generated content.
 	IndependentTxGenerator struct {
 		TxBuilder                *TxBuilder
 		ReadOnlyKeyGenerator     *MultiGenerator[Key]
@@ -26,6 +32,8 @@ type (
 		BlindWriteValueGenerator *ByteArrayGenerator
 		MetadataGenerator        *ByteArrayGenerator
 		Modifiers                []Modifier
+		invalidSignRnd           *rand.Rand
+		invalidSignProbability   Probability
 	}
 
 	// Modifier modifies a TX.
@@ -40,24 +48,23 @@ type (
 // DefaultGeneratedNamespaceID for now we're only generating transactions for a single namespace.
 const DefaultGeneratedNamespaceID = "0"
 
-// newIndependentTxGenerators creates workers that generates independent transactions and apply the modifiers.
-// Each worker will have a unique instance of the modifier to avoid concurrency issues.
-// The modifiers will be applied in the order they are given.
-// A transaction modifier can modify any of its fields to adjust the workload.
-// For example, a modifier can query the database for the read-set versions to simulate a real transaction.
-// The signature modifier is applied last so all previous modifications will be signed correctly.
+// newIndependentTxGenerators creates workers that generate independent transactions and apply the
+// modifiers. Each worker will have a unique instance of the modifier to avoid concurrency issues.
+// The modifiers are applied in the order they are given; a modifier can modify any of the TX fields
+// to adjust the workload (for example, adding dependencies). The invalid-signature stamp is applied
+// last, after the modifiers, so it overrides any endorsement they may have produced.
 func newIndependentTxGenerators(profile *Profile, extraModifiers ...Generator[Modifier]) []*IndependentTxGenerator {
 	seeders, keyGens := newSeedersAndKeyGens(profile)
 	gens := make([]*IndependentTxGenerator, len(seeders))
 	for i, s := range seeders {
-		modifiers := make([]Modifier, 0, len(extraModifiers)+2)
-		if len(profile.Conflicts.Dependencies) > 0 {
+		modifiers := make([]Modifier, 0, len(extraModifiers)+1)
+		if len(profile.Transaction.Dependencies) > 0 {
 			modifiers = append(modifiers, newTxDependenciesModifier(s.nextSeed(), profile))
 		}
 		for _, mod := range extraModifiers {
 			modifiers = append(modifiers, mod.Next())
 		}
-		modifiers = append(modifiers, newSignTxModifier(s.nextSeed(), profile))
+		invalidSignRnd := s.nextSeed()
 		txb, err := NewTxBuilderFromPolicy(&profile.Policy, s.nextSeed())
 		utils.Must(err)
 		gens[i] = &IndependentTxGenerator{
@@ -69,6 +76,8 @@ func newIndependentTxGenerators(profile *Profile, extraModifiers ...Generator[Mo
 			BlindWriteValueGenerator: valueGenerator(s.nextSeed(), profile.Transaction.BlindWriteValueSize),
 			MetadataGenerator:        valueGenerator(s.nextSeed(), profile.Transaction.MetadataSize),
 			Modifiers:                modifiers,
+			invalidSignRnd:           invalidSignRnd,
+			invalidSignProbability:   profile.Transaction.InvalidSignatures,
 		}
 	}
 	return gens
@@ -119,6 +128,13 @@ func (g *IndependentTxGenerator) Next() *servicepb.LoadGenTx {
 	}
 	for _, mod := range g.Modifiers {
 		mod.Modify(tx)
+	}
+	if g.invalidSignRnd.Float64() < g.invalidSignProbability {
+		// Pre-assigning a dummy endorsement prevents TxBuilder from producing a valid signature.
+		tx.Endorsements = make([]*applicationpb.Endorsements, len(tx.Namespaces))
+		for i := range tx.Namespaces {
+			tx.Endorsements[i] = testsig.CreateEndorsementsForThresholdRule(invalidSignatureBytes)[0]
+		}
 	}
 	return g.TxBuilder.MakeTx(tx)
 }

--- a/loadgen/workload/tx.go
+++ b/loadgen/workload/tx.go
@@ -9,10 +9,10 @@ package workload
 import (
 	"math/rand"
 
+	"github.com/cockroachdb/errors"
 	"github.com/hyperledger/fabric-x-common/api/applicationpb"
 
 	"github.com/hyperledger/fabric-x-committer/api/servicepb"
-	"github.com/hyperledger/fabric-x-committer/utils"
 	"github.com/hyperledger/fabric-x-committer/utils/testsig"
 )
 
@@ -53,7 +53,9 @@ const DefaultGeneratedNamespaceID = "0"
 // The modifiers are applied in the order they are given; a modifier can modify any of the TX fields
 // to adjust the workload (for example, adding dependencies). The invalid-signature stamp is applied
 // last, after the modifiers, so it overrides any endorsement they may have produced.
-func newIndependentTxGenerators(profile *Profile, extraModifiers ...Generator[Modifier]) []*IndependentTxGenerator {
+func newIndependentTxGenerators(
+	profile *Profile, extraModifiers ...Generator[Modifier],
+) ([]*IndependentTxGenerator, error) {
 	seeders, keyGens := newSeedersAndKeyGens(profile)
 	gens := make([]*IndependentTxGenerator, len(seeders))
 	for i, s := range seeders {
@@ -66,7 +68,9 @@ func newIndependentTxGenerators(profile *Profile, extraModifiers ...Generator[Mo
 		}
 		invalidSignRnd := s.nextSeed()
 		txb, err := NewTxBuilderFromPolicy(&profile.Policy, s.nextSeed())
-		utils.Must(err)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to create tx builder")
+		}
 		gens[i] = &IndependentTxGenerator{
 			TxBuilder:                txb,
 			ReadOnlyKeyGenerator:     multiKeyGenerator(keyGens[i], profile.Transaction.ReadOnlyCount),
@@ -80,11 +84,27 @@ func newIndependentTxGenerators(profile *Profile, extraModifiers ...Generator[Mo
 			invalidSignProbability:   profile.Transaction.InvalidSignatures,
 		}
 	}
-	return gens
+	return gens, nil
 }
 
-// Next generate a new TX.
-func (g *IndependentTxGenerator) Next() *servicepb.LoadGenTx {
+// buildAndSignBatch builds n unsigned transactions and signs them, returning the
+// ready-to-submit batch. This is the no-query generation path.
+func (g *IndependentTxGenerator) buildAndSignBatch(n int) []*servicepb.LoadGenTx {
+	return g.signBatch(g.buildBatch(n))
+}
+
+// buildBatch builds n unsigned transactions from the key, value, and metadata generators, and
+// applies the modifiers. The invalid-signature stamp and signing happen later, in signBatch.
+func (g *IndependentTxGenerator) buildBatch(n int) []*applicationpb.Tx {
+	txs := make([]*applicationpb.Tx, n)
+	for i := range txs {
+		txs[i] = g.buildTx()
+	}
+	return txs
+}
+
+// buildTx builds a single unsigned TX.
+func (g *IndependentTxGenerator) buildTx() *applicationpb.Tx {
 	readOnly := g.ReadOnlyKeyGenerator.Next()
 	readWrite := g.ReadWriteKeyGenerator.Next()
 	blindWriteKey := g.BlindWriteKeyGenerator.Next()
@@ -129,14 +149,24 @@ func (g *IndependentTxGenerator) Next() *servicepb.LoadGenTx {
 	for _, mod := range g.Modifiers {
 		mod.Modify(tx)
 	}
-	if g.invalidSignRnd.Float64() < g.invalidSignProbability {
-		// Pre-assigning a dummy endorsement prevents TxBuilder from producing a valid signature.
-		tx.Endorsements = make([]*applicationpb.Endorsements, len(tx.Namespaces))
-		for i := range tx.Namespaces {
-			tx.Endorsements[i] = testsig.CreateEndorsementsForThresholdRule(invalidSignatureBytes)[0]
+	return tx
+}
+
+// signBatch applies the invalid-signature stamp (decided independently per TX from the
+// generator's own random source) and signs each TX via the TxBuilder.
+func (g *IndependentTxGenerator) signBatch(txs []*applicationpb.Tx) []*servicepb.LoadGenTx {
+	signed := make([]*servicepb.LoadGenTx, len(txs))
+	for i, tx := range txs {
+		if g.invalidSignRnd.Float64() < g.invalidSignProbability {
+			// Pre-assigning a dummy endorsement prevents TxBuilder from producing a valid signature.
+			tx.Endorsements = make([]*applicationpb.Endorsements, len(tx.Namespaces))
+			for j := range tx.Namespaces {
+				tx.Endorsements[j] = testsig.CreateEndorsementsForThresholdRule(invalidSignatureBytes)[0]
+			}
 		}
+		signed[i] = g.TxBuilder.MakeTx(tx)
 	}
-	return g.TxBuilder.MakeTx(tx)
+	return signed
 }
 
 func multiKeyGenerator(keyGen Generator[Key], keyCount uint32) *MultiGenerator[Key] {

--- a/service/coordinator/dependencygraph/manager_test.go
+++ b/service/coordinator/dependencygraph/manager_test.go
@@ -61,7 +61,7 @@ func BenchmarkDependencyGraph(b *testing.B) {
 				p := workload.DefaultProfile(1)
 				name := "no-dep"
 				if idx > 0 {
-					p.Conflicts.Dependencies = []workload.DependencyDescription{dep}
+					p.Transaction.Dependencies = []workload.DependencyDescription{dep}
 					name = fmt.Sprintf("%s AND %s", dep.Src, dep.Dst)
 				}
 				p.Transaction.ReadWriteCount = uint32(keyCount) //nolint:gosec // small test value.


### PR DESCRIPTION
#### Type of change

- Improvement (improvement to code, performance, etc)

#### Description

Two behavior-preserving loadgen cleanups ahead of the index-addressable / query work;
the generated workload is unchanged.

**Config consolidation:**

- Fold `key.size` (`KeyProfile`) into `TransactionProfile.KeySize`; delete `KeyProfile`.
- Fold `invalid-signatures` and `dependencies` into `TransactionProfile`; delete
  `ConflictProfile`. `DependencyDescription` and the dependency-conflict machinery
  (`dependenciesModifier`) are unchanged — only their config home moves.
- Inline invalid-signature stamping into the generator and drop `signTxModifier`; the
  per-worker bernoulli decision and dummy endorsement are unchanged. The generic
  `Modifier` mechanism stays (still used by `dependenciesModifier`).
- Move `key-size`, `invalid-signatures`, and `dependencies` under `transaction` in the
  config sample and template.

**Batch build/sign pipeline + error-returning construction:**

- Split the per-tx `Next()` into batch methods `buildBatch`/`signBatch` (with a
  `buildAndSignBatch` convenience). The stream worker generates a whole batch per
  iteration (`generateBatches`) instead of wrapping the generator in `MultiGenerator`;
  the `ingestBatchesToQueue` tx-batching wrapper is removed.
- `newIndependentTxGenerators` and `NewTxStream` now return an error (surfaced by
  `NewLoadGenClient`) instead of `utils.Must`-panicking on tx-builder setup.

#### Additional details (Optional)

Config consolidation: the generation seed order is preserved (the inlined
invalid-signature RNG consumes the seed where `signTxModifier` did), so output is
byte-identical; the coordinator's `BenchmarkDependencyGraph` is unchanged except for the
moved field reference (`p.Conflicts.Dependencies` -> `p.Transaction.Dependencies`).

Batch pipeline: the per-worker seeders, key/value generators, the `Modifier` mechanism
(and `DependencyDescription` conflicts), and `MakeTx` are unchanged, so output stays
byte-identical — each random source is consumed in the same per-transaction order (build
all, then sign all).

#### Related issues

- resolves #698
