### PR TITLE
[skills] Expand development/tests skill guidance for comments, whitespace, file layout, helper extraction

### DIFF
--- a/.bob/skills/development/SKILL.md
+++ b/.bob/skills/development/SKILL.md
@@ -21,6 +21,7 @@ here. Follow it whenever you add or change production Go source.
 covers *authoring* production code.
 
 **Authoritative sources in the repo** (read them when a topic needs depth):
+
 - `guidelines.md` — the simplicity philosophy and error-handling policy.
 - `docs/core-concurrency-pattern.md` — the errgroup + context-aware channel doctrine.
 - `.golangci.yml` — every linter that gates your PR (see the cheat sheet at the end).
@@ -43,6 +44,38 @@ abstraction, stop:
 - **Explicit and a few lines longer beats compact and clever.** Guard clauses, early
   returns, intermediate variables. Max ~3 levels of nesting; `gocognit` caps complexity
   at 15.
+
+## Comments explain *why*, not *what*
+
+A comment earns its place only if it tells the reader something the code cannot: the
+reasoning behind a choice, a non-obvious invariant, a trade-off, an edge case that looks
+like a bug but isn't, or a pointer to *why* something is shaped the way it is. If a
+comment just restates the next line in English, delete it — the code already says that,
+and a paraphrase comment rots the moment the code changes underneath it.
+
+```go
+// BAD — restates the code, adds nothing
+// increment the retry count
+retryCount++
+
+// GOOD — explains why this exists / a non-obvious constraint
+// Capped at 3: beyond that the coordinator's own timeout fires first, so a 4th
+// retry here would never be observed by the caller.
+retryCount++
+```
+
+When writing or reviewing a doc comment on a function, ask "does this only describe
+parameters/return values I could read from the signature, or does it explain something
+the signature can't" — keep the latter, cut the former down to the minimum Go convention
+requires (the `godot`-enforced one-line summary starting with the function name).
+
+Apply the same restraint to comment *length*: a comment that has grown longer than the
+function it documents is a sign it is explaining implementation mechanics that belong in
+the code (better names, an extracted helper) rather than prose above it. Prefer a short
+pointer to *where* the fuller rationale already lives (a doc file, a field comment) over
+restating it inline every time. If review feedback says "shrink this comment,"
+the fix is almost always: keep the one or two sentences that are genuinely load-bearing
+(why, not what) and delete or relocate the rest.
 
 ## Step 0 — reuse before you write
 
@@ -90,15 +123,25 @@ Model file: `service/vc/committer.go` reads `newCommitter` → `run` → `commit
 ```go
 // service/vc/committer.go:50 — run() sits directly above the commit() it calls
 func (c *transactionCommitter) run(ctx context.Context, db *database, numWorkers int) error {
-	g, eCtx := errgroup.WithContext(ctx)
-	for range numWorkers {
-		g.Go(func() error { return c.commit(eCtx, db) }) // callee defined next
-	}
-	return g.Wait()
+ g, eCtx := errgroup.WithContext(ctx)
+ for range numWorkers {
+  g.Go(func() error { return c.commit(eCtx, db) }) // callee defined next
+ }
+ return g.Wait()
 }
 
 func (c *transactionCommitter) commit(ctx context.Context, db *database) error { /* ... */ }
 ```
+
+This applies when you *add* a helper too — insert it directly below its caller, not
+above, and not wherever there is spare room in the file. When you extract a helper out
+of an existing function during a refactor, double-check the extracted function's new
+position still satisfies caller-before-callee relative to *every* caller, not just the
+one you were looking at (a helper called from two places belongs below the one that
+reads top-to-bottom first). Free-standing utility/formatting helpers with no domain
+logic of their own (string formatting, tiny predicates, struct-literal constructors used
+from a single call site) belong at the very bottom of the file — see file layout item 10
+below — even below the last method of the file's main type.
 
 ### Group methods by struct
 
@@ -108,6 +151,23 @@ its methods. Don't interleave two types' methods by chance.
 **Exception:** when two types collaborate tightly in one file, top-down call order
 (above) wins over strict grouping — order by the processing flow
 (`service/sidecar/notify.go` does this deliberately).
+
+### Whitespace and readability
+
+A blank line is a signal that groups related statements and separates one step from
+the next — use it deliberately, the same way paragraph breaks work in prose. Put a
+blank line between: setting up inputs and using them, a guard-clause block and the main
+body that follows, and independent steps of a function (e.g. "drain", "write", "drain
+again" each get their own line group in `submitConfigBlock`). Don't cram unrelated
+statements onto adjacent lines just to shorten the function — a dense function is
+harder to scan than a slightly longer one with clear paragraphs, and reviewers will ask
+for the blank lines back.
+
+Conversely, don't scatter blank lines *inside* one cohesive step (e.g. between building
+a struct literal's fields, or between an `if err != nil` guard and its `return`) — that
+signals a break where there isn't one. Related declarations, a single guard clause, and
+a struct literal's fields stay tight together; the break goes at the boundary between
+distinct concepts, not in the middle of one.
 
 ### Don't fragment into tiny single-use helpers — but do manage complexity
 
@@ -129,6 +189,7 @@ For logic shared *within* one function, use a local closure
 Every `.go` file follows this order (model: `service/coordinator/coordinator.go`):
 
 1. Apache-2.0 header — the `/* ... */` block comment (the `goheader` linter requires it):
+
    ```go
    /*
    Copyright IBM Corp. All Rights Reserved.
@@ -136,6 +197,7 @@ Every `.go` file follows this order (model: `service/coordinator/coordinator.go`
    SPDX-License-Identifier: Apache-2.0
    */
    ```
+
 2. `package` clause.
 3. `import (...)` — three blank-line-separated groups: stdlib, third-party, then internal
    `github.com/hyperledger/fabric-x-committer/...` (`goimports` local-prefixes enforces this).
@@ -156,6 +218,17 @@ pipeline component/manager (`preparer.go`, `validator.go`, `committer.go`, `data
 Keep files moderate (~200–750 lines); give a large concern its own file. Tests are
 co-located as `<file>_test.go`; shared exported test helpers go in `test_exports.go`.
 
