### PR TITLE
[coordinator] Split the VC request/response API from the VC manager

### DIFF
--- a/service/coordinator/coordinator.go
+++ b/service/coordinator/coordinator.go
@@ -41,6 +41,7 @@ type (
 		dependencyMgr         *dependencygraph.Manager
 		signatureVerifierMgr  *signatureVerifierManager
 		validatorCommitterMgr *validatorCommitterManager
+		validatorCommitterAPI *validatorCommitterAPI
 		policyMgr             *policyManager
 		queues                *channels
 		config                *Config
@@ -183,6 +184,16 @@ func NewCoordinatorService(c *Config) *Service {
 func (c *Service) Run(ctx context.Context) error {
 	canCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
+
+	// The API is created before the managers start, so the coordinator can query any vcservice
+	// without waiting for the validator-committer manager to open its per-endpoint connections.
+	var err error
+	c.validatorCommitterAPI, err = newValidatorCommitterAPI(&c.config.ValidatorCommitter, c.policyMgr)
+	if err != nil {
+		return err
+	}
+	defer c.validatorCommitterAPI.close()
+
 	g, eCtx := errgroup.WithContext(canCtx)
 
 	g.Go(func() error {
@@ -215,12 +226,8 @@ func (c *Service) Run(ctx context.Context) error {
 		return nil
 	})
 
-	if !c.validatorCommitterMgr.ready.WaitForReady(eCtx) {
-		return g.Wait()
-	}
-
 	// We attempt to recover the policy manager and the last committed block number from the state DB.
-	if err := c.validatorCommitterMgr.recoverPolicyManagerFromStateDB(ctx); err != nil {
+	if err := c.validatorCommitterAPI.recoverPolicyManagerFromStateDB(ctx); err != nil {
 		return err
 	}
 
@@ -250,8 +257,8 @@ func (c *Service) SetLastCommittedBlockNumber(
 	ctx context.Context,
 	lastBlock *servicepb.BlockRef,
 ) (*emptypb.Empty, error) {
-	// Error is already wrapped with proper gRPC status code by validatorCommitterMgr.
-	return &emptypb.Empty{}, c.validatorCommitterMgr.setLastCommittedBlockNumber(ctx, lastBlock)
+	// Error is already wrapped with proper gRPC status code by validatorCommitterAPI.
+	return &emptypb.Empty{}, c.validatorCommitterAPI.setLastCommittedBlockNumber(ctx, lastBlock)
 }
 
 // GetNextBlockNumberToCommit returns the next expected block number to be received by the coordinator.
@@ -259,8 +266,8 @@ func (c *Service) GetNextBlockNumberToCommit(
 	ctx context.Context,
 	_ *emptypb.Empty,
 ) (*servicepb.BlockRef, error) {
-	// Error is already wrapped with proper gRPC status code by validatorCommitterMgr.
-	return c.validatorCommitterMgr.getNextBlockNumberToCommit(ctx)
+	// Error is already wrapped with proper gRPC status code by validatorCommitterAPI.
+	return c.validatorCommitterAPI.getNextBlockNumberToCommit(ctx)
 }
 
 // GetTransactionsStatus returns the status of given transactions identifiers.
@@ -268,8 +275,8 @@ func (c *Service) GetTransactionsStatus(
 	ctx context.Context,
 	q *committerpb.TxIDsBatch,
 ) (*committerpb.TxStatusBatch, error) {
-	// Error is already wrapped with proper gRPC status code by validatorCommitterMgr.
-	return c.validatorCommitterMgr.getTransactionsStatus(ctx, q)
+	// Error is already wrapped with proper gRPC status code by validatorCommitterAPI.
+	return c.validatorCommitterAPI.getTransactionsStatus(ctx, q)
 }
 
 // NoPendingTransactionProcessing returns true when all previously submitted

--- a/service/coordinator/validator_committer_api.go
+++ b/service/coordinator/validator_committer_api.go
@@ -1,0 +1,108 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package coordinator
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hyperledger/fabric-x-common/api/applicationpb"
+	"github.com/hyperledger/fabric-x-common/api/committerpb"
+	"google.golang.org/grpc"
+
+	"github.com/hyperledger/fabric-x-committer/api/servicepb"
+	"github.com/hyperledger/fabric-x-committer/utils/connection"
+	"github.com/hyperledger/fabric-x-committer/utils/grpcerror"
+)
+
+// validatorCommitterAPI exposes the request/response API that any vcservice can serve.
+//
+// These calls are unrelated to the transaction pipeline that the validator-committer manager
+// drives: they are served by whichever vcservice a load-balanced connection happens to pick, and
+// the coordinator issues them outside the pipeline -- once during recovery, and then on demand from
+// its own gRPC handlers. Holding them here leaves the manager responsible only for streaming
+// transactions to the vcservices.
+type validatorCommitterAPI struct {
+	conn      *grpc.ClientConn
+	client    servicepb.ValidationAndCommitServiceClient
+	policyMgr *policyManager
+}
+
+func newValidatorCommitterAPI(
+	conf *connection.MultiClientConfig,
+	policyMgr *policyManager,
+) (*validatorCommitterAPI, error) {
+	conn, err := connection.NewLoadBalancedConnection(conf)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create connection to validator persisters: %w", err)
+	}
+	return &validatorCommitterAPI{
+		conn:      conn,
+		client:    servicepb.NewValidationAndCommitServiceClient(conn),
+		policyMgr: policyMgr,
+	}, nil
+}
+
+func (vca *validatorCommitterAPI) close() {
+	connection.CloseConnectionsLog(vca.conn)
+}
+
+func (vca *validatorCommitterAPI) recoverPolicyManagerFromStateDB(ctx context.Context) error {
+	policyMsg, err := vca.getNamespacePolicies(ctx)
+	if err != nil {
+		return err
+	}
+	configMsg, err := vca.getConfigTransaction(ctx)
+	if err != nil {
+		return err
+	}
+	if len(policyMsg.Policies) == 0 && configMsg.Envelope == nil {
+		return nil
+	}
+	vca.policyMgr.update(&servicepb.VerifierUpdates{
+		NamespacePolicies: policyMsg,
+		Config:            configMsg,
+	})
+	return nil
+}
+
+func (vca *validatorCommitterAPI) getNamespacePolicies(
+	ctx context.Context,
+) (*applicationpb.NamespacePolicies, error) {
+	ret, err := vca.client.GetNamespacePolicies(ctx, nil)
+	return ret, grpcerror.WrapWithContext(err, "failed loading policies")
+}
+
+func (vca *validatorCommitterAPI) getConfigTransaction(
+	ctx context.Context,
+) (*applicationpb.ConfigTransaction, error) {
+	ret, err := vca.client.GetConfigTransaction(ctx, nil)
+	return ret, grpcerror.WrapWithContext(err, "failed loading config transaction")
+}
+
+func (vca *validatorCommitterAPI) setLastCommittedBlockNumber(
+	ctx context.Context,
+	lastBlock *servicepb.BlockRef,
+) error {
+	_, err := vca.client.SetLastCommittedBlockNumber(ctx, lastBlock)
+	return grpcerror.WrapWithContext(err, "failed setting the last committed block number")
+}
+
+func (vca *validatorCommitterAPI) getNextBlockNumberToCommit(
+	ctx context.Context,
+) (*servicepb.BlockRef, error) {
+	ret, err := vca.client.GetNextBlockNumberToCommit(ctx, nil)
+	return ret, grpcerror.WrapWithContext(err, "failed getting the next expected block number")
+}
+
+func (vca *validatorCommitterAPI) getTransactionsStatus(
+	ctx context.Context,
+	query *committerpb.TxIDsBatch,
+) (*committerpb.TxStatusBatch, error) {
+	ret, err := vca.client.GetTransactionsStatus(ctx, query)
+	return ret, grpcerror.WrapWithContext(err, "failed getting transactions status")
+}

--- a/service/coordinator/validator_committer_manager.go
+++ b/service/coordinator/validator_committer_manager.go
@@ -12,7 +12,6 @@ import (
 	"slices"
 
 	"github.com/cockroachdb/errors"
-	"github.com/hyperledger/fabric-x-common/api/applicationpb"
 	"github.com/hyperledger/fabric-x-common/api/committerpb"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
@@ -22,7 +21,6 @@ import (
 	"github.com/hyperledger/fabric-x-committer/utils"
 	"github.com/hyperledger/fabric-x-committer/utils/channel"
 	"github.com/hyperledger/fabric-x-committer/utils/connection"
-	"github.com/hyperledger/fabric-x-committer/utils/grpcerror"
 	"github.com/hyperledger/fabric-x-committer/utils/monitoring/promutil"
 	"github.com/hyperledger/fabric-x-committer/utils/retry"
 )
@@ -36,12 +34,12 @@ type (
 	// 2. Receiving the status of the transactions from the vcservices.
 	// 3. Forwarding the validated transactions node to the dependency graph manager.
 	// 4. Forwarding the status of the transactions to the coordinator.
+	//
+	// The request/response API that any vcservice can serve is not part of this manager; see
+	// validatorCommitterAPI.
 	validatorCommitterManager struct {
 		config             *validatorCommitterManagerConfig
-		commonClient       servicepb.ValidationAndCommitServiceClient
 		validatorCommitter []*validatorCommitter
-		// ready indicates that the validatorCommitter array is initialized.
-		ready *channel.Ready
 	}
 
 	// validatorCommitter is responsible for managing the communication with a single
@@ -71,12 +69,10 @@ func newValidatorCommitterManager(c *validatorCommitterManagerConfig) *validator
 	logger.Info("Initializing new ValidatorCommitterManager")
 	return &validatorCommitterManager{
 		config: c,
-		ready:  channel.NewReady(),
 	}
 }
 
 func (vcm *validatorCommitterManager) run(ctx context.Context) error {
-	defer vcm.ready.Reset()
 	c := vcm.config
 	logger.Infof("Connections to %d vc's will be opened from vc manager", len(c.clientConfig.Endpoints))
 	vcm.validatorCommitter = make([]*validatorCommitter, len(c.clientConfig.Endpoints))
@@ -92,13 +88,6 @@ func (vcm *validatorCommitterManager) run(ctx context.Context) error {
 		)
 		return nil
 	})
-
-	commonConn, err := connection.NewLoadBalancedConnection(c.clientConfig)
-	if err != nil {
-		return fmt.Errorf("failed to create connection to validator persisters: %w", err)
-	}
-	defer connection.CloseConnectionsLog(commonConn)
-	vcm.commonClient = servicepb.NewValidationAndCommitServiceClient(commonConn)
 
 	connections, connErr := connection.NewConnectionPerEndpoint(c.clientConfig)
 	if connErr != nil {
@@ -126,64 +115,7 @@ func (vcm *validatorCommitterManager) run(ctx context.Context) error {
 		})
 	}
 
-	vcm.ready.SignalReady()
 	return utils.ProcessErr(g.Wait(), "validator-committer manager failed")
-}
-
-func (vcm *validatorCommitterManager) setLastCommittedBlockNumber(
-	ctx context.Context,
-	lastBlock *servicepb.BlockRef,
-) error {
-	_, err := vcm.commonClient.SetLastCommittedBlockNumber(ctx, lastBlock)
-	return grpcerror.WrapWithContext(err, "failed setting the last committed block number")
-}
-
-func (vcm *validatorCommitterManager) getNextBlockNumberToCommit(
-	ctx context.Context,
-) (*servicepb.BlockRef, error) {
-	ret, err := vcm.commonClient.GetNextBlockNumberToCommit(ctx, nil)
-	return ret, grpcerror.WrapWithContext(err, "failed getting the next expected block number")
-}
-
-func (vcm *validatorCommitterManager) getTransactionsStatus(
-	ctx context.Context,
-	query *committerpb.TxIDsBatch,
-) (*committerpb.TxStatusBatch, error) {
-	ret, err := vcm.commonClient.GetTransactionsStatus(ctx, query)
-	return ret, grpcerror.WrapWithContext(err, "failed getting transactions status")
-}
-
-func (vcm *validatorCommitterManager) getNamespacePolicies(
-	ctx context.Context,
-) (*applicationpb.NamespacePolicies, error) {
-	ret, err := vcm.commonClient.GetNamespacePolicies(ctx, nil)
-	return ret, grpcerror.WrapWithContext(err, "failed loading policies")
-}
-
-func (vcm *validatorCommitterManager) getConfigTransaction(
-	ctx context.Context,
-) (*applicationpb.ConfigTransaction, error) {
-	ret, err := vcm.commonClient.GetConfigTransaction(ctx, nil)
-	return ret, grpcerror.WrapWithContext(err, "failed loading config transaction")
-}
-
-func (vcm *validatorCommitterManager) recoverPolicyManagerFromStateDB(ctx context.Context) error {
-	policyMsg, err := vcm.getNamespacePolicies(ctx)
-	if err != nil {
-		return err
-	}
-	configMsg, err := vcm.getConfigTransaction(ctx)
-	if err != nil {
-		return err
-	}
-	if len(policyMsg.Policies) == 0 && configMsg.Envelope == nil {
-		return nil
-	}
-	vcm.config.policyMgr.update(&servicepb.VerifierUpdates{
-		NamespacePolicies: policyMsg,
-		Config:            configMsg,
-	})
-	return nil
 }
 
 func newValidatorCommitter(conn *grpc.ClientConn, metrics *perfMetrics, policyMgr *policyManager) *validatorCommitter {

--- a/service/coordinator/validator_committer_manager_test.go
+++ b/service/coordinator/validator_committer_manager_test.go
@@ -68,7 +68,12 @@ func newVcMgrTestEnv(t *testing.T, numVCService int) *vcMgrTestEnv {
 		err := connection.FilterStreamRPCError(vcm.run(ctx))
 		assert.NoError(t, err)
 		return nil
-	}, vcm.ready.WaitForReady)
+	}, nil)
+	// Waiting for all the connections ensures the validatorCommitter slice is fully populated,
+	// as newSvMgrTestEnv does for the verifiers.
+	monitoring.WaitForConnections(
+		t, vcm.config.metrics.Provider, "coordinator_vcservice_connection_status", numVCService,
+	)
 
 	return &vcMgrTestEnv{
 		validatorCommitterManager: vcm,


### PR DESCRIPTION
#### Type of change

- Improvement (improvement to code, performance, etc)

#### Description

- Move the load-balanced vcservice connection, and the request/response calls it serves
  (`SetLastCommittedBlockNumber`, `GetNextBlockNumberToCommit`, `GetTransactionsStatus`,
  `GetNamespacePolicies`, `GetConfigTransaction`), out of `validatorCommitterManager` and into a new
  `validatorCommitterAPI`. These calls are served by whichever vcservice the load-balanced
  connection picks and are issued outside the transaction pipeline, so the manager is now
  responsible only for streaming transactions to the vcservices.
- The coordinator owns the API and creates it in `Run` before starting the managers. The
  `channel.Ready` handshake that existed only to tell the coordinator when the manager had assigned
  its `commonClient` is therefore removed, along with the `WaitForReady` call in `Run`.
- `newVcMgrTestEnv` waits for the vcservice connections instead of that handshake, matching what
  `newSvMgrTestEnv` already does for the verifiers.

#### Related issues

- resolves partly #611


