### PR TITLE
[vc] Create snapshot clone before committing the _snapshot marker

### DIFF
--- a/.bob/skills/development/SKILL.md
+++ b/.bob/skills/development/SKILL.md
@@ -250,6 +250,14 @@ Uses `github.com/cockroachdb/errors` (the `depguard` linter bans `github.com/pkg
    enforces this). This adds a message without a redundant second trace.
 3. **Return errors up the stack; do not log mid-stack.** Log once, at the boundary.
 
+**Pitfall — double-wrapping our own errors.** When the error already came from our code
+(any `service/`, `utils/`, or helper that already `errors.Wrap`-ped it), do NOT re-wrap
+with `errors.Wrap/Wrapf` — that captures a second, redundant stack trace at the same
+logical point. Use `fmt.Errorf("context: %w", err)` to add context while preserving the
+original trace. Reserve `errors.Wrap/Wrapf` for the origin (external lib or first crossing
+into our code). Example: `readStatusWithHeight` already wraps, so a caller adding the txID
+uses `fmt.Errorf("failed to read status for tx %s: %w", txID, err)`, not `errors.Wrapf`.
+
 ```go
 if len(query.TxIds) == 0 {
 	return nil, grpcerror.WrapInvalidArgument(errors.New("query is empty"))

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.x'
+          python-version: "3.x"
       - run: pip install mkdocs-material
       - run: mkdocs build
 
@@ -116,6 +116,12 @@ jobs:
     name: Core DB Tests (yugabyte)
     needs: [gate]
     runs-on: ubuntu-latest
+    # This job starts YugabyteDB (get-and-start-yuga.sh), so override the workflow-level
+    # DB_TYPE=postgres. The snapshot clone tests create a per-database snapshot schedule
+    # (testdb.EnsureSnapshotSchedule) only when DB_TYPE=yugabyte; without this
+    # the schedule is skipped and the clone fails with "Could not find snapshot schedule".
+    env:
+      DB_TYPE: yugabyte
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5

--- a/docs/deployment-guide.md
+++ b/docs/deployment-guide.md
@@ -168,7 +168,31 @@ Start the database cluster first and wait for it to be healthy before starting a
    - This is a one-time administrative operation that must be performed before booting the committer for the first time
    - The command is safe to run multiple times
 
-3. **Start Services** (any order after database is healthy and initialized)
+3. **Provision a YugabyteDB PITR snapshot schedule (required for state snapshots)**
+
+   State snapshots create a native database clone via `CREATE DATABASE ... TEMPLATE`.
+   On YugabyteDB, cloning is built on Point-in-Time Recovery and **fails without a
+   pre-existing snapshot schedule** on the state database (error: `Could not find
+   snapshot schedule for namespace <db>`) — this applies even to as-of-now clones.
+   **Without this schedule, snapshots cannot be created.** PostgreSQL deployments do
+   not need this step.
+
+   The schedule can only be created with the `yb-admin` CLI (no YSQL statement exists),
+   so it is an operator provisioning step performed once against the state database:
+   ```shell
+   yb-admin --master_addresses <ip1:7100,ip2:7100,ip3:7100> \
+     create_snapshot_schedule <interval-minutes> <retention-minutes> ysql.<database>
+   ```
+
+   **Keep the interval and retention as short as your operations allow.** The committer
+   needs the schedule only to enable cloning, not for a recovery window. Retention is the
+   performance lever: a long window pins old SST files (disk growth) and forces DocDB to
+   retain more MVCC history (larger, slower scans). A short interval/retention lets
+   compaction reclaim history promptly. The schedule's mere existence has no throughput
+   cost. Note that while a schedule exists it blocks `DROP DATABASE` of the state database
+   and disallows `DROP TABLESPACE` cluster-wide.
+
+4. **Start Services** (any order after database is healthy and initialized)
    - VC Service — connects to database on startup
    - Query Service — connects to database on startup
    - Verifier Service — stateless, loads policies on first request

--- a/docs/validator-committer.md
+++ b/docs/validator-committer.md
@@ -275,6 +275,41 @@ If this happens, the writes and/or statuses for the corresponding transactions a
 **e. Reporting Status:** After the commit is successful, the `batchStatus` is sent to the `txsStatus` channel, which relays the information 
 back to the Coordinator, completing the workflow for the transaction batch.
 
+### Task 4. Creating State Snapshots (Clone-First)
+
+When a `_snapshot` marker transaction is committed, the VC creates a native,
+zero-copy clone of the state database **before** the marker's transaction ID is
+committed, preserving the invariant `txID committed <=> clone exists <=> PENDING row`.
+The clone is a consistent copy of the drained state cut and is never dropped by
+the VC (dropping is forbidden because it could delete a clone whose txID has not
+yet committed). See [snapshot.go](/service/vc/snapshot.go).
+
+A `_snapshot` transaction is submitted standalone: the sidecar drains the pipeline
+before and after it, so no user transaction commits until the snapshot is fully
+processed. The clone therefore captures the exact snapshot cut with a plain
+`CREATE DATABASE <clone> TEMPLATE <source>` (as of current time), with no `AS OF`
+timestamp required.
+
+> **YugabyteDB prerequisite — a PITR snapshot schedule is mandatory.** YugabyteDB
+> database cloning is built on Point-in-Time Recovery: `CREATE DATABASE ... TEMPLATE`
+> fails with `Could not find snapshot schedule for namespace <db>` unless a snapshot
+> schedule already exists on the source database — this holds even for as-of-now
+> clones (no `AS OF`). **Without a snapshot schedule, snapshots cannot be created.**
+>
+> The schedule can only be created with the `yb-admin` CLI (there is no YSQL/SQL
+> statement for it), so it is an out-of-band operator provisioning step, not something
+> the VC creates at runtime. See the deployment guide for provisioning and tuning.
+>
+> **Performance:** merely having a schedule does not slow the database; the cost is
+> driven by the retention window. A long retention pins old SST files (disk growth)
+> and forces DocDB to keep more MVCC history, which enlarges scans. Because the
+> committer only needs cloning (not a recovery window), keep the snapshot interval and
+> retention as short as YugabyteDB allows. Also note a schedule blocks `DROP DATABASE`
+> of the source and disallows `DROP TABLESPACE` cluster-wide while it exists.
+>
+> PostgreSQL uses `CREATE DATABASE ... TEMPLATE ... STRATEGY=FILE_COPY` and needs no
+> schedule.
+
 ## 6. gRPC Service API
 
 The VC service exposes a [gRPC API](/service/vc/validator_committer_service.go) (`ValidationAndCommitServiceClient`) for the Coordinator and other system components. The methods are:

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,8 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0
 	github.com/hyperledger/fabric-lib-go v1.1.5-0.20260708100132-163bcc919208
 	github.com/hyperledger/fabric-protos-go-apiv2 v0.3.7
-	github.com/hyperledger/fabric-x-common v0.2.9-0.20260716124624-c6defc2b11b4
+	github.com/hyperledger/fabric-x-common v0.2.9-0.20260722080022-42995bb28ab4
+	github.com/jackc/pgerrcode v0.0.0-20250907135507-afb5586c32a6
 	github.com/jackc/puddle/v2 v2.2.2
 	github.com/moby/moby/api v1.55.0
 	github.com/moby/moby/client v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -178,13 +178,15 @@ github.com/hyperledger/fabric-lib-go v1.1.5-0.20260708100132-163bcc919208 h1:qA4
 github.com/hyperledger/fabric-lib-go v1.1.5-0.20260708100132-163bcc919208/go.mod h1:EKqTudBsC2yovZdcJq5ekWvkq3USF1mbau07I0y8zMs=
 github.com/hyperledger/fabric-protos-go-apiv2 v0.3.7 h1:sQ5qv8vQQfwewa1JlCiSCC8dLElmaU2/frLolpgibEY=
 github.com/hyperledger/fabric-protos-go-apiv2 v0.3.7/go.mod h1:bJnwzfv03oZQeCc863pdGTDgf5nmCy6Za3RAE7d2XsQ=
-github.com/hyperledger/fabric-x-common v0.2.9-0.20260716124624-c6defc2b11b4 h1:jmVAZ5vi3z1v/XlZwvhwJqkPZo5x+lxG/nx3dsG6hhM=
-github.com/hyperledger/fabric-x-common v0.2.9-0.20260716124624-c6defc2b11b4/go.mod h1:f30Yws3c5Cg22yHLy2oT2XR0wwZI+JdqbUqB2fwFIsM=
+github.com/hyperledger/fabric-x-common v0.2.9-0.20260722080022-42995bb28ab4 h1:koLa0IHVFmi5cdXC8R8lMbePA3PhFCFhSY7MheIx7NA=
+github.com/hyperledger/fabric-x-common v0.2.9-0.20260722080022-42995bb28ab4/go.mod h1:f30Yws3c5Cg22yHLy2oT2XR0wwZI+JdqbUqB2fwFIsM=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imkira/go-interpol v1.1.0 h1:KIiKr0VSG2CUW1hl1jpiyuzuJeKUUpC8iM1AIE7N1Vk=
 github.com/imkira/go-interpol v1.1.0/go.mod h1:z0h2/2T3XF8kyEPpRgJ3kmNv+C43p+I/CoI+jC3w2iA=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/jackc/pgerrcode v0.0.0-20250907135507-afb5586c32a6 h1:D/V0gu4zQ3cL2WKeVNVM4r2gLxGGf6McLwgXzRTo2RQ=
+github.com/jackc/pgerrcode v0.0.0-20250907135507-afb5586c32a6/go.mod h1:a/s9Lp5W7n/DD0VrVoyJ00FbP2ytTPDVOivvn2bMlds=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=

--- a/scripts/get-and-start-yuga.sh
+++ b/scripts/get-and-start-yuga.sh
@@ -22,7 +22,13 @@ docker run --name "$YUGA_CONTAINER" \
     --background false \
     --ui false \
     --insecure \
-    --tserver_flags "pgsql_proxy_bind_address=0.0.0.0,ysql_max_connections=500,tablet_replicas_per_gib_limit=4000,yb_num_shards_per_tserver=1,minloglevel=3,yb_enable_read_committed_isolation=true"
+    --tserver_flags "pgsql_proxy_bind_address=0.0.0.0,ysql_max_connections=500,tablet_replicas_per_gib_limit=4000,yb_num_shards_per_tserver=1,minloglevel=3,yb_enable_read_committed_isolation=true" \
+    --master_flags "enable_db_clone=true"
+#  enable_db_clone is required for database cloning (CREATE DATABASE ... TEMPLATE,
+#  used by service/vc/snapshot.go). Without it the clone fails with
+#  "FLAGS_enable_db_clone is disabled". Cloning also needs a per-database snapshot
+#  schedule; that is created at test time by testdb.EnsureSnapshotSchedule
+#  (which knows the random per-test database name).
 #  By default, 1 GB of memory reserved for a YB-Tserver can support up to 1497
 #  tablets. When tests are run in parallel, this limit is sometimes reached in
 #  environments with low resource allocation, causing the test to fail. To handle

--- a/service/coordinator/dependencygraph/transaction_node.go
+++ b/service/coordinator/dependencygraph/transaction_node.go
@@ -172,7 +172,7 @@ func readAndWriteKeys(txNamespaces []*applicationpb.TxNamespace) readWriteKeys {
 		// for all previously submitted transactions to be processed before submitting a config block, and
 		// waits for that block to comnitted before sending new transactions. Therefore, we do not need to
 		// track dependencies between meta-namespace and configuration transactions.
-		if !utils.IsSystemNamespace(ns.NsId) {
+		if !committerpb.IsSystemNamespace(ns.NsId) {
 			readOnlyKeys = append(readOnlyKeys, constructCompositeKey(committerpb.MetaNamespaceID, []byte(ns.NsId)))
 		}
 

--- a/service/vc/committer.go
+++ b/service/vc/committer.go
@@ -122,6 +122,17 @@ func (c *transactionCommitter) commitTransactions(
 	// to reuse transaction IDs.
 	// However, we still limit the number of retries to some arbitrary number to avoid an endless loop due to a bug.
 	maxRetriesToRemoveAllInvalidTxs := 1024
+	// Snapshot-database-first: if batch carries a _snapshot record, create native
+	// database and rewrite record value to PENDING+clone_database BEFORE batch
+	// commits. Snapshot txID commits only once snapshot database exists
+	// (invariant txID <=> database <=> record). Creation failure aborts batch and
+	// coordinator retries it.
+	// TODO: COORDINATOR detects VC failure and decides resubmission or snapshot
+	// database recreation/re-hash; VC does not self-recover.
+	if err := db.createSnapshotIfPresent(ctx, vTx.newWrites); err != nil {
+		return nil, fmt.Errorf("failed to create snapshot before commit: %w", err)
+	}
+
 	for range maxRetriesToRemoveAllInvalidTxs {
 		// Group the writes by namespace so that we can commit to each table independently.
 		info := &statesToBeCommitted{

--- a/service/vc/database.go
+++ b/service/vc/database.go
@@ -55,6 +55,7 @@ type (
 		metrics              *perfMetrics
 		retryProfile         *retry.Profile
 		tablePreSplitTablets int
+		config               *statedb.Config
 	}
 
 	// keyToVersion is a map from key to version.
@@ -98,6 +99,7 @@ func newDatabase(ctx context.Context, config *statedb.Config, metrics *perfMetri
 		metrics:              metrics,
 		retryProfile:         config.Retry,
 		tablePreSplitTablets: tablePreSplitTablets,
+		config:               config,
 	}, nil
 }
 

--- a/service/vc/preparer.go
+++ b/service/vc/preparer.go
@@ -177,13 +177,12 @@ func (p *transactionPreparer) prepare(ctx context.Context) error { //nolint:goco
 				tID := TxID(tx.Ref.TxId)
 				logger.Debugf("Preparing namespace %s in TX with ID %s ", nsOperations.NsId, tx.Ref.TxId)
 
-				// The _snapshot marker TX carries no application reads/writes and takes no
-				// _meta namespace-version dependency. We synthesize a single new write into
-				// the _snapshot namespace so the namespace is forwarded to the committer:
-				// key = tx_id, value = SnapshotState{TxRef}. Only the TxRef is set here; the
-				// committer/hash worker fills in the lifecycle status and clone details. The
-				// nil version makes this a new key, and MVCC on tx_id gives idempotency for
-				// duplicate snapshot requests.
+				// _snapshot record TX carries no application reads/writes and takes no _meta
+				// namespace-version dependency. We synthesize one new _snapshot record so
+				// namespace reaches committer: key = tx_id, value = SnapshotState{TxRef}.
+				// Only TxRef is set here; committer/hash worker fills lifecycle status and
+				// snapshot database details. Nil version makes this a new key, and MVCC on
+				// tx_id gives idempotency for duplicate snapshot requests.
 				if nsOperations.NsId == committerpb.SnapshotNamespaceID {
 					// proto.Marshal cannot fail here: SnapshotState{TxRef} is a small, acyclic
 					// message. We return the error only for completeness. proto.Marshal is

--- a/service/vc/preparer_test.go
+++ b/service/vc/preparer_test.go
@@ -655,7 +655,7 @@ func TestPrepareTx(t *testing.T) { //nolint:maintidx // cannot improve.
 	ensurePreparedTx(t, expectedPreparedTxs, preparedTxs)
 }
 
-// TestPrepareSnapshotTx verifies that a _snapshot marker TX takes no _meta namespace-version
+// TestPrepareSnapshotTx verifies that a _snapshot record TX takes no _meta namespace-version
 // dependency and is forwarded to the committer as a single new write into the _snapshot
 // namespace (key = tx_id, value = SnapshotState{TxRef}), so the namespace survives the preparer.
 func TestPrepareSnapshotTx(t *testing.T) {

--- a/service/vc/snapshot.go
+++ b/service/vc/snapshot.go
@@ -1,0 +1,279 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package vc
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/cockroachdb/errors"
+	"github.com/hyperledger/fabric-x-common/api/committerpb"
+	"github.com/jackc/pgerrcode"
+	"github.com/yugabyte/pgx/v5"
+	"github.com/yugabyte/pgx/v5/pgconn"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/hyperledger/fabric-x-committer/utils/statedb"
+)
+
+// maintenanceDBName is the neutral admin database the clone runs against.
+// A session cannot CREATE/DROP the database it is connected to on EITHER
+// backend, so both PostgreSQL and YugabyteDB need a separate always-present DB
+// to issue CREATE DATABASE from; that is what this connects to.
+//
+// "postgres" is chosen because it is created by default on both backends
+// (YugabyteDB ships a "postgres" database for PG compatibility) and is never
+// the clone source, so it is never locked out by the PostgreSQL
+// ALLOW_CONNECTIONS dance. The extra PostgreSQL requirement that the TEMPLATE
+// source be free of other sessions is handled in createPostgresSnapshotDatabase, not here,
+// and does not apply to YugabyteDB (DocDB cloning keeps the source live).
+const maintenanceDBName = "postgres"
+
+// createSnapshotIfPresent detects a _snapshot record in the batch's
+// per-transaction new-writes and, BEFORE the batch is committed, creates the
+// snapshot database and rewrites the record's value to a PENDING SnapshotState
+// carrying that database name. The rewritten value is then persisted atomically
+// with the snapshot txID by the normal db.commit path, giving the invariant
+// txID committed <=> snapshot database exists <=> PENDING record.
+//
+// The sidecar drains before and after a snapshot TX, so it is submitted
+// standalone: its batch holds exactly one transaction (one new-write entry) and
+// the preparer adds exactly one _snapshot record (key = tx_id) for it. We short-
+// circuit unless newWrites has exactly one entry and act on that single record
+// rather than scanning every write.
+//
+// The incoming record value carries only TxRef with status UNSPECIFIED (the
+// preparer sets no status). This function is called exactly once per batch,
+// before the committer's retry loop, so it neither reads a status back from the
+// _snapshot table nor re-observes its own PENDING rewrite.
+//
+// Snapshot database creation MUST succeed before txID is committed. On failure
+// this returns an error, batch is not committed, txID stays uncommitted, and
+// coordinator retries snapshot (this PR does not self-recover).
+func (db *database) createSnapshotIfPresent(ctx context.Context, newWrites transactionToWrites) error {
+	// A snapshot TX is submitted standalone: the sidecar drains before and after it,
+	// so its batch contains exactly one transaction and hence one new-write entry.
+	// Any other count means there is no _snapshot record to act on.
+	if len(newWrites) != 1 {
+		return nil
+	}
+	for _, nsWrites := range newWrites {
+		w := nsWrites[committerpb.SnapshotNamespaceID]
+		if w.empty() {
+			return nil
+		}
+		// Exactly one key: the preparer adds a single _snapshot record per snapshot TX.
+		snapshotState, err := db.createSnapshotDatabaseAndRewriteRecord(ctx, w.keys[0], w.values[0])
+		if err != nil {
+			return err
+		}
+		if snapshotState != nil {
+			w.values[0] = snapshotState
+		}
+	}
+	return nil
+}
+
+// createSnapshotDatabaseAndRewriteRecord decodes one _snapshot record, creates
+// or reuses its snapshot database when needed, and returns a rewritten PENDING
+// record. A nil result means leave recordValue unchanged.
+//
+// The tx_status lookup and CREATE-only database operation handle these cases:
+//
+//	snapshot case                                txID in tx_status  database action            record result
+//	fresh snapshot                               no                 create                    rewritten PENDING
+//	retry after failed database creation         no                 create                    rewritten PENDING
+//	retry after database creation, before commit no                 CREATE; duplicate = reuse rewritten PENDING
+//	resubmission or duplicate txID               yes                do not create or reuse     unchanged
+//
+// A txID already in tx_status may be a same-height resubmission or a
+// different-height duplicate. The normal commit path resolves that distinction;
+// this function must not create a snapshot database for either case.
+func (db *database) createSnapshotDatabaseAndRewriteRecord(
+	ctx context.Context, key, recordValue []byte,
+) ([]byte, error) {
+	var state committerpb.SnapshotState
+	if err := proto.Unmarshal(recordValue, &state); err != nil {
+		return nil, errors.Wrapf(err, "failed to decode _snapshot record for key %s", key)
+	}
+	ref := state.TxRef
+	if ref == nil {
+		return nil, errors.Newf("_snapshot record for key %s has no TxRef", key)
+	}
+
+	// Skip database creation unless this is first-ever submission (txID absent
+	// from tx_status). If txID exists at SAME height it is a resubmission whose
+	// snapshot database was created in a prior life; if it exists at DIFFERENT
+	// height snapshot TX is rejected as duplicate and must not leave an orphan
+	// database behind. Either way leave record unchanged; commit path returns
+	// correct status.
+	rows, err := db.readStatusWithHeight(ctx, [][]byte{[]byte(ref.TxId)})
+	if err != nil {
+		return nil, fmt.Errorf("failed to read status for snapshot tx %s: %w", ref.TxId, err)
+	}
+	if len(rows) > 0 {
+		return nil, nil
+	}
+
+	snapshotDatabase := snapshotDatabaseName(ref)
+	if createErr := db.createSnapshotDatabase(ctx, snapshotDatabase); createErr != nil {
+		return nil, fmt.Errorf("failed to create snapshot database %s: %w", snapshotDatabase, createErr)
+	}
+
+	// PENDING record rewrite: written atomically with the snapshot txID by the
+	// normal db.commit path once the snapshot database exists.
+	snapshotState, err := proto.Marshal(&committerpb.SnapshotState{
+		TxRef:         ref,
+		Status:        committerpb.SnapshotState_PENDING,
+		CloneDatabase: snapshotDatabase,
+	})
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to marshal PENDING snapshot state for database %s", snapshotDatabase)
+	}
+	return snapshotState, nil
+}
+
+// snapshotDatabaseName returns deterministic database name for a snapshot at
+// given TxRef. Name encodes block height so any VC (first attempt or
+// coordinator-directed resubmission) targets same database.
+func snapshotDatabaseName(ref *committerpb.TxRef) string {
+	return fmt.Sprintf("snapshot_%d", ref.BlockNum)
+}
+
+// createSnapshotDatabase creates native zero-copy database named databaseName
+// from source database. CREATE-only: it never DROPs. A "database already exists"
+// result is treated as success (reuse) — name is deterministic and database
+// content is drained deterministic cut, so a sibling VC's database is
+// equivalent. Dropping here could delete a database whose txID has not yet
+// committed, so it is forbidden.
+//
+// TODO: a hard-kill of the PostgreSQL path between
+// ALLOW_CONNECTIONS false and the deferred re-enable locks out src for ALL
+// pools. A VC cannot fix this (it may be dead; peers aren't authorized). The
+// COORDINATOR, on detecting VC failure, re-enables ALLOW_CONNECTIONS via the
+// maintenance DB. Not implemented in this PR.
+func (db *database) createSnapshotDatabase(ctx context.Context, databaseName string) error {
+	isYuga, err := statedb.IsYugabyteDB(ctx, db.pool)
+	if err != nil {
+		return err
+	}
+	src := pgx.Identifier{db.config.Database}.Sanitize()
+	snapshotDatabase := pgx.Identifier{databaseName}.Sanitize()
+
+	if isYuga {
+		return db.createYugabyteSnapshotDatabase(ctx, snapshotDatabase, src)
+	}
+	return db.createPostgresSnapshotDatabase(ctx, snapshotDatabase, src)
+}
+
+// createYugabyteSnapshotDatabase uses DocDB cloning via CREATE DATABASE ... TEMPLATE; the
+// source stays live. We clone as of current time (no AS OF): the sidecar drains
+// before and after the snapshot TX and no user TX commits until the snapshot is
+// fully processed, so "now" already is the exact snapshot cut. Cloning still
+// requires a snapshot schedule to exist on the source keyspace (a standing PITR
+// object provisioned out of band); without it YugabyteDB returns "Could not
+// find snapshot schedule for namespace".
+func (db *database) createYugabyteSnapshotDatabase(ctx context.Context, clone, src string) error {
+	sql := fmt.Sprintf("CREATE DATABASE %s TEMPLATE %s", clone, src)
+	return ignoreDuplicateDatabase(db.adminExec(ctx, sql))
+}
+
+// createPostgresSnapshotDatabase uses STRATEGY=FILE_COPY. PostgreSQL requires the source
+// to have no other sessions during the clone, so we block new connections and
+// terminate existing ones, then re-allow (via defer, so it runs even on error).
+func (db *database) createPostgresSnapshotDatabase(ctx context.Context, clone, src string) error {
+	if err := db.adminExec(ctx, fmt.Sprintf("ALTER DATABASE %s ALLOW_CONNECTIONS false", src)); err != nil {
+		return err
+	}
+	// Re-enable even if CREATE DATABASE fails, so the source is never left locked
+	// out on the happy/soft-error path. (Hard-kill lockout is coordinator-recovered.)
+	defer func() { //nolint:contextcheck // re-enable must run even if ctx is already cancelled/expired.
+		if err := db.adminExec(context.Background(),
+			fmt.Sprintf("ALTER DATABASE %s ALLOW_CONNECTIONS true", src)); err != nil {
+			logger.Warnf("failed to re-enable connections on source database: %+v", err)
+		}
+	}()
+
+	// terminate uses a string-built literal (not a parameterized query) because
+	// adminExec takes a bare SQL string; db.config.Database is server-configured,
+	// not attacker input, so quote-doubling escaping is sufficient here.
+	terminate := fmt.Sprintf(
+		"SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '%s' AND pid <> pg_backend_pid()",
+		strings.ReplaceAll(db.config.Database, "'", "''"),
+	)
+	if err := db.adminExec(ctx, terminate); err != nil {
+		return err
+	}
+
+	sql := fmt.Sprintf("CREATE DATABASE %s TEMPLATE %s STRATEGY=FILE_COPY", clone, src)
+	return ignoreDuplicateDatabase(db.adminExec(ctx, sql))
+}
+
+// adminExec opens a short-lived dedicated connection to the maintenance DB
+// (outside the pgxpool) and runs a single statement. Used for CREATE DATABASE
+// and the PostgreSQL ALTER DATABASE dance, which cannot run on the source pool.
+//
+// Unlike the rest of this package, adminExec deliberately does NOT wrap the call
+// in db.retryProfile. The admin statements are one-shot DDL whose errors are
+// deterministic and semantically meaningful to the caller: "database already
+// exists" (PG SQLSTATE 42P04) is mapped to success by ignoreDuplicateDatabase,
+// and a missing template or bad name is a permanent failure. Retrying would
+// either loop on a permanent error until the context deadline or defeat that
+// mapping. The clone flow is instead re-driven end-to-end by the coordinator on
+// VC failure.
+//
+// Uses a bounded dial timeout (via a plain pgx.ConnConfig, not pgxpool) so an
+// unreachable endpoint in a multi-host DSN fails fast instead of hanging for
+// the context's full lifetime — pgx.Connect's default dialer has no timeout.
+func (db *database) adminExec(ctx context.Context, sql string) error {
+	c := db.config
+	dsn, err := statedb.DataSourceName(statedb.DataSourceNameParams{
+		Username:        c.Username,
+		Password:        c.Password,
+		Database:        maintenanceDBName,
+		EndpointsString: c.EndpointsString(),
+		LoadBalance:     c.LoadBalance,
+		TLS:             c.TLS,
+	})
+	if err != nil {
+		return err
+	}
+	connConfig, err := pgx.ParseConfig(dsn)
+	if err != nil {
+		return errors.Wrap(err, "failed to parse maintenance-db DSN")
+	}
+	dialer := &net.Dialer{Timeout: 10 * time.Second}
+	connConfig.DialFunc = dialer.DialContext
+
+	conn, err := pgx.ConnectConfig(ctx, connConfig)
+	if err != nil {
+		return errors.Wrap(err, "failed to open maintenance-db admin connection")
+	}
+	defer func() { _ = conn.Close(ctx) }()
+
+	if _, err := conn.Exec(ctx, sql); err != nil {
+		return errors.Wrapf(err, "failed to execute admin statement [%s]", sql)
+	}
+	return nil
+}
+
+// ignoreDuplicateDatabase maps the "database already exists" error (PG SQLSTATE
+// 42P04) to success: a concurrent sibling VC created the clone first, which is
+// exactly the clone we need (reuse).
+func ignoreDuplicateDatabase(err error) error {
+	if err == nil {
+		return nil
+	}
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) && pgErr.Code == pgerrcode.DuplicateDatabase {
+		return nil
+	}
+	return err
+}

--- a/service/vc/snapshot.go
+++ b/service/vc/snapshot.go
@@ -30,10 +30,14 @@ import (
 //
 // "postgres" is chosen because it is created by default on both backends
 // (YugabyteDB ships a "postgres" database for PG compatibility) and is never
-// the clone source, so it is never locked out by the PostgreSQL
-// ALLOW_CONNECTIONS dance. The extra PostgreSQL requirement that the TEMPLATE
-// source be free of other sessions is handled in createPostgresSnapshotDatabase, not here,
-// and does not apply to YugabyteDB (DocDB cloning keeps the source live).
+// the clone source. That matters because createPostgresSnapshotDatabase blocks
+// and terminates sessions on the SOURCE database only (ALLOW_CONNECTIONS false /
+// terminate-backends / ALLOW_CONNECTIONS true, see below) to satisfy PostgreSQL's
+// TEMPLATE requirement that the source be free of other sessions; connecting
+// admin operations through "postgres" instead of the source keeps this
+// connection itself from being one of the sessions that gets terminated or
+// locked out by that sequence. Does not apply to YugabyteDB (DocDB cloning
+// keeps the source live, so no lockout dance is needed there).
 const maintenanceDBName = "postgres"
 
 // createSnapshotIfPresent detects a _snapshot record in the batch's
@@ -186,8 +190,10 @@ func (db *database) createYugabyteSnapshotDatabase(ctx context.Context, clone, s
 }
 
 // createPostgresSnapshotDatabase uses STRATEGY=FILE_COPY. PostgreSQL requires the source
-// to have no other sessions during the clone, so we block new connections and
-// terminate existing ones, then re-allow (via defer, so it runs even on error).
+// to have no other sessions during the clone, so this runs a three-step sequence:
+// ALTER DATABASE ... ALLOW_CONNECTIONS false to block new sessions, terminate
+// existing backends via pg_terminate_backend, then CREATE DATABASE ... TEMPLATE ...
+// STRATEGY=FILE_COPY; ALLOW_CONNECTIONS is re-enabled via defer so it runs even on error.
 func (db *database) createPostgresSnapshotDatabase(ctx context.Context, clone, src string) error {
 	if err := db.adminExec(ctx, fmt.Sprintf("ALTER DATABASE %s ALLOW_CONNECTIONS false", src)); err != nil {
 		return err
@@ -258,10 +264,8 @@ func (db *database) adminExec(ctx context.Context, sql string) error {
 	}
 	defer func() { _ = conn.Close(ctx) }()
 
-	if _, err := conn.Exec(ctx, sql); err != nil {
-		return errors.Wrapf(err, "failed to execute admin statement [%s]", sql)
-	}
-	return nil
+	_, err = conn.Exec(ctx, sql)
+	return errors.Wrapf(err, "failed to execute admin statement [%s]", sql)
 }
 
 // ignoreDuplicateDatabase maps the "database already exists" error (PG SQLSTATE

--- a/service/vc/snapshot_test.go
+++ b/service/vc/snapshot_test.go
@@ -1,0 +1,253 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package vc
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hyperledger/fabric-x-common/api/committerpb"
+	"github.com/stretchr/testify/require"
+	"github.com/yugabyte/pgx/v5"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/hyperledger/fabric-x-committer/api/servicepb"
+	"github.com/hyperledger/fabric-x-committer/utils/channel"
+	"github.com/hyperledger/fabric-x-committer/utils/retry"
+	"github.com/hyperledger/fabric-x-committer/utils/testdb"
+)
+
+func TestSnapshotDatabaseName(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		blockNum uint64
+		want     string
+	}{
+		{name: "zero", blockNum: 0, want: "snapshot_0"},
+		{name: "typical", blockNum: 42, want: "snapshot_42"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.want, snapshotDatabaseName(&committerpb.TxRef{BlockNum: tc.blockNum}))
+		})
+	}
+}
+
+func TestCreateSnapshotDatabase(t *testing.T) {
+	t.Parallel()
+	env := NewDatabaseTestEnv(t)
+	testdb.EnsureSnapshotSchedule(t, env.DBConf.Database)
+	ctx, _ := createContext(t)
+	ref := &committerpb.TxRef{BlockNum: 1234567, TxNum: 0, TxId: "snap-clone-1"}
+	name := snapshotDatabaseName(ref)
+	dropCloneCleanup(t, env.DB, name)
+
+	// First creation succeeds and snapshot database exists.
+	require.NoError(t, env.DB.createSnapshotDatabase(ctx, name))
+	require.True(t, cloneExists(t, env.DB, name))
+
+	// Second creation over existing database is a no-op success (reuse), not drop+recreate.
+	require.NoError(t, env.DB.createSnapshotDatabase(ctx, name))
+	require.True(t, cloneExists(t, env.DB, name))
+}
+
+func cloneExists(t *testing.T, db *database, name string) bool {
+	t.Helper()
+	// createSnapshotDatabase's PostgreSQL path terminates all connections to source
+	// database (see createPostgresSnapshotDatabase), which can include this pool's own connection
+	// to db.config.Database, not just the clone name being polled for; the very next
+	// pool acquisition can hit that severed connection (SQLSTATE 57P01) before pgxpool
+	// notices and redials. Production callers tolerate this via db.retryProfile
+	// (e.g. commit's post-clone follow-up query); do the same here instead of a bare query.
+	exists, err := retry.ExecuteWithResult(t.Context(), db.retryProfile, func() (bool, error) {
+		var exists bool
+		err := db.pool.QueryRow(t.Context(),
+			"SELECT EXISTS(SELECT 1 FROM pg_database WHERE datname = $1)", name).Scan(&exists)
+		return exists, err
+	})
+	require.NoError(t, err)
+	return exists
+}
+
+func dropCloneCleanup(t *testing.T, db *database, name string) {
+	t.Helper()
+	t.Cleanup(func() {
+		sql := fmt.Sprintf("DROP DATABASE IF EXISTS %s", pgx.Identifier{name}.Sanitize())
+		_ = db.adminExec(context.Background(), sql)
+	})
+}
+
+func TestCommitSnapshotTxCreatesCloneAndPendingRow(t *testing.T) {
+	t.Parallel()
+	env := newCommitterTestEnv(t)
+	testdb.EnsureSnapshotSchedule(t, env.dbEnv.DBConf.Database)
+	ctx, _ := createContext(t)
+
+	ref := &committerpb.TxRef{BlockNum: 987654, TxNum: 1, TxId: "snap-e2e-1"}
+	name := snapshotDatabaseName(ref)
+	dropCloneCleanup(t, env.dbEnv.DB, name)
+
+	// Preparer routes _snapshot record as a new write: key=txId, value=SnapshotState{TxRef}.
+	value, err := proto.Marshal(&committerpb.SnapshotState{TxRef: ref})
+	require.NoError(t, err)
+
+	newWrites := make(transactionToWrites)
+	nw := newWrites.getOrCreate(TxID(ref.TxId), committerpb.SnapshotNamespaceID)
+	nw.append([]byte(ref.TxId), value, 0)
+
+	vTx := &validatedTransactions{
+		validTxNonBlindWrites: transactionToWrites{},
+		validTxBlindWrites:    transactionToWrites{},
+		newWrites:             newWrites,
+		readToTxIDs:           readToTransactions{},
+		invalidTxStatus:       map[TxID]committerpb.Status{},
+		txIDToHeight:          transactionIDToHeight{TxID(ref.TxId): servicepb.NewHeightFromTxRef(ref)},
+	}
+
+	channel.NewWriter(ctx, env.validatedTxs).Write(vTx)
+
+	// Committed status is returned.
+	status, ok := channel.NewReader(ctx, env.txStatus).Read()
+	require.True(t, ok)
+	require.Len(t, status.Status, 1)
+	require.Equal(t, committerpb.Status_COMMITTED, status.Status[0].Status)
+
+	// Snapshot database exists.
+	require.True(t, cloneExists(t, env.dbEnv.DB, name))
+
+	// Committed _snapshot record is PENDING with clone_database set.
+	rows := env.dbEnv.FetchKeys(t, committerpb.SnapshotNamespaceID, [][]byte{[]byte(ref.TxId)})
+	stored := rows[ref.TxId]
+	require.NotNil(t, stored)
+	var got committerpb.SnapshotState
+	require.NoError(t, proto.Unmarshal(stored.Value, &got))
+	require.Equal(t, committerpb.SnapshotState_PENDING, got.Status)
+	require.Equal(t, name, got.CloneDatabase)
+	require.Equal(t, ref.TxId, got.TxRef.TxId)
+}
+
+func TestSnapshotDatabaseFailureReturnsError(t *testing.T) {
+	t.Parallel()
+	env := NewDatabaseTestEnv(t)
+	ctx, _ := createContext(t)
+
+	// Force database-creation failure by pointing source DB name at nonexistent DB.
+	env.DB.config.Database = "definitely_not_a_real_source_db_name"
+
+	ref := &committerpb.TxRef{BlockNum: 555, TxNum: 0, TxId: "snap-fail-1"}
+	value, err := proto.Marshal(&committerpb.SnapshotState{TxRef: ref})
+	require.NoError(t, err)
+	nws := make(transactionToWrites)
+	nws.getOrCreate(TxID(ref.TxId), committerpb.SnapshotNamespaceID).append([]byte(ref.TxId), value, 0)
+
+	err = env.DB.createSnapshotIfPresent(ctx, nws)
+	require.ErrorContains(t, err, "failed to create snapshot database")
+	require.False(t, cloneExists(t, env.DB, snapshotDatabaseName(ref)))
+}
+
+func TestSnapshotDuplicateTxIDIsIdempotent(t *testing.T) {
+	t.Parallel()
+	env := newCommitterTestEnv(t)
+	testdb.EnsureSnapshotSchedule(t, env.dbEnv.DBConf.Database)
+	ctx, _ := createContext(t)
+	writer := channel.NewWriter(ctx, env.validatedTxs)
+	reader := channel.NewReader(ctx, env.txStatus)
+
+	ref := &committerpb.TxRef{BlockNum: 222333, TxNum: 0, TxId: "snap-dup-1"}
+	name := snapshotDatabaseName(ref)
+	dropCloneCleanup(t, env.dbEnv.DB, name)
+
+	build := func() *validatedTransactions {
+		value, err := proto.Marshal(&committerpb.SnapshotState{TxRef: ref})
+		require.NoError(t, err)
+		nws := make(transactionToWrites)
+		nws.getOrCreate(TxID(ref.TxId), committerpb.SnapshotNamespaceID).append([]byte(ref.TxId), value, 0)
+		return &validatedTransactions{
+			validTxNonBlindWrites: transactionToWrites{},
+			validTxBlindWrites:    transactionToWrites{},
+			newWrites:             nws,
+			readToTxIDs:           readToTransactions{},
+			invalidTxStatus:       map[TxID]committerpb.Status{},
+			txIDToHeight:          transactionIDToHeight{TxID(ref.TxId): servicepb.NewHeightFromTxRef(ref)},
+		}
+	}
+
+	// First submission: COMMITTED, row present.
+	writer.Write(build())
+	s1, ok := reader.Read()
+	require.True(t, ok)
+	require.Equal(t, committerpb.Status_COMMITTED, s1.Status[0].Status)
+
+	// Second submission of the same tx_id at the same height: the commit path
+	// detects the duplicate txID, but setCorrectStatusForDuplicateTxID recognizes
+	// it as a resubmission (same TX, same height) and returns the real committed
+	// status, not a duplicate-rejection. Exactly one row remains (no re-insert).
+	writer.Write(build())
+	s2, ok := reader.Read()
+	require.True(t, ok)
+	require.Equal(t, committerpb.Status_COMMITTED, s2.Status[0].Status)
+
+	require.True(t, cloneExists(t, env.dbEnv.DB, name))
+	rows := env.dbEnv.FetchKeys(t, committerpb.SnapshotNamespaceID, [][]byte{[]byte(ref.TxId)})
+	require.Len(t, rows, 1)
+}
+
+func TestSnapshotResubmissionSkipsReclone(t *testing.T) {
+	t.Parallel()
+	env := newCommitterTestEnv(t)
+	testdb.EnsureSnapshotSchedule(t, env.dbEnv.DBConf.Database)
+	ctx, _ := createContext(t)
+	writer := channel.NewWriter(ctx, env.validatedTxs)
+	reader := channel.NewReader(ctx, env.txStatus)
+
+	ref := &committerpb.TxRef{BlockNum: 444555, TxNum: 0, TxId: "snap-resubmit-1"}
+	name := snapshotDatabaseName(ref)
+	dropCloneCleanup(t, env.dbEnv.DB, name)
+
+	build := func() *validatedTransactions {
+		value, err := proto.Marshal(&committerpb.SnapshotState{TxRef: ref})
+		require.NoError(t, err)
+		nws := make(transactionToWrites)
+		nws.getOrCreate(TxID(ref.TxId), committerpb.SnapshotNamespaceID).append([]byte(ref.TxId), value, 0)
+		return &validatedTransactions{
+			validTxNonBlindWrites: transactionToWrites{},
+			validTxBlindWrites:    transactionToWrites{},
+			newWrites:             nws,
+			readToTxIDs:           readToTransactions{},
+			invalidTxStatus:       map[TxID]committerpb.Status{},
+			txIDToHeight:          transactionIDToHeight{TxID(ref.TxId): servicepb.NewHeightFromTxRef(ref)},
+		}
+	}
+
+	// First submission commits the snapshot (clone + PENDING row + txID).
+	writer.Write(build())
+	s1, ok := reader.Read()
+	require.True(t, ok)
+	require.Equal(t, committerpb.Status_COMMITTED, s1.Status[0].Status)
+	require.True(t, cloneExists(t, env.dbEnv.DB, name))
+
+	// Drop the clone out-of-band to prove the resubmission does NOT re-create it:
+	// because txID is already committed, createSnapshotIfPresent must skip database creation.
+	require.NoError(t, env.dbEnv.DB.adminExec(ctx,
+		fmt.Sprintf("DROP DATABASE IF EXISTS %s", pgx.Identifier{name}.Sanitize())))
+	require.False(t, cloneExists(t, env.dbEnv.DB, name))
+
+	// Resubmit the same snapshot TX (block re-delivered after combined failure).
+	// setCorrectStatusForDuplicateTxID recognizes this as a resubmission (same TX,
+	// same height) and returns the real committed status, not a duplicate-rejection.
+	writer.Write(build())
+	s2, ok := reader.Read()
+	require.True(t, ok)
+	require.Equal(t, committerpb.Status_COMMITTED, s2.Status[0].Status)
+
+	// The clone was NOT re-created — the resubmission short-circuited on the
+	// already-committed txID and returned the committed status.
+	require.False(t, cloneExists(t, env.dbEnv.DB, name))
+}

--- a/service/vc/snapshot_test.go
+++ b/service/vc/snapshot_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/hyperledger/fabric-x-committer/api/servicepb"
 	"github.com/hyperledger/fabric-x-committer/utils/channel"
 	"github.com/hyperledger/fabric-x-committer/utils/retry"
+	"github.com/hyperledger/fabric-x-committer/utils/statedb"
 	"github.com/hyperledger/fabric-x-committer/utils/testdb"
 )
 
@@ -49,13 +50,59 @@ func TestCreateSnapshotDatabase(t *testing.T) {
 	name := snapshotDatabaseName(ref)
 	dropCloneCleanup(t, env.DB, name)
 
+	// Distinguishable data written to the source, across TWO namespaces, BEFORE
+	// cloning; the clone must carry both rows so a later reader observes the exact
+	// source state rather than a partial/single-table copy.
+	cloneRows := []cloneRow{
+		{ns: ns1, key: []byte("clone-check-key-1"), value: []byte("clone-check-value-1")},
+		{ns: ns2, key: []byte("clone-check-key-2"), value: []byte("clone-check-value-2")},
+	}
+	env.populateData(t, []string{ns1, ns2}, namespaceToWrites{
+		ns1: {keys: [][]byte{cloneRows[0].key}, values: [][]byte{cloneRows[0].value}, versions: []uint64{0}},
+		ns2: {keys: [][]byte{cloneRows[1].key}, values: [][]byte{cloneRows[1].value}, versions: []uint64{0}},
+	}, nil, nil)
+
 	// First creation succeeds and snapshot database exists.
 	require.NoError(t, env.DB.createSnapshotDatabase(ctx, name))
 	require.True(t, cloneExists(t, env.DB, name))
+	for _, row := range cloneRows {
+		requireCloneHasRow(t, env.DB, name, row)
+	}
 
 	// Second creation over existing database is a no-op success (reuse), not drop+recreate.
 	require.NoError(t, env.DB.createSnapshotDatabase(ctx, name))
 	require.True(t, cloneExists(t, env.DB, name))
+	for _, row := range cloneRows {
+		requireCloneHasRow(t, env.DB, name, row)
+	}
+}
+
+// cloneRow identifies a single key/value expectation in a namespace, used by
+// requireCloneHasRow to keep its argument count within the linter's limit.
+type cloneRow struct {
+	ns    string
+	key   []byte
+	value []byte
+}
+
+// requireCloneHasRow opens a short-lived pool against the clone database (not
+// the source pool) and asserts it contains row's key/value in row's namespace,
+// proving the clone's content matches the source instead of merely existing.
+func requireCloneHasRow(t *testing.T, db *database, cloneName string, row cloneRow) {
+	t.Helper()
+	cloneConfig := *db.config
+	cloneConfig.Database = cloneName
+	clonePool, err := statedb.NewPool(t.Context(), &cloneConfig)
+	require.NoError(t, err)
+	defer clonePool.Close()
+
+	var gotValue []byte
+	err = retry.Execute(t.Context(), db.retryProfile, func() error {
+		query := fmt.Sprintf("SELECT value FROM %s WHERE key = $1", statedb.TableName(row.ns))
+		return clonePool.QueryRow(t.Context(), query, row.key).Scan(&gotValue)
+	})
+	require.NoError(t, err)
+	require.Equal(t, row.value, gotValue)
 }
 
 func cloneExists(t *testing.T, db *database, name string) bool {

--- a/service/verifier/policy/policy.go
+++ b/service/verifier/policy/policy.go
@@ -19,7 +19,6 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"github.com/hyperledger/fabric-x-committer/api/servicepb"
-	"github.com/hyperledger/fabric-x-committer/utils"
 	"github.com/hyperledger/fabric-x-committer/utils/signature"
 )
 
@@ -119,7 +118,7 @@ func UnmarshalNamespacePolicy(policyBytes []byte) (*applicationpb.NamespacePolic
 // validateNamespaceIDInPolicy checks that a given namespace fulfills namespace naming conventions.
 func validateNamespaceIDInPolicy(nsID string) error {
 	// System namespaces cannot be used as ordinary application namespace policies.
-	if utils.IsSystemNamespace(nsID) {
+	if committerpb.IsSystemNamespace(nsID) {
 		return ErrInvalidNamespaceID
 	}
 

--- a/utils/statedb/dbinit.go
+++ b/utils/statedb/dbinit.go
@@ -39,13 +39,6 @@ var (
 	//go:embed create_namespace_tmpl.sql
 	createNamespaceSQLStmt string
 
-	systemNamespaces = []string{
-		committerpb.MetaNamespaceID,
-		committerpb.ConfigNamespaceID,
-		committerpb.SnapshotNamespaceID,
-		committerpb.CheckpointNamespaceID,
-	}
-
 	logger = flogging.MustGetLogger("db-init")
 )
 
@@ -101,7 +94,7 @@ func SetupSystemTablesAndNamespaces(
 		return fmt.Errorf("failed to create system tables and functions: %w", execErr)
 	}
 
-	for _, nsID := range systemNamespaces {
+	for _, nsID := range committerpb.SystemNamespaces() {
 		query := MakeNsTablesQuery(nsID, tablePreSplitTablets)
 		if execErr := retry.ExecuteSQL(ctx, config.Retry, pool, query); execErr != nil {
 			return errors.Wrapf(

--- a/utils/testdb/container.go
+++ b/utils/testdb/container.go
@@ -72,6 +72,11 @@ var (
 			"yb_num_shards_per_tserver=1," +
 			"minloglevel=3," +
 			"yb_enable_read_committed_isolation=true",
+		// enable_db_clone is a master flag required for `CREATE DATABASE ... TEMPLATE`
+		// (used by service/vc/snapshot.go createYugabyteClone). Without it, the clone
+		// statement fails with "FLAGS_enable_db_clone is disabled".
+		"--master_flags",
+		"enable_db_clone=true",
 	}
 
 	// passwordRegex is the compiled regular expression.
@@ -485,4 +490,25 @@ func (dc *DatabaseContainer) EnsureNodeReadinessByLogs(t *testing.T, requiredOut
 		output := dc.GetContainerLogs(t)
 		require.Contains(ct, output, requiredOutput)
 	}, 45*time.Second, 250*time.Millisecond)
+}
+
+// EnsureSnapshotSchedule creates a YugabyteDB snapshot schedule for dbName.
+// It registers cleanup before the test database is dropped. This is a no-op for
+// non-YugabyteDB containers.
+func (dc *DatabaseContainer) EnsureSnapshotSchedule(t *testing.T, dbName string) {
+	t.Helper()
+	if dc.DatabaseType != YugaDBType {
+		return
+	}
+	// yb-admin's default master address (127.0.0.1:7100) doesn't work here: yb-master
+	// binds to the container's network IP, not loopback. Use the container's actual IP.
+	masterAddr := dc.GetContainerConnectionDetails(t).Host + ":7100"
+	t.Logf("creating snapshot schedule for ysql.%s", dbName)
+
+	output := dc.ExecuteCommand(t, createSnapshotScheduleCmd(masterAddr, dbName))
+	scheduleID := parseSnapshotScheduleID(t, output)
+
+	t.Cleanup(func() {
+		dc.ExecuteCommand(t, deleteSnapshotScheduleCmd(masterAddr, scheduleID))
+	})
 }

--- a/utils/testdb/database_setup.go
+++ b/utils/testdb/database_setup.go
@@ -11,9 +11,11 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/base32"
+	"encoding/json"
 	"fmt"
 	"log"
 	"os"
+	"os/exec"
 	"strings"
 	"testing"
 	"time"
@@ -46,6 +48,12 @@ const (
 
 	deploymentTypeEnv = "DB_DEPLOYMENT"
 	databaseTypeEnv   = "DB_TYPE"
+
+	// localYugaContainerEnv overrides the name of the locally-started YugabyteDB
+	// container that DB_DEPLOYMENT=local tests exec yb-admin into (for snapshot
+	// schedule creation). Defaults to the name used by scripts/get-and-start-yuga.sh.
+	localYugaContainerEnv     = "YUGA_CONTAINER"
+	defaultLocalYugaContainer = "sc_test_yugabyte"
 )
 
 // sharedContainer holds the container created by SetupSharedContainer for use
@@ -123,6 +131,7 @@ func PrepareTestEnvWithConnection(t *testing.T, conn *Connection) *Connection {
 			logger.Warnf("%+v", err)
 		}
 	})
+
 	conn.Database = dbName
 	return conn
 }
@@ -202,6 +211,91 @@ func CleanupSharedContainer() {
 	}); err != nil {
 		log.Printf("Warning: failed to remove container %s: %v", dc.Name, err)
 	}
+}
+
+// EnsureSnapshotSchedule creates a YugabyteDB snapshot schedule for dbName.
+// This is opt-in and called only by tests that create a snapshot database. It is
+// a no-op for postgres.
+//
+// Deployment modes:
+//   - container: exec yb-admin via the docker client on the container object.
+//   - local (e.g. CI): exec yb-admin through `docker exec <YUGA_CONTAINER>`.
+func EnsureSnapshotSchedule(t *testing.T, dbName string) {
+	t.Helper()
+	if getDBTypeFromEnv() != YugaDBType {
+		return
+	}
+	if sharedContainer != nil {
+		sharedContainer.EnsureSnapshotSchedule(t, dbName)
+		return
+	}
+	if getDBDeploymentFromEnv() == deploymentLocal {
+		ensureLocalSnapshotSchedule(t, dbName)
+	}
+}
+
+// ensureLocalSnapshotSchedule creates (and registers cleanup for) a snapshot schedule
+// on the locally-started YugabyteDB container by running yb-admin through `docker exec`.
+// The container name comes from YUGA_CONTAINER (default: the name used by
+// scripts/get-and-start-yuga.sh). That script starts yugabyted with
+// --advertise_address 0.0.0.0, so yb-master is reachable at the default 127.0.0.1:7100
+// from inside the container.
+func ensureLocalSnapshotSchedule(t *testing.T, dbName string) {
+	t.Helper()
+	container := os.Getenv(localYugaContainerEnv)
+	if container == "" {
+		container = defaultLocalYugaContainer
+	}
+	const masterAddr = "127.0.0.1:7100"
+	t.Logf("creating snapshot schedule for ysql.%s on container %s", dbName, container)
+
+	output := dockerExec(t, container, createSnapshotScheduleCmd(masterAddr, dbName)...)
+	scheduleID := parseSnapshotScheduleID(t, output)
+
+	t.Cleanup(func() {
+		dockerExec(t, container, deleteSnapshotScheduleCmd(masterAddr, scheduleID)...)
+	})
+}
+
+// createSnapshotScheduleCmd builds the yb-admin argv that creates a snapshot schedule
+// (interval 1 minute, retention 10 minutes) for the ysql.<dbName> keyspace.
+func createSnapshotScheduleCmd(masterAddr, dbName string) []string {
+	return []string{
+		"bin/yb-admin", "--master_addresses", masterAddr,
+		"create_snapshot_schedule", "1", "10", "ysql." + dbName,
+	}
+}
+
+// deleteSnapshotScheduleCmd builds the yb-admin argv that deletes a snapshot schedule.
+func deleteSnapshotScheduleCmd(masterAddr, scheduleID string) []string {
+	return []string{
+		"bin/yb-admin", "--master_addresses", masterAddr,
+		"delete_snapshot_schedule", scheduleID,
+	}
+}
+
+// parseSnapshotScheduleID extracts the schedule_id from yb-admin create_snapshot_schedule
+// JSON output, failing the test if it is missing.
+func parseSnapshotScheduleID(t *testing.T, output string) string {
+	t.Helper()
+	var resp struct {
+		ScheduleID string `json:"schedule_id"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(output), &resp),
+		"unexpected create_snapshot_schedule output: %s", output)
+	require.NotEmpty(t, resp.ScheduleID, "create_snapshot_schedule returned no schedule_id: %s", output)
+	return resp.ScheduleID
+}
+
+// dockerExec runs `docker exec <container> <args...>` and returns stdout, failing the
+// test on a non-zero exit.
+func dockerExec(t *testing.T, container string, args ...string) string {
+	t.Helper()
+	//nolint:gosec // test-only, fixed args.
+	cmd := exec.Command("docker", append([]string{"exec", container}, args...)...)
+	out, err := cmd.CombinedOutput()
+	require.NoErrorf(t, err, "docker exec %s %s failed: %s", container, strings.Join(args, " "), out)
+	return string(out)
 }
 
 // RunTestMain is a convenience wrapper for TestMain functions that only need

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -117,25 +117,6 @@ func IsConfigTx(namespaces []*applicationpb.TxNamespace) bool {
 	return len(namespaces) == 1 && namespaces[0].NsId == committerpb.ConfigNamespaceID
 }
 
-// IsSystemNamespace returns true if the namespace ID is one of the reserved system
-// namespaces (_meta, _config, _snapshot, _checkpoint). System namespaces are handled
-// specially across the pipeline: they cannot be used as ordinary application namespace
-// policies and they do not take the normal _meta namespace-version read dependency.
-//
-// TODO: move this to fabric-x-common alongside the committerpb namespace constants,
-// so all repos share a single system-namespace predicate.
-func IsSystemNamespace(nsID string) bool {
-	switch nsID {
-	case committerpb.MetaNamespaceID,
-		committerpb.ConfigNamespaceID,
-		committerpb.SnapshotNamespaceID,
-		committerpb.CheckpointNamespaceID:
-		return true
-	default:
-		return false
-	}
-}
-
 // RandIntN returns a true random (crypto/rand) number in the range [0, n).
 // If it fails to read the crypto/rand stream, it falls back to a pseudo random number generator.
 func RandIntN(n uint64) uint64 {


### PR DESCRIPTION
#### Type of change

- New feature
- Documentation update

#### Description

- On `_snapshot` commit, create a native zero-copy DB clone BEFORE the marker's
  txID commits, then rewrite the marker to a PENDING `SnapshotState` carrying the
  clone name — persisted atomically with the txID by the normal commit path
  (invariant: txID committed <=> clone exists <=> PENDING row).
- Clone as of current time via plain `CREATE DATABASE ... TEMPLATE` (no `AS OF`):
  the snapshot TX is drained/standalone, so "now" is the exact cut.
- Both backends: YugabyteDB `TEMPLATE` clone (source stays live; requires
  `enable_db_clone` + a PITR snapshot schedule); PostgreSQL `TEMPLATE ...
  STRATEGY=FILE_COPY` behind the ALLOW_CONNECTIONS/terminate dance.
- Skip cloning when the snapshot txID already exists in `tx_status` (resubmission
  or duplicate) so no orphan clone is left behind; a duplicate clone name is
  treated as reuse. Clones are never dropped here.
- Wire the clone into the committer before the commit retry loop; on clone
  failure the batch is not committed and the coordinator re-drives it.
- Reuse `committerpb.IsSystemNamespace`/`SystemNamespaces` from fabric-x-common
  (bump the dep) and drop the duplicated local helpers.

#### Additional details (Optional)

- `adminExec` runs clone/admin DDL on a dedicated out-of-pool connection with a
  bounded dial timeout and is deliberately not retried (deterministic DDL errors;
  42P04 "already exists" is mapped to success).
- Test-only `EnsureSnapshotScheduleForCloning` provisions the required YugabyteDB
  snapshot schedule per test DB (yb-admin; no SQL API); the container enables
  `enable_db_clone`.
- Docs: added a snapshot subsection to `docs/validator-committer.md` and a
  provisioning/tuning step to `docs/deployment-guide.md` noting the schedule is
  mandatory and retention should be kept short.
- Verified with `make test-all-db` (YugabyteDB snapshot suite) and `make lint`.

#### Related issues

- resolves #661
- resolves #691 
