### PR TITLE
[sidecar, query] Add metric for active client connections

### DIFF
--- a/docs/metrics_reference.md
+++ b/docs/metrics_reference.md
@@ -22,6 +22,7 @@ The following Sidecar metrics are exported for consumption by Prometheus.
 | sidecar_relay_output_committed_block_queue_size            | gauge     |                                  | Size of the output committed block queue of the relay service.                                                                                           |
 | sidecar_coordinator_connection_status                      | gauge     | grpc_target                      | Connection status to coordinator service by grpc target (1 = connected, 0 = disconnected).                                                               |
 | sidecar_coordinator_connection_failure_total               | counter   | grpc_target                      | Total number of connection failures to coordinator service. Short-lived failures may not always be captured.                                             |
+| sidecar_grpc_active_connections                            | gauge     |                                  | Number of client connections currently open on the server                                                                                                |
 | sidecar_ledger_append_block_seconds                        | histogram |                                  | Time spent appending a block to the ledger.                                                                                                              |
 | sidecar_ledger_block_height                                | gauge     |                                  | The current block height of the ledger.                                                                                                                  |
 | sidecar_relay_transaction_in_total                         | counter   |                                  | Total number of transactions received from the orderer.                                                                                                  |
@@ -108,18 +109,19 @@ The following Validator-Committer metrics are exported for consumption by Promet
 
 The following Query Service metrics are exported for consumption by Prometheus.
 
-| Name                                                     | Type      | Labels  | Description                                              |
-|----------------------------------------------------------|-----------|---------|----------------------------------------------------------|
-| queryservice_grpc_requests_total                         | counter   | method  | Number of requests by the service                        |
-| queryservice_grpc_requests_latency_seconds               | histogram | method  | The latency (seconds) of requests by the service         |
-| queryservice_grpc_key_requested_total                    | counter   |         | Number of keys requested by the service                  |
-| queryservice_grpc_key_responded_total                    | counter   |         | Number of keys responded by the service                  |
-| queryservice_database_processing_sessions                | gauge     | session | Number of processing sessions in the service             |
-| queryservice_database_batch_queueing_time_seconds        | histogram |         | The time batches waits for execution                     |
-| queryservice_database_batch_query_size                   | histogram |         | The size of submitted batches                            |
-| queryservice_database_batch_response_size                | histogram |         | The size of response for batch queries                   |
-| queryservice_database_request_assignment_latency_seconds | histogram |         | The latency of the query request assignment to the queue |
-| queryservice_database_query_latency_seconds              | histogram |         | The latency of the queries' batches                      |
+| Name                                                     | Type      | Labels  | Description                                               |
+|----------------------------------------------------------|-----------|---------|-----------------------------------------------------------|
+| queryservice_grpc_requests_total                         | counter   | method  | Number of requests by the service                         |
+| queryservice_grpc_requests_latency_seconds               | histogram | method  | The latency (seconds) of requests by the service          |
+| queryservice_grpc_key_requested_total                    | counter   |         | Number of keys requested by the service                   |
+| queryservice_grpc_active_connections                     | gauge     |         | Number of client connections currently open on the server |
+| queryservice_grpc_key_responded_total                    | counter   |         | Number of keys responded by the service                   |
+| queryservice_database_processing_sessions                | gauge     | session | Number of processing sessions in the service              |
+| queryservice_database_batch_queueing_time_seconds        | histogram |         | The time batches waits for execution                      |
+| queryservice_database_batch_query_size                   | histogram |         | The size of submitted batches                             |
+| queryservice_database_batch_response_size                | histogram |         | The size of response for batch queries                    |
+| queryservice_database_request_assignment_latency_seconds | histogram |         | The latency of the query request assignment to the queue  |
+| queryservice_database_query_latency_seconds              | histogram |         | The latency of the queries' batches                       |
 
 ## Load Generator Metrics
 