+Don't hesitate to introduce a new file when a change grows a distinct concept inside an
+existing one — a new file is cheap and often clarifies more than it costs. Signs it's
+time to split: a file's unrelated concerns start interleaving in the caller-before-callee
+order (two call chains competing for the same file), a single `.go` file is approaching
+the upper end of the ~750-line guideline, or a chunk of logic (e.g. a validation ruleset,
+a new sub-protocol, a splitting/merging algorithm) is substantial enough to have its own
+doc comment block, tests, and helpers that would otherwise crowd the file that merely
+*uses* it. When you do split, move the whole concept — its types, constructor, methods,
+and any free helpers it privately relies on — together, and keep its own tests in the
+matching `<newfile>_test.go` rather than leaving them behind in the original test file.
+
 ## Concurrency
 
 Read `docs/core-concurrency-pattern.md` once. The rules:
@@ -170,7 +243,7 @@ completion — that is errgroup's job. Bound parallelism with a fixed worker cou
 ```go
 g, eCtx := errgroup.WithContext(ctx)
 for range numWorkers {
-	g.Go(func() error { return c.commit(eCtx, db) })
+ g.Go(func() error { return c.commit(eCtx, db) })
 }
 return g.Wait()
 ```
@@ -198,10 +271,10 @@ operation releases immediately on cancellation and the system never hangs on shu
 incoming := channel.NewReader(ctx, c.incomingValidatedTransactions)
 outgoing := channel.NewWriter(ctx, c.outgoingTransactionsStatus)
 for {
-	vTx, ok := incoming.Read()
-	if !ok { return nil } // ctx done or channel closed
-	// ...
-	outgoing.Write(txsStatus)
+ vTx, ok := incoming.Read()
+ if !ok { return nil } // ctx done or channel closed
+ // ...
+ outgoing.Write(txsStatus)
 }
 ```
 
@@ -242,6 +315,7 @@ The codebase is aggressively modern. **Prefer** in new code:
 Uses `github.com/cockroachdb/errors` (the `depguard` linter bans `github.com/pkg/errors`).
 
 **Decision rule:**
+
 1. **Originate or first cross into our code** (a new condition, or an error from a DB
    driver / gRPC `Recv` / marshal) → `errors.New` / `errors.Newf` / `errors.Wrap` /
    `errors.Wrapf`. This captures the stack trace at the origin.
@@ -260,12 +334,12 @@ uses `fmt.Errorf("failed to read status for tx %s: %w", txID, err)`, not `errors
 
 ```go
 if len(query.TxIds) == 0 {
-	return nil, grpcerror.WrapInvalidArgument(errors.New("query is empty"))
+ return nil, grpcerror.WrapInvalidArgument(errors.New("query is empty"))
 }
 txIDsStatus, err := vc.db.readStatusWithHeight(ctx, txIDs)
 if err != nil {
-	logger.Errorf("%+v", err)                    // log full trace, once, at the boundary
-	return nil, grpcerror.WrapInternalError(err) // convert to a gRPC status code
+ logger.Errorf("%+v", err)                    // log full trace, once, at the boundary
+ return nil, grpcerror.WrapInternalError(err) // convert to a gRPC status code
 }
 ```
 
