### PR TITLE
[skills] Document fork-based PR workflow in commit-and-issue skill

### DIFF
--- a/.bob/skills/commit-and-issue/SKILL.md
+++ b/.bob/skills/commit-and-issue/SKILL.md
@@ -10,7 +10,10 @@ PR description**. So a commit message here is not a throwaway line — it is the
 description, reviewed as-is. Write it to the PR template and keep the exact wording the
 user approves.
 
-The repo for all `gh` operations is **`hyperledger/fabric-x-committer`** (the `gh` default).
+The upstream repo for all `gh` operations (issues, and PRs via `--repo`) is
+**`hyperledger/fabric-x-committer`**. PRs, however, are pushed from and opened off **your
+fork** (`<your-user>/fabric-x-committer`), not upstream — see
+[Push to your fork, then open the PR against upstream](#5-push-to-your-fork-then-open-the-pr-against-upstream).
 
 Pick the workflow that matches the request:
 
@@ -148,10 +151,51 @@ git commit -s -F /tmp/commit-msg.txt
 
 Amend with `git commit -s --amend -F /tmp/commit-msg.txt` if refining an existing commit.
 
-The same body is the PR description verbatim — if a PR already exists or the user wants to
-open one, reuse it with `gh pr create --body-file ...` or `gh pr edit --body-file ...`. Apply
-any labels to the PR through `gh` when applicable (e.g. `gh pr edit --add-label vc,bug`) —
-never in the message body.
+### 5. Push to your fork, then open the PR against upstream
+
+Contributors don't have push access to `hyperledger/fabric-x-committer`, so the branch must
+live on **your fork**, and the PR is opened from `your-fork:branch` into
+`hyperledger:main`. Never push feature branches to the upstream remote.
+
+Inspect the remotes and pick the fork (the one that is *not* `hyperledger/...`):
+
+```bash
+git remote -v
+```
+
+By GitHub convention, `origin` points at your fork (`<your-user>/fabric-x-committer`) and
+`upstream` points at `hyperledger/fabric-x-committer` — but don't assume the names match;
+read the URLs from `git remote -v` and pick by URL, not by name (this repo's own clone may
+name them differently). Confirm your fork's owner rather than hardcoding a name:
+
+```bash
+FORK_OWNER=$(gh api user -q .login)          # your GitHub login
+FORK_REMOTE=$(git remote -v | awk -v u="$FORK_OWNER/fabric-x-committer" '$2 ~ u {print $1; exit}')
+```
+
+Push the branch to the fork and open the PR with an explicit cross-repo `--head`:
+
+```bash
+git push -u "$FORK_REMOTE" <branch>
+gh pr create --repo hyperledger/fabric-x-committer \
+  --base main --head "$FORK_OWNER:<branch>" \
+  --title "[component] Short description" \
+  --body-file /tmp/pr-body.md
+```
+
+The `--head owner:branch` form is what makes it a fork PR — omitting the `owner:` prefix
+makes `gh` look for the branch on upstream and fail (or, if you accidentally pushed there,
+open an upstream-branch PR). If a branch was mistakenly pushed to the upstream remote,
+delete it there (`git push <upstream-remote> --delete <branch>`, using the remote name
+identified from `git remote -v`, not assumed to be `origin`) and re-point local tracking at
+the fork (`git branch --set-upstream-to=$FORK_REMOTE/<branch>`).
+
+The PR body is the commit message body verbatim (subject line and the `Signed-off-by:`
+trailer removed). If a PR already exists or you're updating one, reuse the same body with
+`gh pr edit --repo hyperledger/fabric-x-committer <num> --body-file /tmp/pr-body.md`. Apply
+any labels to the PR through `gh` when applicable (e.g.
+`gh pr edit --repo hyperledger/fabric-x-committer <num> --add-label vc,bug`) — never in the
+message body.
 
 ## Opening a GitHub issue
 


### PR DESCRIPTION
#### Type of change

- Documentation update

#### Description

- Add a "Push to your fork, then open the PR against upstream" step to the commit-and-issue
  skill: push the branch to your fork and open the PR with
  `gh pr create --repo hyperledger/fabric-x-committer --head <your-user>:<branch>`, never
  pushing feature branches to upstream.
- Derive the fork owner generically via `gh api user -q .login` (no hardcoded username), and
  explain how to identify the fork remote from `git remote -v`.
- Note that omitting the `owner:` prefix on `--head` opens an upstream-branch PR or fails,
  and document recovering from a branch mistakenly pushed to upstream
  (`git push origin --delete`, re-point tracking to the fork).
- Update the top-of-file note so `hyperledger/fabric-x-committer` is described as the
  upstream for `--repo`/issues while PRs come from the fork.

#### Related issues

- resolves #703
