### PR TITLE
[sidecar] Validate and split _snapshot/_checkpoint system transactions

### DIFF
--- a/docs/sidecar.md
+++ b/docs/sidecar.md
@@ -256,8 +256,33 @@ enum Status {
    MALFORMED_MISSING_SIGNATURE = 113;                  // Number of signatures does not match the number of namespaces.
    MALFORMED_NAMESPACE_POLICY_INVALID = 114;           // Invalid namespace policy.
    MALFORMED_CONFIG_TX_INVALID = 115;                  // Invalid configuration transaction.
+   MALFORMED_SNAPSHOT_NOT_MARKER_ONLY = 116;           // `_snapshot` namespace has reads/writes; it must be marker only.
+   MALFORMED_CHECKPOINT_INVALID_KEY = 117;             // `_checkpoint` namespace form or key is invalid.
+   MALFORMED_SYSTEM_TX_NOT_STANDALONE = 118;           // System namespace TX (`_snapshot`/`_checkpoint`) is not standalone.
+   REJECTED_DUPLICATE_SNAPSHOT_IN_BLOCK = 121;         // More than one `_snapshot` TX in a block; only the first is processed, the rest rejected.
 }
 ```
+
+#### System namespace transaction forms
+
+The sidecar applies additional form checks for system namespaces before forwarding transactions to the coordinator.
+
+- `_snapshot` transactions must be standalone: exactly one namespace, and that namespace must be `_snapshot`. The
+  `_snapshot` namespace is a marker only, so it must have no reads, no read-writes, and no blind-writes. A non-empty
+  read-write set is rejected with `MALFORMED_SNAPSHOT_NOT_MARKER_ONLY`; a mixed `_snapshot`+user transaction is
+  rejected with `MALFORMED_SYSTEM_TX_NOT_STANDALONE`. Ordinary user namespaces with no writes still use
+  `MALFORMED_NO_WRITES`.
+- `_checkpoint` transactions must be standalone: exactly one namespace, and that namespace must be `_checkpoint`. The
+  namespace must contain exactly one read-write, no reads-only entries, and no blind writes. The read-write key must
+  decode as a full `servicepb.Height` via `servicepb.NewHeightFromBytes`; valid height prefixes with trailing bytes
+  are rejected. Invalid checkpoint form is rejected with `MALFORMED_CHECKPOINT_INVALID_KEY`; a mixed
+  `_checkpoint`+user transaction is rejected with `MALFORMED_SYSTEM_TX_NOT_STANDALONE`.
+- `_meta` keeps the existing namespace-policy update checks. `_config` is still rejected if submitted as an
+  application transaction namespace.
+- Only the first `_snapshot` transaction in a block is accepted. Any additional `_snapshot` transaction in the same
+  block is rejected with `REJECTED_DUPLICATE_SNAPSHOT_IN_BLOCK` (a stored status, so the outcome is recorded in the
+  state database), regardless of the first snapshot's outcome. This bounds the snapshot drain to at most one barrier
+  per block.
 
 **c. In-Flight Duplicate Transaction Detection**: 
 
@@ -315,6 +340,26 @@ When a block satisfies the criteria outlined in step f, the relay component perf
 
 2. Creates a `committedBlockWithTxs` structure containing the block number, transaction list, and
    status information, and sends it to the notification service for distribution to subscribers.
+
+#### Snapshot split and drain
+
+When a valid `_snapshot` marker transaction appears in a block, the sidecar treats it as a submission barrier:
+
+1. Submit regular transactions that appear before the snapshot to the coordinator.
+2. Wait for `waitingTxsSlots.WaitTillEmpty(ctx)` so all in-flight regular transactions complete.
+3. Submit the snapshot transaction as a one-transaction coordinator batch, preserving its original block number and
+   transaction number.
+4. Wait for `waitingTxsSlots.WaitTillEmpty(ctx)` again so the snapshot transaction reaches a final status from the VC.
+5. Resume submission of later transactions and later blocks.
+
+The drain ends when the sidecar receives the snapshot transaction status, normally `COMMITTED`. It does not wait for
+background snapshot hash computation in the validator-committer.
+
+At most one snapshot barrier is applied per block: only the first `_snapshot` transaction in a block is accepted, so
+the block is split into at most three segments — the regular transactions before the snapshot, the snapshot
+transaction alone, and the regular transactions after it. When the snapshot is the first or last transaction (and
+there are no rejected statuses to carry on the empty side), the empty leading or trailing segment is omitted, leaving
+two segments, or a single snapshot-only segment when the block contains nothing else.
 
 ### Task 3. Persisting Committed Block in the File System
 

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0
 	github.com/hyperledger/fabric-lib-go v1.1.5-0.20260708100132-163bcc919208
 	github.com/hyperledger/fabric-protos-go-apiv2 v0.3.7
-	github.com/hyperledger/fabric-x-common v0.2.9-0.20260716124624-c6defc2b11b4
+	github.com/hyperledger/fabric-x-common v0.2.9-0.20260723091942-e43f1af10c7e
 	github.com/jackc/puddle/v2 v2.2.2
 	github.com/moby/moby/api v1.55.0
 	github.com/moby/moby/client v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -178,8 +178,8 @@ github.com/hyperledger/fabric-lib-go v1.1.5-0.20260708100132-163bcc919208 h1:qA4
 github.com/hyperledger/fabric-lib-go v1.1.5-0.20260708100132-163bcc919208/go.mod h1:EKqTudBsC2yovZdcJq5ekWvkq3USF1mbau07I0y8zMs=
 github.com/hyperledger/fabric-protos-go-apiv2 v0.3.7 h1:sQ5qv8vQQfwewa1JlCiSCC8dLElmaU2/frLolpgibEY=
 github.com/hyperledger/fabric-protos-go-apiv2 v0.3.7/go.mod h1:bJnwzfv03oZQeCc863pdGTDgf5nmCy6Za3RAE7d2XsQ=
-github.com/hyperledger/fabric-x-common v0.2.9-0.20260716124624-c6defc2b11b4 h1:jmVAZ5vi3z1v/XlZwvhwJqkPZo5x+lxG/nx3dsG6hhM=
-github.com/hyperledger/fabric-x-common v0.2.9-0.20260716124624-c6defc2b11b4/go.mod h1:f30Yws3c5Cg22yHLy2oT2XR0wwZI+JdqbUqB2fwFIsM=
+github.com/hyperledger/fabric-x-common v0.2.9-0.20260723091942-e43f1af10c7e h1:1TiqmKe1L3/KnKXHHId+i1WHY/4hIaI8sCyLrhWFpsI=
+github.com/hyperledger/fabric-x-common v0.2.9-0.20260723091942-e43f1af10c7e/go.mod h1:f30Yws3c5Cg22yHLy2oT2XR0wwZI+JdqbUqB2fwFIsM=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imkira/go-interpol v1.1.0 h1:KIiKr0VSG2CUW1hl1jpiyuzuJeKUUpC8iM1AIE7N1Vk=
 github.com/imkira/go-interpol v1.1.0/go.mod h1:z0h2/2T3XF8kyEPpRgJ3kmNv+C43p+I/CoI+jC3w2iA=

--- a/service/sidecar/mapping.go
+++ b/service/sidecar/mapping.go
@@ -29,6 +29,12 @@ type (
 		block       *servicepb.CoordinatorBatch
 		withStatus  *blockWithStatus
 		isConfig    bool
+		hasSnapshot bool
+		// snapshotTxIndex is the index (into block.Txs) of the accepted snapshot TX.
+		// Only the first snapshot TX in a block is accepted; any further snapshot TXs in the
+		// same block are rejected with REJECTED_DUPLICATE_SNAPSHOT_IN_BLOCK. Valid only when
+		// hasSnapshot is true.
+		snapshotTxIndex int
 		// txIDToHeight is a reference to the relay map.
 		txIDToHeight *utils.SyncMap[string, servicepb.Height]
 	}
@@ -135,6 +141,20 @@ func (b *blockMappingResult) mapMessage(msgIndex uint32, msg []byte) error {
 		}
 		if status := verifyTxForm(tx); status != statusNotYetValidated {
 			return b.rejectTx(ref, status, "malformed tx")
+		}
+		if isSnapshotTx(tx) {
+			if b.hasSnapshot {
+				// Only the first snapshot TX in a block is processed; reject the rest with a
+				// stored status so the outcome is recorded, regardless of the first's outcome.
+				return b.rejectTx(ref, committerpb.Status_REJECTED_DUPLICATE_SNAPSHOT_IN_BLOCK,
+					"duplicate snapshot tx in block")
+			}
+			if err := b.appendTx(ref, tx); err != nil {
+				return err
+			}
+			b.hasSnapshot = true
+			b.snapshotTxIndex = len(b.block.Txs) - 1
+			return nil
 		}
 		return b.appendTx(ref, tx)
 	default:
@@ -259,11 +279,17 @@ func verifyTxForm(tx *applicationpb.Tx) committerpb.Status {
 	if status := checkEndorsements(tx); status != statusNotYetValidated {
 		return status
 	}
+	if status := checkStandaloneSystemTx(tx); status != statusNotYetValidated {
+		return status
+	}
 
 	nsIDs := make(map[string]any, len(tx.Namespaces))
 	for _, ns := range tx.Namespaces {
 		// Checks that the application does not submit a config TX.
-		if ns.NsId == committerpb.ConfigNamespaceID || policy.ValidateNamespaceID(ns.NsId) != nil {
+		if ns.NsId == committerpb.ConfigNamespaceID {
+			return committerpb.Status_MALFORMED_NAMESPACE_ID_INVALID
+		}
+		if !utils.IsSystemNamespace(ns.NsId) && policy.ValidateNamespaceID(ns.NsId) != nil {
 			return committerpb.Status_MALFORMED_NAMESPACE_ID_INVALID
 		}
 		if _, ok := nsIDs[ns.NsId]; ok {
@@ -271,7 +297,7 @@ func verifyTxForm(tx *applicationpb.Tx) committerpb.Status {
 		}
 
 		for _, check := range []func(ns *applicationpb.TxNamespace) committerpb.Status{
-			checkNamespaceFormation, checkMetaNamespace,
+			checkNamespaceReadsWrites, checkSystemNamespace,
 		} {
 			if status := check(ns); status != statusNotYetValidated {
 				return status
@@ -303,8 +329,53 @@ func checkEndorsements(tx *applicationpb.Tx) committerpb.Status {
 	return statusNotYetValidated
 }
 
-func checkNamespaceFormation(ns *applicationpb.TxNamespace) committerpb.Status {
-	if len(ns.ReadWrites) == 0 && len(ns.BlindWrites) == 0 {
+func isSnapshotTx(tx *applicationpb.Tx) bool {
+	return len(tx.Namespaces) == 1 && tx.Namespaces[0].NsId == committerpb.SnapshotNamespaceID
+}
+
+func checkStandaloneSystemTx(tx *applicationpb.Tx) committerpb.Status {
+	for _, ns := range tx.Namespaces {
+		if ns.NsId != committerpb.SnapshotNamespaceID && ns.NsId != committerpb.CheckpointNamespaceID {
+			continue
+		}
+		if len(tx.Namespaces) == 1 {
+			continue
+		}
+		// System TX must be standalone; not namespace ID/snapshot marker/checkpoint key error.
+		return committerpb.Status_MALFORMED_SYSTEM_TX_NOT_STANDALONE
+	}
+	return statusNotYetValidated
+}
+
+func checkSystemNamespace(ns *applicationpb.TxNamespace) committerpb.Status {
+	switch ns.NsId {
+	case committerpb.MetaNamespaceID:
+		return checkMetaNamespace(ns)
+	case committerpb.SnapshotNamespaceID:
+		if len(ns.ReadsOnly) > 0 || len(ns.ReadWrites) > 0 || len(ns.BlindWrites) > 0 {
+			return committerpb.Status_MALFORMED_SNAPSHOT_NOT_MARKER_ONLY
+		}
+	case committerpb.CheckpointNamespaceID:
+		if len(ns.ReadsOnly) > 0 || len(ns.BlindWrites) > 0 || len(ns.ReadWrites) != 1 {
+			return committerpb.Status_MALFORMED_CHECKPOINT_INVALID_KEY
+		}
+		_, n, err := servicepb.NewHeightFromBytes(ns.ReadWrites[0].Key)
+		if err != nil || n != len(ns.ReadWrites[0].Key) {
+			return committerpb.Status_MALFORMED_CHECKPOINT_INVALID_KEY
+		}
+	default:
+		return statusNotYetValidated
+	}
+	return statusNotYetValidated
+}
+
+// checkNamespaceReadsWrites validates the reads/writes shape shared by user and system
+// namespaces: it rejects a namespace with no writes (except the marker-only `_snapshot` and
+// `_checkpoint` system namespaces, whose write requirements are checked in checkSystemNamespace)
+// and validates all keys. It runs for every namespace in the transaction.
+func checkNamespaceReadsWrites(ns *applicationpb.TxNamespace) committerpb.Status {
+	if len(ns.ReadWrites) == 0 && len(ns.BlindWrites) == 0 &&
+		ns.NsId != committerpb.SnapshotNamespaceID && ns.NsId != committerpb.CheckpointNamespaceID {
 		return committerpb.Status_MALFORMED_NO_WRITES
 	}
 

--- a/service/sidecar/mapping_test.go
+++ b/service/sidecar/mapping_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/hyperledger/fabric-lib-go/common/flogging"
 	"github.com/hyperledger/fabric-protos-go-apiv2/common"
+	"github.com/hyperledger/fabric-x-common/api/applicationpb"
 	"github.com/hyperledger/fabric-x-common/api/committerpb"
 	"github.com/stretchr/testify/require"
 
@@ -20,6 +21,9 @@ import (
 	"github.com/hyperledger/fabric-x-committer/utils"
 	"github.com/hyperledger/fabric-x-committer/utils/test"
 )
+
+// testChannelID is a shared channel ID used by sidecar mapping/relay tests.
+const testChannelID = "chan"
 
 func BenchmarkMapOneBlock(b *testing.B) {
 	flogging.ActivateSpec("fatal")
@@ -66,7 +70,7 @@ func BenchmarkMapBlockSize(b *testing.B) {
 
 func TestBlockMapping(t *testing.T) {
 	t.Parallel()
-	txb := &workload.TxBuilder{ChannelID: "chan"}
+	txb := &workload.TxBuilder{ChannelID: testChannelID}
 	txs, expected := MalformedTxTestCases(txb)
 	expectedBlockSize := 0
 	expectedRejected := 0
@@ -104,4 +108,201 @@ func TestBlockMapping(t *testing.T) {
 	require.Len(t, mappedBlock.block.Rejected, expectedRejected)
 	//nolint:gosec // int -> int32
 	require.Equal(t, int32(expectedBlockSize), mappedBlock.withStatus.pendingCount.Load())
+}
+
+func TestSystemNamespaceFormValidation(t *testing.T) {
+	t.Parallel()
+
+	const ordinaryNsID = "ordinary"
+	heightKey := servicepb.NewHeight(7, 3).ToBytes()
+	heightKeyWithTrailingBytes := append(append([]byte{}, heightKey...), []byte("junk")...)
+
+	for _, tc := range []struct {
+		name                string
+		tx                  *applicationpb.Tx
+		expectedStatus      committerpb.Status
+		expectedHasSnapshot bool
+		expectedSnapshotIdx int
+	}{
+		{
+			name: "marker-only snapshot namespace is valid",
+			tx: &applicationpb.Tx{
+				Namespaces:   []*applicationpb.TxNamespace{{NsId: committerpb.SnapshotNamespaceID}},
+				Endorsements: dummyEndorsements(1),
+			},
+			expectedStatus:      statusNotYetValidated,
+			expectedHasSnapshot: true,
+			expectedSnapshotIdx: 0,
+		},
+		{
+			name: "snapshot namespace with reads-only is malformed",
+			tx: &applicationpb.Tx{
+				Namespaces: []*applicationpb.TxNamespace{{
+					NsId:      committerpb.SnapshotNamespaceID,
+					ReadsOnly: []*applicationpb.Read{{Key: []byte("key")}},
+				}},
+				Endorsements: dummyEndorsements(1),
+			},
+			expectedStatus: committerpb.Status_MALFORMED_SNAPSHOT_NOT_MARKER_ONLY,
+		},
+		{
+			name: "snapshot namespace with read-writes is malformed",
+			tx: &applicationpb.Tx{
+				Namespaces: []*applicationpb.TxNamespace{{
+					NsId:       committerpb.SnapshotNamespaceID,
+					ReadWrites: []*applicationpb.ReadWrite{{Key: []byte("key"), Value: []byte("value")}},
+				}},
+				Endorsements: dummyEndorsements(1),
+			},
+			expectedStatus: committerpb.Status_MALFORMED_SNAPSHOT_NOT_MARKER_ONLY,
+		},
+		{
+			name: "snapshot namespace with blind-writes is malformed",
+			tx: &applicationpb.Tx{
+				Namespaces: []*applicationpb.TxNamespace{{
+					NsId:        committerpb.SnapshotNamespaceID,
+					BlindWrites: []*applicationpb.Write{{Key: []byte("key"), Value: []byte("value")}},
+				}},
+				Endorsements: dummyEndorsements(1),
+			},
+			expectedStatus: committerpb.Status_MALFORMED_SNAPSHOT_NOT_MARKER_ONLY,
+		},
+		{
+			name: "snapshot namespace mixed with ordinary namespace is malformed",
+			tx: &applicationpb.Tx{
+				Namespaces: []*applicationpb.TxNamespace{
+					{NsId: committerpb.SnapshotNamespaceID},
+					{NsId: ordinaryNsID, BlindWrites: []*applicationpb.Write{{Key: []byte("key")}}},
+				},
+				Endorsements: dummyEndorsements(2),
+			},
+			expectedStatus: committerpb.Status_MALFORMED_SYSTEM_TX_NOT_STANDALONE,
+		},
+		{
+			name: "ordinary empty namespace is malformed with no writes",
+			tx: &applicationpb.Tx{
+				Namespaces:   []*applicationpb.TxNamespace{{NsId: ordinaryNsID}},
+				Endorsements: dummyEndorsements(1),
+			},
+			expectedStatus: committerpb.Status_MALFORMED_NO_WRITES,
+		},
+		{
+			name: "checkpoint namespace with height key is valid",
+			tx: &applicationpb.Tx{
+				Namespaces: []*applicationpb.TxNamespace{{
+					NsId:       committerpb.CheckpointNamespaceID,
+					ReadWrites: []*applicationpb.ReadWrite{{Key: heightKey, Value: []byte("checkpoint")}},
+				}},
+				Endorsements: dummyEndorsements(1),
+			},
+			expectedStatus: statusNotYetValidated,
+		},
+		{
+			name: "checkpoint namespace with non-height key is malformed",
+			tx: &applicationpb.Tx{
+				Namespaces: []*applicationpb.TxNamespace{{
+					NsId:       committerpb.CheckpointNamespaceID,
+					ReadWrites: []*applicationpb.ReadWrite{{Key: []byte("not-height"), Value: []byte("checkpoint")}},
+				}},
+				Endorsements: dummyEndorsements(1),
+			},
+			expectedStatus: committerpb.Status_MALFORMED_CHECKPOINT_INVALID_KEY,
+		},
+		{
+			name: "checkpoint namespace with height key plus trailing bytes is malformed",
+			tx: &applicationpb.Tx{
+				Namespaces: []*applicationpb.TxNamespace{{
+					NsId: committerpb.CheckpointNamespaceID,
+					ReadWrites: []*applicationpb.ReadWrite{{
+						Key:   heightKeyWithTrailingBytes,
+						Value: []byte("checkpoint"),
+					}},
+				}},
+				Endorsements: dummyEndorsements(1),
+			},
+			expectedStatus: committerpb.Status_MALFORMED_CHECKPOINT_INVALID_KEY,
+		},
+		{
+			name: "checkpoint namespace mixed with ordinary namespace is malformed",
+			tx: &applicationpb.Tx{
+				Namespaces: []*applicationpb.TxNamespace{
+					{
+						NsId:       committerpb.CheckpointNamespaceID,
+						ReadWrites: []*applicationpb.ReadWrite{{Key: heightKey, Value: []byte("checkpoint")}},
+					},
+					{NsId: ordinaryNsID, BlindWrites: []*applicationpb.Write{{Key: []byte("key")}}},
+				},
+				Endorsements: dummyEndorsements(2),
+			},
+			expectedStatus: committerpb.Status_MALFORMED_SYSTEM_TX_NOT_STANDALONE,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tc.expectedStatus, verifyTxForm(tc.tx))
+
+			txb := &workload.TxBuilder{ChannelID: testChannelID}
+			block := workload.MapToOrdererBlock(1, []*servicepb.LoadGenTx{txb.MakeTx(tc.tx)})
+
+			var txIDToHeight utils.SyncMap[string, servicepb.Height]
+			mappedBlock, err := mapBlock(block, &txIDToHeight)
+			require.NoError(t, err)
+			require.NotNil(t, mappedBlock)
+			require.Equal(t, tc.expectedHasSnapshot, mappedBlock.hasSnapshot)
+			require.Equal(t, tc.expectedSnapshotIdx, mappedBlock.snapshotTxIndex)
+		})
+	}
+}
+
+// TestDuplicateSnapshotInBlock verifies that when a block contains more than one snapshot TX,
+// only the first is accepted and the rest are rejected with
+// REJECTED_DUPLICATE_SNAPSHOT_IN_BLOCK (a stored status), regardless of the first's outcome.
+func TestDuplicateSnapshotInBlock(t *testing.T) {
+	t.Parallel()
+
+	snapshotTx := func() *applicationpb.Tx {
+		return &applicationpb.Tx{
+			Namespaces:   []*applicationpb.TxNamespace{{NsId: committerpb.SnapshotNamespaceID}},
+			Endorsements: dummyEndorsements(1),
+		}
+	}
+	regularTx := func() *applicationpb.Tx {
+		return &applicationpb.Tx{
+			Namespaces: []*applicationpb.TxNamespace{{
+				NsId:        "ns",
+				BlindWrites: []*applicationpb.Write{{Key: []byte("key")}},
+			}},
+			Endorsements: dummyEndorsements(1),
+		}
+	}
+
+	txb := &workload.TxBuilder{ChannelID: testChannelID}
+	// Block layout: [regular, snapshot#0 (accepted), regular, snapshot#1 (rejected)].
+	block := workload.MapToOrdererBlock(1, []*servicepb.LoadGenTx{
+		txb.MakeTx(regularTx()),
+		txb.MakeTx(snapshotTx()),
+		txb.MakeTx(regularTx()),
+		txb.MakeTx(snapshotTx()),
+	})
+
+	var txIDToHeight utils.SyncMap[string, servicepb.Height]
+	mappedBlock, err := mapBlock(block, &txIDToHeight)
+	require.NoError(t, err)
+	require.NotNil(t, mappedBlock)
+
+	// Only the first snapshot is accepted; its index points into the accepted Txs slice
+	// (regular#0 + snapshot#0 + regular#2 = indexes 0,1,2), so the snapshot is at index 1.
+	require.True(t, mappedBlock.hasSnapshot)
+	require.Equal(t, 1, mappedBlock.snapshotTxIndex)
+	require.Len(t, mappedBlock.block.Txs, 3)
+
+	// The second snapshot is rejected with the dedicated stored status.
+	require.Len(t, mappedBlock.block.Rejected, 1)
+	require.Equal(
+		t,
+		committerpb.Status_REJECTED_DUPLICATE_SNAPSHOT_IN_BLOCK,
+		mappedBlock.block.Rejected[0].Status,
+	)
+	require.Equal(t, uint32(3), mappedBlock.block.Rejected[0].Ref.TxNum)
 }

--- a/service/sidecar/relay.go
+++ b/service/sidecar/relay.go
@@ -126,7 +126,6 @@ func (r *relay) preProcessBlock(
 ) error {
 	incomingBlockToBeCommitted := channel.NewReader(ctx, r.incomingBlockToBeCommitted)
 	queue := channel.NewWriter(ctx, mappedBlockQueue)
-	configBlocks := channel.NewWriter(ctx, r.outgoingConfigBlocks)
 
 	done := context.AfterFunc(ctx, r.waitingTxsSlots.Broadcast)
 	defer done()
@@ -146,26 +145,182 @@ func (r *relay) preProcessBlock(
 			return err
 		}
 		promutil.Observe(r.metrics.blockMappingInRelaySeconds, time.Since(start))
-		if mappedBlock.isConfig {
-			// We wait for all previously submitted transactions to be processed by
-			// the committer before submitting the config block.
-			r.waitingTxsSlots.WaitTillEmpty(ctx)
-			configBlocks.Write(block)
-		}
-
-		txsCount := len(mappedBlock.block.Txs)
-		promutil.AddToCounter(r.metrics.transactionInThroughput, txsCount)
-		r.waitingTxsSlots.Acquire(ctx, int64(txsCount))
-		promutil.AddToGauge(r.metrics.waitingTransactionsQueueSize, txsCount)
-		queue.Write(mappedBlock)
-
-		if mappedBlock.isConfig {
-			// we wait for the config block to be processed by the committer
-			// before submitting any other data transactions.
-			r.waitingTxsSlots.WaitTillEmpty(ctx)
+		if err := r.submitMappedBlock(ctx, queue, block, mappedBlock); err != nil {
+			return err
 		}
 	}
 	return errors.Wrap(ctx.Err(), "context ended")
+}
+
+func (r *relay) submitMappedBlock(
+	ctx context.Context,
+	queue channel.Writer[*blockMappingResult],
+	block *common.Block,
+	mappedBlock *blockMappingResult,
+) error {
+	if !mappedBlock.hasSnapshot && !mappedBlock.isConfig {
+		// Common case: an ordinary user block with no submission barrier.
+		r.queueMappedBlock(ctx, queue, mappedBlock)
+		return nil
+	}
+
+	if mappedBlock.isConfig {
+		return r.submitConfigBlock(ctx, queue, block, mappedBlock)
+	}
+	return r.submitSnapshotBlock(ctx, queue, mappedBlock)
+}
+
+// submitConfigBlock submits a config block as a submission barrier: drain all previously
+// submitted transactions so the committer processes them before applying the config, forward
+// the config block for application, submit it, then drain again so it is processed before any
+// later data transaction is submitted.
+func (r *relay) submitConfigBlock(
+	ctx context.Context,
+	queue channel.Writer[*blockMappingResult],
+	block *common.Block,
+	mappedBlock *blockMappingResult,
+) error {
+	if err := r.drain(ctx); err != nil {
+		return err
+	}
+	channel.NewWriter(ctx, r.outgoingConfigBlocks).Write(block)
+	r.queueMappedBlock(ctx, queue, mappedBlock)
+	return r.drain(ctx)
+}
+
+// submitSnapshotBlock splits a snapshot block into segments and submits them in order. The
+// single snapshot segment is a submission barrier: earlier regular transactions are drained
+// before it, and its status is drained after it, before later transactions are submitted.
+func (r *relay) submitSnapshotBlock(
+	ctx context.Context,
+	queue channel.Writer[*blockMappingResult],
+	mappedBlock *blockMappingResult,
+) error {
+	for _, segment := range splitSnapshotMappedBlock(mappedBlock) {
+		if segment.hasSnapshot {
+			if err := r.drain(ctx); err != nil {
+				return err
+			}
+		}
+
+		r.queueMappedBlock(ctx, queue, segment)
+
+		if segment.hasSnapshot {
+			if err := r.drain(ctx); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// drain blocks until all in-flight transactions have been processed by the committer.
+// It returns a wrapped context error if the context is cancelled while waiting.
+func (r *relay) drain(ctx context.Context) error {
+	r.waitingTxsSlots.WaitTillEmpty(ctx)
+	return errors.Wrap(ctx.Err(), "context ended")
+}
+
+func (r *relay) queueMappedBlock(
+	ctx context.Context,
+	queue channel.Writer[*blockMappingResult],
+	mappedBlock *blockMappingResult,
+) {
+	txsCount := len(mappedBlock.block.Txs)
+	promutil.AddToCounter(r.metrics.transactionInThroughput, txsCount)
+	r.waitingTxsSlots.Acquire(ctx, int64(txsCount))
+	promutil.AddToGauge(r.metrics.waitingTransactionsQueueSize, txsCount)
+	queue.Write(mappedBlock)
+}
+
+func splitSnapshotMappedBlock(mappedBlock *blockMappingResult) []*blockMappingResult {
+	if !mappedBlock.hasSnapshot {
+		return []*blockMappingResult{mappedBlock}
+	}
+
+	// At most three segments: the regular TXs before the snapshot, the snapshot TX alone, and
+	// the regular TXs after it. When the snapshot is the first or last TX (and there are no
+	// rejected statuses to carry on the empty side), the empty leading/trailing segment is
+	// skipped, leaving two segments — or a single snapshot-only segment when the block contains
+	// nothing else.
+	segments := make([]*blockMappingResult, 0, 3)
+	snapshotIndex := mappedBlock.snapshotTxIndex
+
+	// Rejected statuses have no tx body, so they are not part of any Txs slice. Partition them
+	// by their original block position relative to the snapshot's original position: rejects
+	// before the snapshot ride the pre-snapshot segment, rejects after it (e.g. a duplicate
+	// snapshot) ride the post-snapshot segment. This keeps each stored reject's tx_status
+	// commit on the correct side of the snapshot barrier, so a post-snapshot reject is not
+	// committed into the state before the snapshot clone is taken.
+	snapshotTxNum := mappedBlock.block.Txs[snapshotIndex].Ref.TxNum
+	var rejectedBefore, rejectedAfter []*committerpb.TxStatus
+	for _, rejected := range mappedBlock.block.Rejected {
+		if rejected.Ref.TxNum < snapshotTxNum {
+			rejectedBefore = append(rejectedBefore, rejected)
+		} else {
+			rejectedAfter = append(rejectedAfter, rejected)
+		}
+	}
+
+	// Regular segment before the snapshot. Emit it when there are regular TXs or rejected
+	// statuses that precede the snapshot.
+	if snapshotIndex > 0 || len(rejectedBefore) > 0 {
+		segments = append(segments, mappedBlockSegment(
+			mappedBlock,
+			mappedBlock.block.Txs[:snapshotIndex],
+			rejectedBefore,
+			false,
+		))
+	}
+
+	// Snapshot one-TX segment allows waiting for the snapshot status before later TXs.
+	segments = append(segments, mappedBlockSegment(
+		mappedBlock,
+		mappedBlock.block.Txs[snapshotIndex:snapshotIndex+1],
+		nil,
+		true,
+	))
+
+	// Regular segment after the snapshot, submitted once the snapshot drain completes.
+	if snapshotIndex+1 < len(mappedBlock.block.Txs) || len(rejectedAfter) > 0 {
+		segments = append(segments, mappedBlockSegment(
+			mappedBlock,
+			mappedBlock.block.Txs[snapshotIndex+1:],
+			rejectedAfter,
+			false,
+		))
+	}
+
+	return segments
+}
+
+func mappedBlockSegment(
+	mappedBlock *blockMappingResult,
+	txs []*servicepb.TxWithRef,
+	rejected []*committerpb.TxStatus,
+	hasSnapshot bool,
+) *blockMappingResult {
+	// A segment is never a config block: config blocks return early in submitMappedBlock and
+	// are never split, so isConfig is always false here.
+	//
+	// withStatus and txIDToHeight are shared (not copied) across all segments of the block: they
+	// track whole-block state (per-TX statuses, pending count, and the relay-wide txID->height
+	// map) keyed by the original block position, so every segment must point at the same
+	// instances for status correlation and final block assembly to work. As a result the
+	// segment's withStatus.txs may reference more TXs than this segment's CoordinatorBatch
+	// carries — that is intentional: the batch is a per-segment slice while withStatus spans the
+	// whole block.
+	return &blockMappingResult{
+		blockNumber: mappedBlock.blockNumber,
+		block: &servicepb.CoordinatorBatch{
+			Txs:      txs,
+			Rejected: rejected,
+		},
+		withStatus:   mappedBlock.withStatus,
+		hasSnapshot:  hasSnapshot,
+		txIDToHeight: mappedBlock.txIDToHeight,
+	}
 }
 
 func (r *relay) sendBlocksToCoordinator(
@@ -184,8 +339,22 @@ func (r *relay) sendBlocksToCoordinator(
 		}
 
 		startTime := time.Now()
-		r.blkNumToBlkWithStatus.Store(mappedBlock.blockNumber, mappedBlock.withStatus)
-		r.activeBlocksCount.Add(1)
+		// A snapshot block is split into multiple segments that share the same block number and
+		// the same whole-block withStatus. Register the block and count it as active only once,
+		// on the first segment; later segments observe the existing entry. Note that this shared
+		// withStatus tracks all TXs of the original block, so it may reference more txIDs than the
+		// current segment's CoordinatorBatch (mappedBlock.block) sends to the coordinator — the
+		// remaining txIDs are sent by the other segments of the same block. This is not new to the
+		// split: withStatus is always registered here before stream.Send below, so even an
+		// unsplit block transiently holds txIDs not yet submitted to the coordinator. An
+		// alternative split shape — a single blockMappingResult carrying []CoordinatorBatch plus a
+		// snapshotBatchIndex/snapshotTxIndex — would avoid multiple segments but needs extra index
+		// bookkeeping, so we keep the simpler per-segment result here.
+		if _, alreadyTracked := r.blkNumToBlkWithStatus.LoadOrStore(
+			mappedBlock.blockNumber, mappedBlock.withStatus,
+		); !alreadyTracked {
+			r.activeBlocksCount.Add(1)
+		}
 
 		if mappedBlock.withStatus.pendingCount.Load() == 0 {
 			r.processCommittedBlocksInOrder(ctx, outgoingCommittedBlock, outgoingCommittedBlockWithTxs)

--- a/service/sidecar/relay_test.go
+++ b/service/sidecar/relay_test.go
@@ -12,12 +12,15 @@ import (
 	"time"
 
 	"github.com/hyperledger/fabric-protos-go-apiv2/common"
+	"github.com/hyperledger/fabric-x-common/api/applicationpb"
 	"github.com/hyperledger/fabric-x-common/api/committerpb"
 	"github.com/hyperledger/fabric-x-common/utils/testcrypto"
 	"github.com/stretchr/testify/require"
 
 	"github.com/hyperledger/fabric-x-committer/api/servicepb"
+	"github.com/hyperledger/fabric-x-committer/loadgen/workload"
 	"github.com/hyperledger/fabric-x-committer/mock"
+	"github.com/hyperledger/fabric-x-committer/utils"
 	"github.com/hyperledger/fabric-x-committer/utils/channel"
 	"github.com/hyperledger/fabric-x-committer/utils/connection"
 	"github.com/hyperledger/fabric-x-committer/utils/test"
@@ -272,6 +275,259 @@ func TestRelayConfigBlock(t *testing.T) {
 	require.Equal(t, blk2, committedBlock2)
 }
 
+func TestRelaySnapshotBlockSplitAndDrain(t *testing.T) {
+	t.Parallel()
+	relayEnv := newRelayTestEnv(t)
+	m := relayEnv.metrics
+	coordinatorDelay := 2 * time.Second
+	relayEnv.coordinator.SetDelay(coordinatorDelay)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 15*time.Second)
+	t.Cleanup(cancel)
+	incoming := channel.NewWriter(ctx, relayEnv.incomingBlockToBeCommitted)
+	committed := channel.NewReader(ctx, relayEnv.committedBlock)
+
+	t.Log("Block #0 (regulars + snapshot): Submit")
+	regular1 := makeValidTx(t, "ch1")
+	regular2 := makeValidTx(t, "ch1")
+	snapshot := makeSnapshotTxForTest(t, "ch1")
+	blk0 := &common.Block{
+		Header: &common.BlockHeader{Number: 0},
+		Data: &common.BlockData{Data: [][]byte{
+			regular1.SerializedEnvelope,
+			regular2.SerializedEnvelope,
+			snapshot.SerializedEnvelope,
+		}},
+	}
+	require.Nil(t, blk0.Metadata)
+	require.True(t, incoming.Write(blk0))
+
+	t.Log("Block #0: Check regular transactions submitted first")
+	test.EventuallyIntMetric(t, 2, m.transactionsSentTotal, 5*time.Second, 10*time.Millisecond)
+	test.EventuallyIntMetric(t, 2, m.waitingTransactionsQueueSize, 5*time.Second, 10*time.Millisecond)
+	require.Equal(t, int64(relayEnv.waitingTxsLimit-2), relayEnv.relay.waitingTxsSlots.Load(t))
+
+	t.Log("Block #0: Snapshot not submitted before regular drain")
+	require.Never(t, func() bool {
+		return test.GetIntMetricValue(t, m.transactionsSentTotal) > 2
+	}, coordinatorDelay/2, 10*time.Millisecond)
+
+	t.Log("Block #0: Snapshot submitted after regular drain")
+	test.EventuallyIntMetric(t, 3, m.transactionsSentTotal, 5*time.Second, 10*time.Millisecond)
+	test.EventuallyIntMetric(t, 1, m.waitingTransactionsQueueSize, 5*time.Second, 10*time.Millisecond)
+	require.Equal(t, int64(relayEnv.waitingTxsLimit-1), relayEnv.relay.waitingTxsSlots.Load(t))
+
+	t.Log("Block #1: Enqueue while snapshot path drains")
+	blk1, _ := createBlockForTest(t, 1, nil)
+	require.Nil(t, blk1.Metadata)
+	require.True(t, incoming.Write(blk1))
+
+	t.Log("Block #1: Not submitted before snapshot drain")
+	require.Never(t, func() bool {
+		return test.GetIntMetricValue(t, m.transactionsSentTotal) > 3
+	}, coordinatorDelay/2, 10*time.Millisecond)
+
+	t.Log("Block #0: Committed")
+	committedBlock0, ok := committed.Read()
+	require.True(t, ok)
+	require.Equal(t, blk0, committedBlock0)
+	require.NotNil(t, committedBlock0.Metadata)
+	require.Greater(t, len(committedBlock0.Metadata.Metadata), statusIdx)
+	require.Equal(t, []byte{valid, valid, valid}, committedBlock0.Metadata.Metadata[statusIdx])
+
+	t.Log("Block #1: Eventually submitted and committed")
+	test.EventuallyIntMetric(t, 6, m.transactionsSentTotal, 5*time.Second, 10*time.Millisecond)
+	committedBlock1, ok := committed.Read()
+	require.True(t, ok)
+	require.Equal(t, blk1, committedBlock1)
+	require.NotNil(t, committedBlock1.Metadata)
+	require.Greater(t, len(committedBlock1.Metadata.Metadata), statusIdx)
+	require.Equal(t, []byte{valid, valid, valid}, committedBlock1.Metadata.Metadata[statusIdx])
+}
+
+// TestSplitSnapshotMappedBlockPartitionsRejected verifies that rejected statuses are
+// partitioned around the snapshot by their original block position: rejects before the
+// snapshot ride the pre-snapshot segment and rejects after it ride the post-snapshot
+// segment. This keeps a post-snapshot reject's stored tx_status commit after the snapshot
+// barrier, so it does not leak into the snapshot clone's state.
+func TestSplitSnapshotMappedBlockPartitionsRejected(t *testing.T) {
+	t.Parallel()
+
+	snapshotTx := func() *applicationpb.Tx {
+		return &applicationpb.Tx{
+			Namespaces:   []*applicationpb.TxNamespace{{NsId: committerpb.SnapshotNamespaceID}},
+			Endorsements: dummyEndorsements(1),
+		}
+	}
+	regularTx := func() *applicationpb.Tx {
+		return &applicationpb.Tx{
+			Namespaces: []*applicationpb.TxNamespace{{
+				NsId:        "ns",
+				BlindWrites: []*applicationpb.Write{{Key: []byte("key")}},
+			}},
+			Endorsements: dummyEndorsements(1),
+		}
+	}
+	// malformedTx has no namespaces, so it is rejected (MALFORMED_EMPTY_NAMESPACES) with a
+	// stored status and no tx body, exercising the rejectedBefore partition branch.
+	malformedTx := func() *applicationpb.Tx {
+		return &applicationpb.Tx{Endorsements: dummyEndorsements(1)}
+	}
+
+	txb := &workload.TxBuilder{ChannelID: testChannelID}
+	// Block layout by original TxNum:
+	//   0: malformed (rejected; empty namespaces; original TxNum 0 < snapshot TxNum 2)
+	//   1: regular
+	//   2: snapshot (accepted; the barrier)
+	//   3: regular
+	//   4: snapshot (rejected as duplicate; original TxNum 4 > snapshot TxNum 2)
+	block := workload.MapToOrdererBlock(7, []*servicepb.LoadGenTx{
+		txb.MakeTx(malformedTx()),
+		txb.MakeTx(regularTx()),
+		txb.MakeTx(snapshotTx()),
+		txb.MakeTx(regularTx()),
+		txb.MakeTx(snapshotTx()),
+	})
+
+	var txIDToHeight utils.SyncMap[string, servicepb.Height]
+	mappedBlock, err := mapBlock(block, &txIDToHeight)
+	require.NoError(t, err)
+	require.True(t, mappedBlock.hasSnapshot)
+	require.Len(t, mappedBlock.block.Rejected, 2)
+
+	segments := splitSnapshotMappedBlock(mappedBlock)
+	// Pre-snapshot regular segment, snapshot segment, post-snapshot regular segment.
+	require.Len(t, segments, 3)
+
+	pre, snap, post := segments[0], segments[1], segments[2]
+
+	// Pre-snapshot segment: the leading regular TX plus the malformed reject (original TxNum 0),
+	// which must land here (before the barrier), not on the post-snapshot segment.
+	require.False(t, pre.hasSnapshot)
+	require.Len(t, pre.block.Txs, 1)
+	require.Len(t, pre.block.Rejected, 1)
+	require.Equal(
+		t,
+		committerpb.Status_MALFORMED_EMPTY_NAMESPACES,
+		pre.block.Rejected[0].Status,
+	)
+	require.Equal(t, uint32(0), pre.block.Rejected[0].Ref.TxNum)
+
+	// Snapshot segment: the snapshot TX alone, no rejected.
+	require.True(t, snap.hasSnapshot)
+	require.Len(t, snap.block.Txs, 1)
+	require.Equal(t, committerpb.SnapshotNamespaceID, snap.block.Txs[0].Content.Namespaces[0].NsId)
+	require.Empty(t, snap.block.Rejected)
+
+	// Post-snapshot segment: the trailing regular TX plus the duplicate-snapshot reject,
+	// which must land here (after the barrier), not on the pre-snapshot segment.
+	require.False(t, post.hasSnapshot)
+	require.Len(t, post.block.Txs, 1)
+	require.Len(t, post.block.Rejected, 1)
+	require.Equal(
+		t,
+		committerpb.Status_REJECTED_DUPLICATE_SNAPSHOT_IN_BLOCK,
+		post.block.Rejected[0].Status,
+	)
+	require.Equal(t, uint32(4), post.block.Rejected[0].Ref.TxNum)
+}
+
+// TestSplitSnapshotMappedBlockPositions verifies segment structure for the snapshot at each
+// position in the block: first, middle, last, and snapshot-only. It asserts the number of
+// segments and which segment carries the snapshot, exercising the leading/trailing empty-segment
+// skips in splitSnapshotMappedBlock.
+func TestSplitSnapshotMappedBlockPositions(t *testing.T) {
+	t.Parallel()
+
+	snapshotTx := func() *applicationpb.Tx {
+		return &applicationpb.Tx{
+			Namespaces:   []*applicationpb.TxNamespace{{NsId: committerpb.SnapshotNamespaceID}},
+			Endorsements: dummyEndorsements(1),
+		}
+	}
+	regularTx := func() *applicationpb.Tx {
+		return &applicationpb.Tx{
+			Namespaces: []*applicationpb.TxNamespace{{
+				NsId:        "ns",
+				BlindWrites: []*applicationpb.Write{{Key: []byte("key")}},
+			}},
+			Endorsements: dummyEndorsements(1),
+		}
+	}
+
+	tests := []struct {
+		name string
+		// txs is the ordered list of transaction factories for the block.
+		txs              []func() *applicationpb.Tx
+		expectedSegments int
+		// snapshotSegment is the index of the segment that must carry the snapshot TX.
+		snapshotSegment int
+	}{
+		{
+			name:             "snapshot is the only tx",
+			txs:              []func() *applicationpb.Tx{snapshotTx},
+			expectedSegments: 1,
+			snapshotSegment:  0,
+		},
+		{
+			name:             "snapshot is the first tx",
+			txs:              []func() *applicationpb.Tx{snapshotTx, regularTx, regularTx},
+			expectedSegments: 2,
+			snapshotSegment:  0,
+		},
+		{
+			name:             "snapshot is a middle tx",
+			txs:              []func() *applicationpb.Tx{regularTx, snapshotTx, regularTx},
+			expectedSegments: 3,
+			snapshotSegment:  1,
+		},
+		{
+			name:             "snapshot is the last tx",
+			txs:              []func() *applicationpb.Tx{regularTx, regularTx, snapshotTx},
+			expectedSegments: 2,
+			snapshotSegment:  1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			txb := &workload.TxBuilder{ChannelID: testChannelID}
+			loadGenTxs := make([]*servicepb.LoadGenTx, len(tc.txs))
+			for i, makeTx := range tc.txs {
+				loadGenTxs[i] = txb.MakeTx(makeTx())
+			}
+			block := workload.MapToOrdererBlock(9, loadGenTxs)
+
+			var txIDToHeight utils.SyncMap[string, servicepb.Height]
+			mappedBlock, err := mapBlock(block, &txIDToHeight)
+			require.NoError(t, err)
+			require.True(t, mappedBlock.hasSnapshot)
+			require.Empty(t, mappedBlock.block.Rejected)
+
+			segments := splitSnapshotMappedBlock(mappedBlock)
+			require.Len(t, segments, tc.expectedSegments)
+
+			// Exactly one segment carries the snapshot, and it holds only the snapshot TX.
+			for i, seg := range segments {
+				if i == tc.snapshotSegment {
+					require.True(t, seg.hasSnapshot)
+					require.Len(t, seg.block.Txs, 1)
+					require.Equal(
+						t,
+						committerpb.SnapshotNamespaceID,
+						seg.block.Txs[0].Content.Namespaces[0].NsId,
+					)
+					continue
+				}
+				require.False(t, seg.hasSnapshot)
+				require.NotEmpty(t, seg.block.Txs)
+			}
+		})
+	}
+}
+
 func (e *relayTestEnv) readAllStatusQueue(t *testing.T) []*committerpb.TxStatus {
 	t.Helper()
 	var status []*committerpb.TxStatus
@@ -295,6 +551,15 @@ func createConfigBlockForTest(t *testing.T) *common.Block {
 	})
 	require.NoError(t, err)
 	return block
+}
+
+func makeSnapshotTxForTest(t *testing.T, chanID string) *servicepb.LoadGenTx {
+	t.Helper()
+	txb := workload.TxBuilder{ChannelID: chanID}
+	return txb.MakeTx(&applicationpb.Tx{
+		Namespaces:   []*applicationpb.TxNamespace{{NsId: committerpb.SnapshotNamespaceID, NsVersion: 0}},
+		Endorsements: dummyEndorsements(1),
+	})
 }
 
 // createBlockForTest creates sample block with three txIDs.


### PR DESCRIPTION
#### Type of change

- New feature
- Test update
- Documentation update

#### Description

- Detect the `_snapshot` marker TX in `mapMessage` and validate `_snapshot`/`_checkpoint`
  system-namespace forms in the sidecar:
  - `_snapshot`/`_checkpoint` must be standalone (exactly one namespace); a mixed
    system+user TX returns `MALFORMED_SYSTEM_TX_NOT_STANDALONE`.
  - `_snapshot` must be marker-only (no reads/read-writes/blind-writes), else
    `MALFORMED_SNAPSHOT_NOT_MARKER_ONLY`; an ordinary no-write namespace still returns
    `MALFORMED_NO_WRITES`.
  - `_checkpoint` must have exactly one read-write whose key decodes as a full
    `servicepb.Height` via `NewHeightFromBytes`, else `MALFORMED_CHECKPOINT_INVALID_KEY`.
  - System namespace IDs are recognized during namespace-ID validation while application
    `_config` transactions are still rejected.
- Split-and-drain snapshot blocks in the relay: treat the snapshot TX as a submission
  barrier - submit the regular TXs before it, `WaitTillEmpty`, submit the snapshot alone,
  `WaitTillEmpty` again (drain ends on VC COMMITTED, not on hash completion), then resume.
- Accept only the first `_snapshot` TX in a block; reject any further `_snapshot` in the
  same block with `REJECTED_DUPLICATE_SNAPSHOT_IN_BLOCK` (a stored status), bounding the
  drain to one barrier per block.

#### Additional details (Optional)

- `mapBlock` tracks `hasSnapshot`/`snapshotTxIndex` so the relay splits around the snapshot
  without re-inspecting TX bodies.
- Rejected statuses (which have no TX body) are partitioned around the snapshot by their
  original block position, so a stored post-snapshot reject (e.g. a duplicate snapshot)
  commits after the barrier and does not leak a `tx_status` row into the snapshot clone.
- Each split block is registered and counted active only once, avoiding an
  `activeBlocksCount` over-count across snapshot segments.
- Bumps `fabric-x-common` to the commit introducing the new statuses; behavior documented
  in `docs/sidecar.md`.
- Tested via `service/sidecar` mapping/relay unit tests (form validation, duplicate-in-block,
  segment partitioning for first/middle/last/only positions, and both drain points);
  `make lint` clean.

#### Related issues

- resolves #660