@@ -307,6 +381,7 @@ sample YAML → decoder hooks), Prometheus metrics via `monitoring.Provider`, co
 wiring, `serve.StartAndServe` bootstrap, and a step-by-step checklist.
 
 Quick essentials:
+
 - Constructors return concrete `*T` with **no error** for pure in-memory wiring; return
   `(*T, error)` only when the constructor does I/O (e.g. `newDatabase`).
 - Pass wide dependency lists as a `*xxxConfig` struct, not many positional args (the

--- a/.bob/skills/development/SKILL.md
+++ b/.bob/skills/development/SKILL.md
@@ -123,25 +123,26 @@ Model file: `service/vc/committer.go` reads `newCommitter` → `run` → `commit
 ```go
 // service/vc/committer.go:50 — run() sits directly above the commit() it calls
 func (c *transactionCommitter) run(ctx context.Context, db *database, numWorkers int) error {
- g, eCtx := errgroup.WithContext(ctx)
- for range numWorkers {
-  g.Go(func() error { return c.commit(eCtx, db) }) // callee defined next
- }
- return g.Wait()
+	g, eCtx := errgroup.WithContext(ctx)
+	for range numWorkers {
+		g.Go(func() error { return c.commit(eCtx, db) }) // callee defined next
+	}
+	return g.Wait()
 }
 
 func (c *transactionCommitter) commit(ctx context.Context, db *database) error { /* ... */ }
 ```
 
 This applies when you *add* a helper too — insert it directly below its caller, not
-above, and not wherever there is spare room in the file. When you extract a helper out
-of an existing function during a refactor, double-check the extracted function's new
-position still satisfies caller-before-callee relative to *every* caller, not just the
-one you were looking at (a helper called from two places belongs below the one that
-reads top-to-bottom first). Free-standing utility/formatting helpers with no domain
-logic of their own (string formatting, tiny predicates, struct-literal constructors used
-from a single call site) belong at the very bottom of the file — see file layout item 10
-below — even below the last method of the file's main type.
+above it and not at some other arbitrary location in the file. When you extract a
+helper out of an existing function during a refactor, double-check the extracted
+function's new position still satisfies caller-before-callee relative to *every*
+caller, not just the one you were looking at (a helper called from two places belongs
+below the one that reads top-to-bottom first). Free-standing utility/formatting
+helpers with no domain logic of their own (string formatting, tiny predicates,
+struct-literal constructors used from a single call site) belong at the very bottom of
+the file — see file layout item 10 below — even below the last method of the file's
+main type.
 
 ### Group methods by struct
 
@@ -243,7 +244,7 @@ completion — that is errgroup's job. Bound parallelism with a fixed worker cou
 ```go
 g, eCtx := errgroup.WithContext(ctx)
 for range numWorkers {
- g.Go(func() error { return c.commit(eCtx, db) })
+	g.Go(func() error { return c.commit(eCtx, db) })
 }
 return g.Wait()
 ```
@@ -271,10 +272,10 @@ operation releases immediately on cancellation and the system never hangs on shu
 incoming := channel.NewReader(ctx, c.incomingValidatedTransactions)
 outgoing := channel.NewWriter(ctx, c.outgoingTransactionsStatus)
 for {
- vTx, ok := incoming.Read()
- if !ok { return nil } // ctx done or channel closed
- // ...
- outgoing.Write(txsStatus)
+	vTx, ok := incoming.Read()
+	if !ok { return nil } // ctx done or channel closed
+	// ...
+	outgoing.Write(txsStatus)
 }
 ```
 
@@ -334,12 +335,12 @@ uses `fmt.Errorf("failed to read status for tx %s: %w", txID, err)`, not `errors
 
 ```go
 if len(query.TxIds) == 0 {
- return nil, grpcerror.WrapInvalidArgument(errors.New("query is empty"))
+	return nil, grpcerror.WrapInvalidArgument(errors.New("query is empty"))
 }
 txIDsStatus, err := vc.db.readStatusWithHeight(ctx, txIDs)
 if err != nil {
- logger.Errorf("%+v", err)                    // log full trace, once, at the boundary
- return nil, grpcerror.WrapInternalError(err) // convert to a gRPC status code
+	logger.Errorf("%+v", err)                    // log full trace, once, at the boundary
+	return nil, grpcerror.WrapInternalError(err) // convert to a gRPC status code
 }
 ```
 

--- a/.bob/skills/tests/SKILL.md
+++ b/.bob/skills/tests/SKILL.md
@@ -10,9 +10,9 @@ This document provides specific guidelines for writing and running tests in the 
 - **High Coverage Expected**: Strive for comprehensive test coverage, but focus on meaningful scenarios
 - **Minimize Mocks**: Use mocks sparingly; prefer testing with real dependencies when practical
 - **Database Tests**: Tests requiring databases are categorized:
-    - `test-core-db`: Components that directly interact with the database
-    - `test-requires-db`: Components that depend on the database layer
-    - `test-no-db`: Pure logic tests with no database dependency
+  - `test-core-db`: Components that directly interact with the database
+  - `test-requires-db`: Components that depend on the database layer
+  - `test-no-db`: Pure logic tests with no database dependency
 
 #### Running Database Tests
 
@@ -56,6 +56,7 @@ For authoring the production code these tests cover, use the `development` skill
 ### DO NOT Use Nested Test Groups
 
 ❌ **INCORRECT** - Do not nest success/failure cases:
+
 ```go
 func TestMyFunction(t *testing.T) {
     t.Parallel()
@@ -79,6 +80,7 @@ func TestMyFunction(t *testing.T) {
 ```
 
 ✅ **CORRECT** - Use flat structure with descriptive test names:
+
 ```go
 func TestMyFunction(t *testing.T) {
     t.Parallel()
@@ -137,6 +139,7 @@ func TestMyFunction(t *testing.T) {
 ### Use Inline Test Case Definitions
 
 ✅ **CORRECT** - Define test cases inline:
+
 ```go
 for _, tc := range []struct {
     name     string
@@ -188,6 +191,7 @@ for _, tc := range []struct {
 When testing functions that panic:
 
 ✅ **CORRECT** - Use `require.Panics()` for general panic testing:
+
 ```go
 require.Panics(t, func() {
     MyFunction(invalidInput)
@@ -195,6 +199,7 @@ require.Panics(t, func() {
 ```
 
 ❌ **AVOID** - Don't use `require.PanicsWithValue()` or `require.PanicsWithError()` when error wrapping is involved:
+
 ```go
 // This may fail due to error wrapping (e.g., cockroachdb/errors)
 require.PanicsWithValue(t, "exact error message", func() {
@@ -204,11 +209,64 @@ require.PanicsWithValue(t, "exact error message", func() {
 
 **Rationale**: Error wrapping libraries (like `cockroachdb/errors`) add stack traces and metadata, making exact value matching unreliable. Use `require.Panics()` unless you have a specific need to verify the exact panic value.
 
+## Step comments for multi-step scenario tests
+
+Table-driven tests cover one input/output at a time; many integration and
+sequential-scenario tests instead walk a story with side effects in between (submit a
+block, wait for a status, mutate config, assert a new behavior). For these, narrate each
+stage with a paired `// Step N: <what and, if not obvious, why>` comment directly above
+the code AND a matching `t.Log("Step N: ...")` call at the top of that stage — the
+comment documents intent for a reader of the source, the `t.Log` puts the same narrative
+into `-v` test output so a failure's stack trace lands under a labeled stage instead of
+an anonymous block of assertions.
+
+```go
+// Step 2: Submit config block removing peer-org-2 (keep only peer-org-0 and peer-org-1).
+// CreateOrExtendConfigBlockWithCrypto retains existing crypto on disk, so peer-org-2's
+// certs remain available for reconnection in Step 4.
+t.Log("Step 2: Dynamic removal - submit config with 2 peer orgs")
+c.OrdererEnv.SubmitConfigBlock(t, &testcrypto.ConfigBlock{
+    OrdererEndpoints:      c.OrdererEnv.AllEndpoints,
+    PeerOrganizationCount: 2,
+})
+```
+
+Number steps sequentially for the whole test (`Step 1`, `Step 2`, ...) even across
+helper calls, so the sequence reads as one story; don't restart numbering per subtest.
+Keep the comment focused on *why this step exists in the scenario* (what earlier state
+it depends on, what later step will use its result) — not a restatement of the Go call
+below it, per the `development` skill's comment guidance. A short setup/waiting line
+that isn't really a new scenario stage doesn't need its own step number; reserve numbers
+for the scenario's actual beats. This pattern is orthogonal to table-driven tests — use
+numbered steps for sequential/stateful scenarios, table-driven for independent
+input/output cases; don't force one style onto the other's shape.
+
 ## Code Duplication
 
 - Avoid code duplication in tests
 - Extract common setup logic into helper functions
 - Use table-driven tests to reduce repetitive test code
+
+**Rule of thumb**: if the same 3+ lines of assertions or setup appear in two or more
+tests (even with minor argument differences), extract a small `requireXxx(t, ...)` or
+`makeXxx(t, ...)` helper rather than copy-pasting. This isn't just about line count — a
+repeated assertion block is a repeated *claim* about behavior, and when that behavior
+changes you want one call site to fix, not N near-identical copies that can silently
+drift out of sync with each other. Name the helper after what it verifies or builds
+(`requireStatusMetadata`, `requireSnapshotSegment`), not after the test that happens to
+use it first, so it reads naturally at every call site:
+
+```go
+// BAD — same three-assertion block repeated at every commit-verification site
+require.NotNil(t, committedBlock0.Metadata)
+require.Greater(t, len(committedBlock0.Metadata.Metadata), statusIdx)
+require.Equal(t, []byte{valid, valid, valid}, committedBlock0.Metadata.Metadata[statusIdx])
+// ... repeated again below for committedBlock1 with different expected bytes ...
+
+// GOOD — one assertion helper, called with the varying expectation
+requireStatusMetadata(t, committedBlock0, valid, valid, valid)
+requireStatusMetadata(t, committedBlock1, valid, valid, valid)
+```
 
 ## Test Coverage
 
@@ -282,6 +340,7 @@ The project provides specialized helper functions in [`utils/test/metrics.go`](.
 #### Direct Metric Value Assertions
 
 ✅ **CORRECT** - Use [`test.RequireIntMetricValue()`](../../utils/test/metrics.go:99) for immediate assertions:
+
 ```go
 // Assert metric equals expected value immediately
 test.RequireIntMetricValue(t, 5, myMetric)
@@ -294,6 +353,7 @@ test.RequireIntMetricValue(t, 0, metrics.pendingRequests)
 #### Eventual Metric Value Assertions
 
 ✅ **CORRECT** - Use [`test.EventuallyIntMetric()`](../../utils/test/metrics.go:105) when metrics update asynchronously:
+
 ```go
 // Wait for metric to reach expected value
 test.EventuallyIntMetric(
@@ -365,6 +425,7 @@ require.Greater(t, count, 500)
     - [`test.GetMetricValue()`](../../utils/test/metrics.go:69) for float metrics (histograms, summaries) or when you need the raw float value
 
 2. **Capture Baseline Values**: When testing incremental changes, capture the metric value before the operation:
+
    ```go
    preValue := test.GetIntMetricValue(t, metrics.transactionReceivedTotal)
 
@@ -377,6 +438,7 @@ require.Greater(t, count, 500)
    ```
 
 3. **Test Labeled Metrics**: Use [`WithLabelValues()`](https://pkg.go.dev/github.com/prometheus/client_golang/prometheus#CounterVec.WithLabelValues) to test specific label combinations:
+
    ```go
    test.RequireIntMetricValue(t, 10,
        metrics.transactionCommittedTotal.WithLabelValues("COMMITTED"))
@@ -393,12 +455,14 @@ require.Greater(t, count, 500)
         - Slow operations: `2*time.Second, 200*time.Millisecond`
 
 5. **Test Initial State**: Always verify metrics start at expected initial values:
+
    ```go
    test.RequireIntMetricValue(t, 0, metrics.pendingRequests)
    test.RequireIntMetricValue(t, 0, metrics.activeStreams)
    ```
 
 6. **Verify Metric Decrements**: When testing gauges that can decrease:
+
    ```go
    test.RequireIntMetricValue(t, 5, metrics.queueSize)
    // process items
@@ -406,6 +470,7 @@ require.Greater(t, count, 500)
    ```
 
 7. **Use `require.Never()` for Bounds Testing**: When verifying metrics don't exceed limits:
+
    ```go
    require.Never(t, func() bool {
        return test.GetIntMetricValue(t, metrics.counter) > maxExpected
@@ -413,6 +478,7 @@ require.Greater(t, count, 500)
    ```
 
 8. **Use `require.EventuallyWithT()` for Multi-Metric Conditions**: When checking multiple metrics, always use `require.EventuallyWithT()` instead of `require.Eventually()` to ensure clear visibility of which metric failed:
+
    ```go
    // ✅ CORRECT - Shows which metric failed
    require.EventuallyWithT(t, func(ct *assert.CollectT) {
@@ -430,6 +496,7 @@ require.Greater(t, count, 500)
    ```
 
 9. **Use `require.EventuallyWithT()` for Single Metrics with Context**: When you need detailed assertion messages for a single metric:
+
    ```go
    require.EventuallyWithT(t, func(ct *assert.CollectT) {
        actual := test.GetIntMetricValue(t, metrics.counter)
@@ -438,6 +505,7 @@ require.Greater(t, count, 500)
    ```
 
 10. **Test Timing Metrics**: For histogram and summary metrics, verify they are positive:
+
     ```go
     latency := test.GetMetricValue(t, metrics.requestDurationSeconds)
     require.Greater(t, latency, float64(0))
@@ -446,6 +514,7 @@ require.Greater(t, count, 500)
 ### Common Patterns
 
 #### Pattern 1: Incremental Counter Testing
+
 ```go
 // Capture baseline
 preValue := test.GetIntMetricValue(t, metrics.transactionReceivedTotal)
@@ -459,6 +528,7 @@ test.EventuallyIntMetric(t, preValue+5, metrics.transactionReceivedTotal,
 ```
 
 #### Pattern 2: Multiple Labeled Metrics
+
 ```go
 test.RequireIntMetricValue(t, 30, metrics.notifierPendingTxIDs)
 test.RequireIntMetricValue(t, 6, metrics.notifierUniquePendingTxIDs)
@@ -467,6 +537,7 @@ test.RequireIntMetricValue(t, 0, metrics.notifierTxIDsTimeoutDeliveries)
 ```
 
 #### Pattern 3: Queue Size Monitoring
+
 ```go
 // Verify queue fills up
 test.EventuallyIntMetric(t, 3, metrics.waitingTransactionsQueueSize,
@@ -481,6 +552,7 @@ test.EventuallyIntMetric(t, 0, metrics.waitingTransactionsQueueSize,
 ```
 
 #### Pattern 4: Complex Multi-Metric Conditions
+
 ```go
 // Use EventuallyWithT for clear failure messages
 require.EventuallyWithT(t, func(ct *assert.CollectT) {
@@ -490,6 +562,7 @@ require.EventuallyWithT(t, func(ct *assert.CollectT) {
 ```
 
 #### Pattern 5: Integration Test HTTP Metrics
+
 ```go
 require.EventuallyWithT(t, func(ct *assert.CollectT) {
     count := test.GetMetricValueFromURL(
@@ -546,5 +619,7 @@ func TestRelayMetrics(t *testing.T) {
 - **Use `require.Panics()` for panic testing**
 - **Descriptive test names**
 - **Helper functions at the end with `t.Helper()`**
+- **Extract a helper once 3+ lines of assertions/setup repeat across tests**
+- **Narrate multi-step scenario tests with paired `// Step N:` comments and `t.Log("Step N: ...")`**
 - **Never use `panic()` in tests**
 - **Use metrics testing helpers** - [`test.RequireIntMetricValue()`](../../utils/test/metrics.go:99), [`test.EventuallyIntMetric()`](../../utils/test/metrics.go:105), [`test.GetIntMetricValue()`](../../utils/test/metrics.go:92)


### PR DESCRIPTION
[skills] Expand development/tests skill guidance for comments, whitespace, file layout, helper extraction

#### Type of change

- Documentation update

#### Description

- `development` skill: add "Comments explain *why*, not *what*" section with good/bad
  examples; clarify caller-before-callee placement for newly added/extracted helpers; add
  a "Whitespace and readability" section on blank-line usage as step/paragraph separators;
  add guidance on when to split a growing concern into its own file.
- `tests` skill: add bullets on extracting a helper once 3+ lines of assertions/setup
  repeat across tests, and on narrating multi-step scenario tests with paired
  `// Step N:` comments and `t.Log`.
- Fix markdown fenced-code-block spacing (blank line before/after fences) throughout both
  skill files.

#### Related issues

- resolves #715