--- a/service/query/metrics.go
+++ b/service/query/metrics.go
@@ -42,6 +42,7 @@ type perfMetrics struct {
 	batchResponseSize               prometheus.Histogram
 	requestAssignmentLatencySeconds prometheus.Histogram
 	queryLatencySeconds             prometheus.Histogram
+	serverConnections               prometheus.Gauge
 }
 
 func newQueryServiceMetrics() *perfMetrics {
@@ -67,6 +68,12 @@ func newQueryServiceMetrics() *perfMetrics {
 			Subsystem: "grpc",
 			Name:      "key_requested_total",
 			Help:      "Number of keys requested by the service",
+		}),
+		serverConnections: p.NewGauge(prometheus.GaugeOpts{
+			Namespace: "queryservice",
+			Subsystem: "grpc",
+			Name:      "active_connections",
+			Help:      "Number of client connections currently open on the server",
 		}),
 		keysResponded: p.NewCounter(prometheus.CounterOpts{
 			Namespace: "queryservice",

--- a/service/query/metrics.go
+++ b/service/query/metrics.go
@@ -69,11 +69,9 @@ func newQueryServiceMetrics() *perfMetrics {
 			Name:      "key_requested_total",
 			Help:      "Number of keys requested by the service",
 		}),
-		serverConnections: p.NewGauge(prometheus.GaugeOpts{
+		serverConnections: monitoring.NewConnectionStatsMetrics(p, monitoring.MetricsParameters{
 			Namespace: "queryservice",
 			Subsystem: "grpc",
-			Name:      "active_connections",
-			Help:      "Number of client connections currently open on the server",
 		}),
 		keysResponded: p.NewCounter(prometheus.CounterOpts{
 			Namespace: "queryservice",

--- a/service/query/query_service.go
+++ b/service/query/query_service.go
@@ -125,6 +125,7 @@ func (q *Service) RegisterService(s serve.Servers) {
 	healthgrpc.RegisterHealthServer(s.GRPC, q.healthcheck)
 	serve.RegisterDynamicTLSUpdater(s.GrpcTLSProvider, &q.tlsUpdater)
 	monitoring.RegisterMonitoringServer(s.HTTP, q.metrics.Provider)
+	serve.RegisterConnStatHandler(s.ConnStatsHandler, q.metrics.serverConnections)
 }
 
 // BeginView implements the query-service interface.

--- a/service/sidecar/metrics.go
+++ b/service/sidecar/metrics.go
@@ -27,6 +27,7 @@ type perfMetrics struct {
 	transactionStatusesProcessingInRelaySeconds prometheus.Histogram
 
 	waitingTransactionsQueueSize prometheus.Gauge
+	serverConnections            prometheus.Gauge
 
 	// queue sizes
 	yetToBeCommittedBlocksQueueSize prometheus.Gauge
@@ -112,6 +113,12 @@ func newPerformanceMetrics() *perfMetrics {
 		coordConnection: monitoring.NewConnectionMetrics(p, monitoring.MetricsParameters{
 			Namespace: "sidecar",
 			Subsystem: "coordinator",
+		}),
+		serverConnections: p.NewGauge(prometheus.GaugeOpts{
+			Namespace: "sidecar",
+			Subsystem: "grpc",
+			Name:      "active_connections",
+			Help:      "Number of client connections currently open on the server",
 		}),
 		appendBlockToLedgerSeconds: p.NewHistogram(prometheus.HistogramOpts{
 			Namespace: "sidecar",

--- a/service/sidecar/metrics.go
+++ b/service/sidecar/metrics.go
@@ -114,11 +114,9 @@ func newPerformanceMetrics() *perfMetrics {
 			Namespace: "sidecar",
 			Subsystem: "coordinator",
 		}),
-		serverConnections: p.NewGauge(prometheus.GaugeOpts{
+		serverConnections: monitoring.NewConnectionStatsMetrics(p, monitoring.MetricsParameters{
 			Namespace: "sidecar",
 			Subsystem: "grpc",
-			Name:      "active_connections",
-			Help:      "Number of client connections currently open on the server",
 		}),
 		appendBlockToLedgerSeconds: p.NewHistogram(prometheus.HistogramOpts{
 			Namespace: "sidecar",

--- a/service/sidecar/sidecar.go
+++ b/service/sidecar/sidecar.go
@@ -176,6 +176,7 @@ func (s *Service) RegisterService(srv serve.Servers) {
 	healthgrpc.RegisterHealthServer(srv.GRPC, s.healthcheck)
 	serve.RegisterDynamicTLSUpdater(srv.GrpcTLSProvider, &s.tlsUpdater)
 	monitoring.RegisterMonitoringServer(srv.HTTP, s.metrics.Provider)
+	serve.RegisterConnStatHandler(srv.ConnStatsHandler, s.metrics.serverConnections)
 }
 
 func (s *Service) sendBlocksAndReceiveStatus(

--- a/utils/monitoring/metrics.go
+++ b/utils/monitoring/metrics.go
@@ -79,6 +79,16 @@ func NewConnectionMetrics(p *Provider, params MetricsParameters) *ConnectionMetr
 	}
 }
 
+// NewConnectionStatsMetrics creates a gauge that tracks the number of active connections to a server.
+func NewConnectionStatsMetrics(p *Provider, params MetricsParameters) prometheus.Gauge {
+	return p.NewGauge(prometheus.GaugeOpts{
+		Namespace: params.Namespace,
+		Subsystem: params.Subsystem,
+		Name:      "active_connections",
+		Help:      "Number of client connections currently open on the server",
+	})
+}
+
 // Connected observed connected.
 func (m *ConnectionMetrics) Connected(grpcTarget string) {
 	promutil.SetGaugeVec(m.Status, []string{grpcTarget}, connection.Connected)

--- a/utils/serve/conn_stats.go
+++ b/utils/serve/conn_stats.go
@@ -1,0 +1,71 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package serve
+
+import (
+	"context"
+	"sync/atomic"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"google.golang.org/grpc/stats"
+)
+
+// ConnStatsHandler is a gRPC stats.Handler that reports the number of open
+// connections on the server.
+//
+// It holds a prometheus.Gauge incremented when a client connects and decremented when it disconnects,
+// so the gauge always reflects the number of connections currently open on the server.
+//
+// The gauge is held in an atomic pointer, so RegisterConnStatHandler is safe to
+// call while or after the server starts serving connections.
+type ConnStatsHandler struct {
+	activeConnections atomic.Pointer[prometheus.Gauge]
+}
+
+func newConnStatsHandler() *ConnStatsHandler {
+	return &ConnStatsHandler{}
+}
+
+// RegisterConnStatHandler wires the gauge that the handler updates on every connection begin and end.
+// Until a gauge is registered, the handler is a no-op.
+func RegisterConnStatHandler(h *ConnStatsHandler, activeConnections prometheus.Gauge) {
+	h.activeConnections.Store(&activeConnections)
+}
+
+// HandleConn tracks the connection lifecycle: the gauge is incremented when the
+// server accepts a connection and decremented when the server tears it down
+// (a client disconnects, keep-alive timeout, max-age, or shutdown).
+func (h *ConnStatsHandler) HandleConn(_ context.Context, s stats.ConnStats) {
+	g := h.activeConnections.Load()
+
+	if g == nil || *g == nil {
+		return
+	}
+
+	activeConnections := *g
+
+	switch s.(type) {
+	case *stats.ConnBegin:
+		activeConnections.Inc()
+	case *stats.ConnEnd:
+		activeConnections.Dec()
+	default:
+	}
+}
+
+// TagConn is required by stats.Handler; it is a no-op.
+func (*ConnStatsHandler) TagConn(ctx context.Context, _ *stats.ConnTagInfo) context.Context {
+	return ctx
+}
+
+// TagRPC is required by stats.Handler; it is a no-op.
+func (*ConnStatsHandler) TagRPC(ctx context.Context, _ *stats.RPCTagInfo) context.Context {
+	return ctx
+}
+
+// HandleRPC is required by stats.Handler; RPC-level stats are not tracked.
+func (*ConnStatsHandler) HandleRPC(context.Context, stats.RPCStats) {}

--- a/utils/serve/conn_stats.go
+++ b/utils/serve/conn_stats.go
@@ -26,10 +26,6 @@ type ConnStatsHandler struct {
 	activeConnections atomic.Pointer[prometheus.Gauge]
 }
 
-func newConnStatsHandler() *ConnStatsHandler {
-	return &ConnStatsHandler{}
-}
-
 // RegisterConnStatHandler wires the gauge that the handler updates on every connection begin and end.
 // Until a gauge is registered, the handler is a no-op.
 func RegisterConnStatHandler(h *ConnStatsHandler, activeConnections prometheus.Gauge) {

--- a/utils/serve/conn_stats_test.go
+++ b/utils/serve/conn_stats_test.go
@@ -1,0 +1,62 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package serve_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger/fabric-x-committer/utils/serve"
+	"github.com/hyperledger/fabric-x-committer/utils/test"
+)
+
+type connStatsRegisterer struct {
+	activeConnections prometheus.Gauge
+}
+
+func (r *connStatsRegisterer) RegisterService(srv serve.Servers) {
+	serve.RegisterConnStatHandler(srv.ConnStatsHandler, r.activeConnections)
+}
+
+// TestServerConnStatsHandler verifies the active-connections gauge end to end:
+// wired through the normal RegisterService path, it rises as real clients connect
+// and returns to zero as they disconnect.
+func TestServerConnStatsHandler(t *testing.T) {
+	t.Parallel()
+
+	activeConnGauge := prometheus.NewGauge(prometheus.GaugeOpts{
+		Name: "test_active_connections",
+		Help: "Test gauge for the connection stats handler.",
+	})
+
+	t.Log("Starting service")
+	serverConfig := test.NewLocalHostServiceConfig(test.InsecureTLSConfig)
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Minute)
+	t.Cleanup(cancel)
+	test.ServeForTest(ctx, t, serverConfig, &connStatsRegisterer{activeConnections: activeConnGauge})
+
+	t.Log("Creating clients")
+	conn := test.NewInsecureConnection(t, &serverConfig.GRPC.Endpoint)
+	conn2 := test.NewInsecureConnection(t, &serverConfig.GRPC.Endpoint)
+
+	test.RequireIntMetricValue(t, 0, activeConnGauge)
+
+	t.Log("Connecting clients")
+	conn.Connect()
+	test.EventuallyIntMetric(t, 1, activeConnGauge, 30*time.Second, 100*time.Millisecond)
+	conn2.Connect()
+	test.EventuallyIntMetric(t, 2, activeConnGauge, 30*time.Second, 100*time.Millisecond)
+
+	t.Log("Disconnecting clients")
+	require.NoError(t, conn.Close())
+	require.NoError(t, conn2.Close())
+	test.EventuallyIntMetric(t, 0, activeConnGauge, 30*time.Second, 100*time.Millisecond)
+}

--- a/utils/serve/start_serve.go
+++ b/utils/serve/start_serve.go
@@ -50,6 +50,10 @@ type (
 		HTTP            *http.ServeMux
 		GrpcTLSProvider *TLSProvider
 
+		// ConnStatsHandler tracks the number of open gRPC connections. A service reports the
+		// count by calling RegisterConnStatHandler with a gauge from its own monitoring provider.
+		ConnStatsHandler *ConnStatsHandler
+
 		httpServer *http.Server
 
 		grpcListener net.Listener
@@ -133,7 +137,9 @@ func NewServers(ctx context.Context, conf *Config) (s Servers, err error) {
 		return s, errors.Wrap(err, "failed to create TLS provider")
 	}
 
-	s.GRPC, err = newGRPCServer(&conf.GRPC, s.GrpcTLSProvider)
+	s.ConnStatsHandler = newConnStatsHandler()
+
+	s.GRPC, err = newGRPCServer(&conf.GRPC, s.GrpcTLSProvider, s.ConnStatsHandler)
 	if err != nil {
 		return s, errors.Wrapf(err, "failed creating GRPC server")
 	}
@@ -253,10 +259,11 @@ func newHTTPListener(ctx context.Context, c *ServerConfig, tlsConfig *tls.Config
 }
 
 // newGRPCServer instantiate a [grpc.Server].
-func newGRPCServer(c *ServerConfig, tlsProvider *TLSProvider) (*grpc.Server, error) {
+func newGRPCServer(c *ServerConfig, tlsProvider *TLSProvider, connStats *ConnStatsHandler) (*grpc.Server, error) {
 	opts := []grpc.ServerOption{
 		grpc.MaxRecvMsgSize(connection.MaxMsgSize),
 		grpc.MaxSendMsgSize(connection.MaxMsgSize),
+		grpc.StatsHandler(connStats),
 	}
 	opts = append(opts, grpc.Creds(newCredentials(tlsProvider.GetServerTLSCredentials())))
 

--- a/utils/serve/start_serve.go
+++ b/utils/serve/start_serve.go
@@ -137,7 +137,7 @@ func NewServers(ctx context.Context, conf *Config) (s Servers, err error) {
 		return s, errors.Wrap(err, "failed to create TLS provider")
 	}
 
-	s.ConnStatsHandler = newConnStatsHandler()
+	s.ConnStatsHandler = &ConnStatsHandler{}
 
 	s.GRPC, err = newGRPCServer(&conf.GRPC, s.GrpcTLSProvider, s.ConnStatsHandler)
 	if err != nil {


### PR DESCRIPTION
#### Type of change

- New feature
- Improvement (improvement to code)

#### Description

- Add a gRPC `stats.Handler` (`serve.ConnStatsHandler`) that tracks the number of
  open server-side connections in a Prometheus gauge - incrementing on `ConnBegin`
  and decrementing on `ConnEnd`. It is attached to every gRPC server.
- A service opts in by registering a gauge from its own provider via
  `serve.RegisterConnStatHandler` in `RegisterService`. Sidecar and query do so,
  exposing `sidecar_grpc_active_connections` and `queryservice_grpc_active_connections`
  on their existing metrics endpoints.
- The gauge is held in an `atomic.Pointer`, so registering it is safe even if it
  races the server handling connections.

#### Related issues

- resolves #705 