### PR TITLE
[coordinator] Fix swapped manager metrics, report queues on scrape

### DIFF
--- a/docs/metrics_reference.md
+++ b/docs/metrics_reference.md
@@ -52,22 +52,23 @@ The following Sidecar metrics are exported for consumption by Prometheus.
 
 The following Coordinator metrics are exported for consumption by Prometheus.
 
-| Name                                                       | Type    | Labels      | Description                                                                                                |
-|------------------------------------------------------------|---------|-------------|------------------------------------------------------------------------------------------------------------|
-| coordinator_grpc_received_transaction_total                | counter |             | Total number of transactions received by the coordinator service from the client.                          |
-| coordinator_grpc_committed_transaction_total               | counter | status      | Total number of transactions committed status sent by the coordinator service to the client.               |
-| coordinator_verifier_input_tx_batch_queue_size             | gauge   |             | Size of the input transaction batch queue of the signature verifier manager.                               |
-| coordinator_verifier_output_validated_tx_batch_queue_size  | gauge   |             | Size of the output validated transaction batch queue of the signature verifier manager.                    |
-| coordinator_vcservice_output_tx_status_batch_queue_size    | gauge   |             | Size of the output transaction status batch queue of the validation and committer service manager.         |
-| coordinator_vcservice_output_validated_tx_batch_queue_size | gauge   |             | Size of the output validated transaction batch queue of the validation and committer service manager.      |
-| coordinator_verifier_transaction_processed_total           | counter |             | Total number of transactions processed by the signature verifier manager.                                  |
-| coordinator_vcservice_transaction_processed_total          | counter |             | Total number of transactions processed by the validation and committer service manager.                    |
-| coordinator_verifier_connection_status                     | gauge   | grpc_target | Connection status to verifier service by grpc target (1 = connected, 0 = disconnected).                    |
-| coordinator_verifier_connection_failure_total              | counter | grpc_target | Total number of connection failures to verifier service. Short-lived failures may not always be captured.  |
-| coordinator_vcservice_retired_transaction_total            | counter |             | Total number of transactions retried by the validation and committer service manager.                      |
-| coordinator_vcservice_connection_status                    | gauge   | grpc_target | Connection status to vcservice service by grpc target (1 = connected, 0 = disconnected).                   |
-| coordinator_vcservice_connection_failure_total             | counter | grpc_target | Total number of connection failures to vcservice service. Short-lived failures may not always be captured. |
-| coordinator_verifier_retired_transaction_total             | counter |             | Total number of transactions retried by the signature verifier manager.                                    |
+| Name                                                    | Type    | Labels      | Description                                                                                                |
+|---------------------------------------------------------|---------|-------------|------------------------------------------------------------------------------------------------------------|
+| coordinator_grpc_received_transaction_total             | counter |             | Total number of transactions received by the coordinator service from the client.                          |
+| coordinator_grpc_committed_transaction_total            | counter | status      | Total number of transactions committed status sent by the coordinator service to the client.               |
+| coordinator_verifier_connection_status                  | gauge   | grpc_target | Connection status to verifier service by grpc target (1 = connected, 0 = disconnected).                    |
+| coordinator_verifier_connection_failure_total           | counter | grpc_target | Total number of connection failures to verifier service. Short-lived failures may not always be captured.  |
+| coordinator_verifier_transaction_processed_total        | counter |             | Total number of transactions processed by the manager.                                                     |
+| coordinator_verifier_transaction_retried_total          | counter |             | Total number of transactions retried by the manager.                                                       |
+| coordinator_verifier_input_batch_queue_size             | gauge   |             | Size of the input batch queue of the manager.                                                              |
+| coordinator_verifier_output_batch_queue_size            | gauge   |             | Size of the output batch queue of the manager.                                                             |
+| coordinator_vcservice_connection_status                 | gauge   | grpc_target | Connection status to vcservice service by grpc target (1 = connected, 0 = disconnected).                   |
+| coordinator_vcservice_connection_failure_total          | counter | grpc_target | Total number of connection failures to vcservice service. Short-lived failures may not always be captured. |
+| coordinator_vcservice_transaction_processed_total       | counter |             | Total number of transactions processed by the manager.                                                     |
+| coordinator_vcservice_transaction_retried_total         | counter |             | Total number of transactions retried by the manager.                                                       |
+| coordinator_vcservice_input_batch_queue_size            | gauge   |             | Size of the input batch queue of the manager.                                                              |
+| coordinator_vcservice_output_batch_queue_size           | gauge   |             | Size of the output batch queue of the manager.                                                             |
+| coordinator_vcservice_output_tx_status_batch_queue_size | gauge   |             | Size of the output transaction status batch queue of the validation and committer service manager.         |
 
 ## Verifier Metrics
 

--- a/scripts/metrics_doc_extract.py
+++ b/scripts/metrics_doc_extract.py
@@ -25,13 +25,17 @@ while repo_root_dir.parent != repo_root_dir:
         break
     repo_root_dir = repo_root_dir.parent
 
-# Pattern: New(Counter|Gauge|Histogram)(Vec)?(prometheus.(Counter|Gauge|Histogram)Opts
-# Captures: group(1)=metric type, group(2)=Vec or None, group(3)=opts type
-metric_pattern = re.compile(r'New([A-Z][a-z]+)(Vec)?\(prometheus\.([A-Z][a-z]+)Opts')
+# Pattern: New(Counter|Gauge|Histogram)(Vec|Func)?(prometheus.(Counter|Gauge|Histogram)Opts
+# Captures: group(1)=metric type, group(2)=Vec, Func or None, group(3)=opts type
+metric_pattern = re.compile(r'New([A-Z][a-z]+)(Vec|Func)?\(prometheus\.([A-Z][a-z]+)Opts')
 
 # Pattern: package.FunctionName(..., monitoring.MetricsParameters
 # Captures: group(1)=package, group(2)=method name
 params_usage_pattern = re.compile(r'(\w+)\.(\w+)\([^)]+,\s*(?:monitoring\.)?MetricsParameters')
+
+# Pattern: FunctionName(..., monitoring.MetricsParameters — a helper in the file being parsed.
+# Captures: group(1)=function name
+local_params_usage_pattern = re.compile(r'(?<![\w.])(\w+)\([^)]+,\s*(?:monitoring\.)?MetricsParameters')
 
 
 def main():
@@ -64,25 +68,37 @@ def print_all_metrics_from_content(content: str):
             print_single_metric_from_block(metric_type, is_vec, params_block)
             continue
 
-        # match_type == 'method'
-        package_name, function_name = rest
-
-        # Determine the source file based on the package name
-        source_file = repo_root_dir / "utils" / package_name / "metrics.go"
-        if not source_file.exists():
-            print(f"Warning: {source_file} not found", file=sys.stderr)
+        params_block = extract_block(params_block, "{}")
+        if not params_block:
             continue
 
+        if match_type == 'local_method':
+            # A helper defined in the file we are already parsing.
+            function_name, = rest
+            source_content = content
+        else:
+            # match_type == 'method'
+            package_name, function_name = rest
+
+            # Determine the source file based on the package name.
+            source_file = repo_root_dir / "utils" / package_name / "metrics.go"
+            if not source_file.exists():
+                print(f"Warning: {source_file} not found", file=sys.stderr)
+                continue
+            source_content = source_file.read_text()
+
         # Extract the function body
-        func_body = extract_function_body(source_file.read_text(), function_name)
+        func_body = extract_function_body(source_content, function_name)
         if not func_body:
             continue
 
-        # Substitute params.Namespace and params.Subsystem in the function body
+        # Substitute "params.Namespace" and "params.Subsystem" in the function body.
         namespace = extract_field(params_block, "Namespace")
         func_body = re.sub(r'\bparams\.Namespace\b', f'"{namespace}"', func_body)
         subsystem = extract_field(params_block, "Subsystem")
         func_body = re.sub(r'\bparams\.Subsystem\b', f'"{subsystem}"', func_body)
+        # Substitute "params" with the actual params definition, so we can extract nested metrics.
+        func_body = re.sub(r'\bparams\b', f'monitoring.MetricsParameters{{{params_block}}}', func_body)
 
         # Extract metrics from the substituted function body
         print_all_metrics_from_content(func_body)
@@ -92,7 +108,7 @@ def iter_all_matches(content: str):
     # Find all metrics.
     for match in metric_pattern.finditer(content):
         metric_type = match.group(1).lower()  # Counter, Gauge, or Histogram
-        is_vec = match.group(2) is not None  # Vec or None
+        is_vec = match.group(2) == 'Vec'  # only a Vec carries labels
         opts_type = match.group(3).lower()  # Counter, Gauge, or Histogram
 
         # Verify that the metric type matches the opts type
@@ -105,6 +121,10 @@ def iter_all_matches(content: str):
         function_name = match.group(2)
         yield match.start(), 'method', package_name, function_name
 
+    # Find all same-file helper calls that use monitoring.MetricsParameters{}
+    for match in local_params_usage_pattern.finditer(content):
+        yield match.start(), 'local_method', match.group(1)
+
 
 def print_single_metric_from_block(metric_type: str, is_vec: bool, block: str):
     """Print a metric as a Markdown table row."""
@@ -115,6 +135,12 @@ def print_single_metric_from_block(metric_type: str, is_vec: bool, block: str):
     labels = extract_labels(block) if is_vec else ""
 
     if not name:
+        return
+
+    # A definition inside a parameterised helper (Namespace: params.Namespace) cannot be
+    # resolved on its own. Skip it here; it is emitted once per call site instead, with the
+    # namespace and subsystem substituted.
+    if not namespace:
         return
 
     metric_name = namespace
@@ -167,9 +193,9 @@ def extract_labels(block: str) -> str:
 
 def extract_function_body(content: str, function_name: str) -> str:
     """Extract the body of a function by name."""
-    # Pattern: func FunctionName(..., params monitoring.MetricsParameters)
+    # Pattern: func FunctionName(..., params monitoring.MetricsParameters[, ...])
     match = re.search(
-        rf'func\s+{function_name}\s*\(([^)]+,)?\s*params\s+(monitoring\.)?MetricsParameters\)',
+        rf'func\s+{function_name}\s*\(([^)]+,)?\s*params\s+(monitoring\.)?MetricsParameters[,)]',
         content, re.MULTILINE,
     )
     if not match:

--- a/service/coordinator/coordinator.go
+++ b/service/coordinator/coordinator.go
@@ -10,7 +10,6 @@ import (
 	"context"
 	"sync"
 	"sync/atomic"
-	"time"
 
 	"github.com/cockroachdb/errors"
 	"github.com/hyperledger/fabric-lib-go/common/flogging"
@@ -128,7 +127,7 @@ func NewCoordinatorService(c *Config) *Service {
 		vcServiceToCoordinatorTxStatus:     newTxStatusQueue(bufSzPerChanForValCommitMgr),
 	}
 
-	metrics := newPerformanceMetrics()
+	metrics := newPerformanceMetrics(queues)
 
 	depMgr := dependencygraph.NewManager(
 		&dependencygraph.Parameters{
@@ -195,11 +194,6 @@ func (c *Service) Run(ctx context.Context) error {
 	defer c.validatorCommitterAPI.close()
 
 	g, eCtx := errgroup.WithContext(canCtx)
-
-	g.Go(func() error {
-		c.monitorQueues(eCtx)
-		return nil
-	})
 
 	g.Go(func() error {
 		logger.Info("Starting dependency graph manager")
@@ -446,24 +440,5 @@ func (c *Service) sendTxStatus(
 		for status, count := range statusCount {
 			promutil.AddToCounter(m.transactionCommittedTotal.WithLabelValues(status.String()), count)
 		}
-	}
-}
-
-func (c *Service) monitorQueues(ctx context.Context) {
-	ticker := time.NewTicker(c.config.QueueMonitorSamplingTime)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-ticker.C:
-		}
-
-		m := c.metrics
-		q := c.queues
-		promutil.SetGauge(m.sigverifierInputTxBatchQueueSize, len(q.depGraphToSigVerifierFreeTxs))
-		promutil.SetGauge(m.sigverifierOutputValidatedTxBatchQueueSize, len(q.sigVerifierToVCServiceValidatedTxs))
-		promutil.SetGauge(m.vcserviceOutputValidatedTxBatchQueueSize, len(q.vcServiceToDepGraphValidatedTxs))
-		promutil.SetGauge(m.vcserviceOutputTxStatusBatchQueueSize, q.vcServiceToCoordinatorTxStatus.len())
 	}
 }

--- a/service/coordinator/coordinator_test.go
+++ b/service/coordinator/coordinator_test.go
@@ -581,23 +581,27 @@ func TestCoordinatorServiceDependentOrderedTxs(t *testing.T) {
 func TestQueueSize(t *testing.T) {
 	t.Parallel()
 	env := newCoordinatorTestEnv(t, &testConfig{numSigService: 2, numVcService: 2})
-	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Minute)
-	t.Cleanup(cancel)
-	go env.coordinator.monitorQueues(ctx)
 
 	q := env.coordinator.queues
 	m := env.coordinator.metrics
+	requireQueueSizes := func(expected int) {
+		test.RequireIntMetricValue(t, expected, m.verifiers.inputQueueSize)
+		test.RequireIntMetricValue(t, expected, m.verifiers.outputQueueSize)
+		test.RequireIntMetricValue(t, expected, m.vcs.inputQueueSize)
+		test.RequireIntMetricValue(t, expected, m.vcs.outputQueueSize)
+		test.RequireIntMetricValue(t, expected, m.vcserviceOutputTxStatusBatchQueueSize)
+	}
+
+	requireQueueSizes(0)
+
+	// The verifier's output queue is the VC's input queue, so one batch covers both.
 	q.depGraphToSigVerifierFreeTxs <- dependencygraph.TxNodeBatch{}
 	q.sigVerifierToVCServiceValidatedTxs <- dependencygraph.TxNodeBatch{}
 	q.vcServiceToDepGraphValidatedTxs <- dependencygraph.TxNodeBatch{}
 	require.True(t, q.vcServiceToCoordinatorTxStatus.write(t.Context(), &committerpb.TxStatusBatch{}))
 
-	require.Eventually(t, func() bool {
-		return test.GetIntMetricValue(t, m.sigverifierInputTxBatchQueueSize) == 1 &&
-			test.GetIntMetricValue(t, m.sigverifierOutputValidatedTxBatchQueueSize) == 1 &&
-			test.GetIntMetricValue(t, m.vcserviceOutputValidatedTxBatchQueueSize) == 1 &&
-			test.GetIntMetricValue(t, m.vcserviceOutputTxStatusBatchQueueSize) == 1
-	}, 3*time.Second, 500*time.Millisecond)
+	// The gauges report the queue length when scraped, so no sampling interval to wait for.
+	requireQueueSizes(1)
 
 	<-q.depGraphToSigVerifierFreeTxs
 	<-q.sigVerifierToVCServiceValidatedTxs
@@ -605,12 +609,7 @@ func TestQueueSize(t *testing.T) {
 	_, ok := q.vcServiceToCoordinatorTxStatus.read(t.Context())
 	require.True(t, ok)
 
-	require.Eventually(t, func() bool {
-		return test.GetIntMetricValue(t, m.sigverifierInputTxBatchQueueSize) == 0 &&
-			test.GetIntMetricValue(t, m.sigverifierOutputValidatedTxBatchQueueSize) == 0 &&
-			test.GetIntMetricValue(t, m.vcserviceOutputValidatedTxBatchQueueSize) == 0 &&
-			test.GetIntMetricValue(t, m.vcserviceOutputTxStatusBatchQueueSize) == 0
-	}, 3*time.Second, 500*time.Millisecond)
+	requireQueueSizes(0)
 }
 
 func TestCoordinatorRecovery(t *testing.T) {

--- a/service/coordinator/metrics.go
+++ b/service/coordinator/metrics.go
@@ -9,34 +9,44 @@ package coordinator
 import (
 	"github.com/prometheus/client_golang/prometheus"
 
+	"github.com/hyperledger/fabric-x-committer/service/coordinator/dependencygraph"
 	"github.com/hyperledger/fabric-x-committer/utils/monitoring"
 )
 
-type perfMetrics struct {
-	*monitoring.Provider
+type (
+	perfMetrics struct {
+		*monitoring.Provider
 
-	// received and processed transactions
-	transactionReceivedTotal  prometheus.Counter
-	transactionCommittedTotal *prometheus.CounterVec
+		// received and processed transactions
+		transactionReceivedTotal  prometheus.Counter
+		transactionCommittedTotal *prometheus.CounterVec
 
-	// queue sizes
-	sigverifierInputTxBatchQueueSize           prometheus.Gauge
-	sigverifierOutputValidatedTxBatchQueueSize prometheus.Gauge
-	vcserviceOutputTxStatusBatchQueueSize      prometheus.Gauge
-	vcserviceOutputValidatedTxBatchQueueSize   prometheus.Gauge
+		// per-service-manager metrics
+		verifiers *managerMetrics
+		vcs       *managerMetrics
 
-	// processed transactions by each manager
-	sigverifierTransactionProcessedTotal prometheus.Counter
-	vcserviceTransactionProcessedTotal   prometheus.Counter
+		// The status queue is read by the coordinator itself, so it has no manager to report it.
+		// Its saturation is what stalls the idle handshake, see NoPendingTransactionProcessing.
+		vcserviceOutputTxStatusBatchQueueSize prometheus.GaugeFunc
+	}
 
-	// connection failure
-	verifiersConnection               *monitoring.ConnectionMetrics
-	verifiersRetriedTransactionTotal  prometheus.Counter
-	vcservicesConnection              *monitoring.ConnectionMetrics
-	vcservicesRetriedTransactionTotal prometheus.Counter
-}
+	// managerMetrics holds the metrics that every service manager reports. Defining them
+	// once and instantiating them per manager keeps the two managers from drifting apart.
+	managerMetrics struct {
+		// connection tracks the connection state to the service endpoints.
+		connection *monitoring.ConnectionMetrics
+		// processedTotal counts the transactions whose status was received and forwarded.
+		processedTotal prometheus.Counter
+		// retriedTotal counts the transactions resubmitted after a failure.
+		retriedTotal prometheus.Counter
+		// inputQueueSize reports the size of the manager's input batch queue.
+		inputQueueSize prometheus.GaugeFunc
+		// outputQueueSize reports the size of the manager's output batch queue.
+		outputQueueSize prometheus.GaugeFunc
+	}
+)
 
-func newPerformanceMetrics() *perfMetrics {
+func newPerformanceMetrics(q *channels) *perfMetrics {
 	p := monitoring.NewProvider()
 
 	return &perfMetrics{
@@ -53,63 +63,63 @@ func newPerformanceMetrics() *perfMetrics {
 			Name:      "committed_transaction_total",
 			Help:      "Total number of transactions committed status sent by the coordinator service to the client.",
 		}, []string{"status"}),
-		sigverifierInputTxBatchQueueSize: p.NewGauge(prometheus.GaugeOpts{
+		verifiers: newManagerMetrics(p, monitoring.MetricsParameters{
 			Namespace: "coordinator",
 			Subsystem: "verifier",
-			Name:      "input_tx_batch_queue_size",
-			Help:      "Size of the input transaction batch queue of the signature verifier manager.",
-		}),
-		sigverifierOutputValidatedTxBatchQueueSize: p.NewGauge(prometheus.GaugeOpts{
+		}, q.depGraphToSigVerifierFreeTxs, q.sigVerifierToVCServiceValidatedTxs),
+		vcs: newManagerMetrics(p, monitoring.MetricsParameters{
 			Namespace: "coordinator",
-			Subsystem: "verifier",
-			Name:      "output_validated_tx_batch_queue_size",
-			Help:      "Size of the output validated transaction batch queue of the signature verifier manager.",
-		}),
-		vcserviceOutputTxStatusBatchQueueSize: p.NewGauge(prometheus.GaugeOpts{
+			Subsystem: "vcservice",
+		}, q.sigVerifierToVCServiceValidatedTxs, q.vcServiceToDepGraphValidatedTxs),
+		vcserviceOutputTxStatusBatchQueueSize: p.NewGaugeFunc(prometheus.GaugeOpts{
 			Namespace: "coordinator",
 			Subsystem: "vcservice",
 			Name:      "output_tx_status_batch_queue_size",
 			Help: "Size of the output transaction status batch queue of " +
 				"the validation and committer service manager.",
+		}, func() float64 {
+			return float64(q.vcServiceToCoordinatorTxStatus.len())
 		}),
-		vcserviceOutputValidatedTxBatchQueueSize: p.NewGauge(prometheus.GaugeOpts{
-			Namespace: "coordinator",
-			Subsystem: "vcservice",
-			Name:      "output_validated_tx_batch_queue_size",
-			Help: "Size of the output validated transaction batch queue " +
-				"of the validation and committer service manager.",
-		}),
-		sigverifierTransactionProcessedTotal: p.NewCounter(prometheus.CounterOpts{
-			Namespace: "coordinator",
-			Subsystem: "verifier",
+	}
+}
+
+// newManagerMetrics creates the metric set of a single service manager. The namespace and
+// subsystem identify which manager reports them, and the two queues are reported on scrape.
+func newManagerMetrics(
+	p *monitoring.Provider,
+	params monitoring.MetricsParameters,
+	inputQueue <-chan dependencygraph.TxNodeBatch,
+	outputQueue chan<- dependencygraph.TxNodeBatch,
+) *managerMetrics {
+	return &managerMetrics{
+		connection: monitoring.NewConnectionMetrics(p, params),
+		processedTotal: p.NewCounter(prometheus.CounterOpts{
+			Namespace: params.Namespace,
+			Subsystem: params.Subsystem,
 			Name:      "transaction_processed_total",
-			Help:      "Total number of transactions processed by the signature verifier manager.",
+			Help:      "Total number of transactions processed by the manager.",
 		}),
-		vcserviceTransactionProcessedTotal: p.NewCounter(prometheus.CounterOpts{
-			Namespace: "coordinator",
-			Subsystem: "vcservice",
-			Name:      "transaction_processed_total",
-			Help:      "Total number of transactions processed by the validation and committer service manager.",
+		retriedTotal: p.NewCounter(prometheus.CounterOpts{
+			Namespace: params.Namespace,
+			Subsystem: params.Subsystem,
+			Name:      "transaction_retried_total",
+			Help:      "Total number of transactions retried by the manager.",
 		}),
-		verifiersConnection: monitoring.NewConnectionMetrics(p, monitoring.MetricsParameters{
-			Namespace: "coordinator",
-			Subsystem: "verifier",
+		inputQueueSize: p.NewGaugeFunc(prometheus.GaugeOpts{
+			Namespace: params.Namespace,
+			Subsystem: params.Subsystem,
+			Name:      "input_batch_queue_size",
+			Help:      "Size of the input batch queue of the manager.",
+		}, func() float64 {
+			return float64(len(inputQueue))
 		}),
-		verifiersRetriedTransactionTotal: p.NewCounter(prometheus.CounterOpts{
-			Namespace: "coordinator",
-			Subsystem: "vcservice",
-			Name:      "retired_transaction_total",
-			Help:      "Total number of transactions retried by the validation and committer service manager.",
-		}),
-		vcservicesConnection: monitoring.NewConnectionMetrics(p, monitoring.MetricsParameters{
-			Namespace: "coordinator",
-			Subsystem: "vcservice",
-		}),
-		vcservicesRetriedTransactionTotal: p.NewCounter(prometheus.CounterOpts{
-			Namespace: "coordinator",
-			Subsystem: "verifier",
-			Name:      "retired_transaction_total",
-			Help:      "Total number of transactions retried by the signature verifier manager.",
+		outputQueueSize: p.NewGaugeFunc(prometheus.GaugeOpts{
+			Namespace: params.Namespace,
+			Subsystem: params.Subsystem,
+			Name:      "output_batch_queue_size",
+			Help:      "Size of the output batch queue of the manager.",
+		}, func() float64 {
+			return float64(len(outputQueue))
 		}),
 	}
 }

--- a/service/coordinator/metrics_test.go
+++ b/service/coordinator/metrics_test.go
@@ -1,0 +1,65 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package coordinator
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger/fabric-x-committer/utils/monitoring/promutil"
+)
+
+// TestManagerMetricsSubsystem asserts on the exported series names rather than on the
+// perfMetrics fields. The two managers previously reported each other's retries because the
+// counters were registered under each other's subsystem, and the tests that covered them
+// asserted on the Go field, so they passed while the exported series was wrong.
+func TestManagerMetricsSubsystem(t *testing.T) {
+	t.Parallel()
+	m := newTestPerfMetrics()
+
+	promutil.AddToCounter(m.verifiers.processedTotal, 3)
+	promutil.AddToCounter(m.verifiers.retriedTotal, 5)
+	promutil.AddToCounter(m.vcs.processedTotal, 7)
+	promutil.AddToCounter(m.vcs.retriedTotal, 11)
+
+	for name, expected := range map[string]int{
+		"coordinator_verifier_transaction_processed_total":  3,
+		"coordinator_verifier_transaction_retried_total":    5,
+		"coordinator_vcservice_transaction_processed_total": 7,
+		"coordinator_vcservice_transaction_retried_total":   11,
+	} {
+		require.Equal(t, expected, gatherCounter(t, m, name), "series %s", name)
+	}
+}
+
+// newTestPerfMetrics builds the metric set over a minimal set of queues. newPerformanceMetrics
+// registers gauge functions over them, and a scrape reads every one, so the status queue must be
+// constructed: it is a pointer, unlike the channels, whose nil length is zero.
+func newTestPerfMetrics() *perfMetrics {
+	return newPerformanceMetrics(&channels{
+		vcServiceToCoordinatorTxStatus: newTxStatusQueue(1),
+	})
+}
+
+// gatherCounter returns the value of the named counter series as the registry exports it,
+// rounded to the nearest integer as the counters here all count transactions.
+func gatherCounter(t *testing.T, m *perfMetrics, name string) int {
+	t.Helper()
+	families, err := m.Registry().Gather()
+	require.NoError(t, err)
+	for _, family := range families {
+		if family.GetName() != name {
+			continue
+		}
+		require.Len(t, family.GetMetric(), 1)
+		return int(math.Round(family.GetMetric()[0].GetCounter().GetValue()))
+	}
+	require.Failf(t, "metric not found", "no series named %s is registered", name)
+	return 0
+}

--- a/service/coordinator/signature_verifier_manager.go
+++ b/service/coordinator/signature_verifier_manager.go
@@ -101,7 +101,7 @@ func (svm *signatureVerifierManager) run(ctx context.Context) error {
 	defer connection.CloseConnectionsLog(connections...)
 	for i, conn := range connections {
 		label := conn.CanonicalTarget()
-		c.metrics.verifiersConnection.Disconnected(label)
+		c.metrics.verifiers.connection.Disconnected(label)
 
 		sv := newSignatureVerifier(c, conn)
 		svm.signVerifier[i] = sv
@@ -163,7 +163,7 @@ func (sv *signatureVerifier) sendTransactionsAndForwardStatus(
 	inputTxBatch channel.ReaderWriter[dependencygraph.TxNodeBatch],
 	outputValidatedTxs channel.Writer[dependencygraph.TxNodeBatch],
 ) error {
-	defer sv.metrics.verifiersConnection.Disconnected(sv.conn.CanonicalTarget())
+	defer sv.metrics.verifiers.connection.Disconnected(sv.conn.CanonicalTarget())
 	g, gCtx := errgroup.WithContext(ctx)
 
 	stream, err := sv.client.StartStream(gCtx)
@@ -172,7 +172,7 @@ func (sv *signatureVerifier) sendTransactionsAndForwardStatus(
 	}
 
 	// if the stream is started, the connection is established.
-	sv.metrics.verifiersConnection.Connected(sv.conn.CanonicalTarget())
+	sv.metrics.verifiers.connection.Connected(sv.conn.CanonicalTarget())
 
 	// NOTE: sendTransactionsToSVService and receiveStatusAndForwardToOutput must
 	//       always return an error on exist.
@@ -299,7 +299,7 @@ func (sv *signatureVerifier) receiveStatusAndForwardToOutput(
 			return errors.Wrap(outputValidatedTxs.Context().Err(), "context ended")
 		}
 
-		promutil.AddToCounter(sv.metrics.sigverifierTransactionProcessedTotal, len(response.Status))
+		promutil.AddToCounter(sv.metrics.verifiers.processedTotal, len(response.Status))
 	}
 }
 
@@ -341,7 +341,7 @@ func (sv *signatureVerifier) recoverPendingTransactions(inputTxBatch channel.Wri
 	sv.txBeingValidated = make(map[servicepb.Height]*dependencygraph.TransactionNode)
 
 	inputTxBatch.Write(pendingTxs)
-	promutil.AddToCounter(sv.metrics.verifiersRetriedTransactionTotal, len(pendingTxs))
+	promutil.AddToCounter(sv.metrics.verifiers.retriedTotal, len(pendingTxs))
 }
 
 func (sv *signatureVerifier) addTxsBeingValidated(txBatch dependencygraph.TxNodeBatch) {

--- a/service/coordinator/signature_verifier_manager_test.go
+++ b/service/coordinator/signature_verifier_manager_test.go
@@ -50,12 +50,17 @@ func newSvMgrTestEnv(t *testing.T, numSvService int, expectedEndErrorMsg ...byte
 	outputValidatedTxs := make(chan dependencygraph.TxNodeBatch, 10)
 
 	pm := newPolicyManager()
+	metrics := newPerformanceMetrics(&channels{
+		depGraphToSigVerifierFreeTxs:       inputTxBatch,
+		sigVerifierToVCServiceValidatedTxs: outputValidatedTxs,
+		vcServiceToCoordinatorTxStatus:     newTxStatusQueue(1),
+	})
 	svm := newSignatureVerifierManager(
 		&signVerifierManagerConfig{
 			clientConfig:             test.ServerToMultiClientConfig(test.InsecureTLSConfig, sc.Configs...),
 			incomingTxsForValidation: inputTxBatch,
 			outgoingValidatedTxs:     outputValidatedTxs,
-			metrics:                  newPerformanceMetrics(),
+			metrics:                  metrics,
 			policyManager:            pm,
 		},
 	)
@@ -74,7 +79,7 @@ func newSvMgrTestEnv(t *testing.T, numSvService int, expectedEndErrorMsg ...byte
 		nil,
 	)
 	monitoring.WaitForConnections(
-		t, svm.metrics.Provider, "coordinator_verifier_connection_status", numSvService,
+		t, metrics.Provider, "coordinator_verifier_connection_status", numSvService,
 	)
 
 	env := &svMgrTestEnv{
@@ -162,7 +167,7 @@ func (e *svMgrTestEnv) requireConnectionMetrics(
 	sv := e.signVerifierManager.signVerifier[svIndex]
 	monitoring.RequireConnectionMetrics(
 		t, sv.conn.CanonicalTarget(),
-		e.signVerifierManager.metrics.verifiersConnection,
+		e.signVerifierManager.metrics.verifiers.connection,
 		monitoring.ExpectedConn{Status: expectedConnStatus, FailureTotal: expectedConnFailureTotal},
 	)
 }
@@ -170,7 +175,7 @@ func (e *svMgrTestEnv) requireConnectionMetrics(
 func (e *svMgrTestEnv) requireRetriedTxsTotal(t *testing.T, expectedRetriedTxsTotal int) {
 	t.Helper()
 	test.EventuallyIntMetric(
-		t, expectedRetriedTxsTotal, e.signVerifierManager.metrics.verifiersRetriedTransactionTotal,
+		t, expectedRetriedTxsTotal, e.signVerifierManager.metrics.verifiers.retriedTotal,
 		30*time.Second, 250*time.Millisecond,
 	)
 }
@@ -192,7 +197,7 @@ func TestSignatureVerifierManagerWithSingleVerifier(t *testing.T) {
 	env.requireTxBatch(t, expectedValidatedTxs)
 
 	test.EventuallyIntMetric(
-		t, 15, env.signVerifierManager.config.metrics.sigverifierTransactionProcessedTotal,
+		t, 15, env.signVerifierManager.config.metrics.verifiers.processedTotal,
 		30*time.Second, 10*time.Millisecond,
 	)
 }
@@ -222,7 +227,7 @@ func TestSignatureVerifierManagerWithLargeSize(t *testing.T) {
 	// env.requireTxBatch(t, expectedValidatedTxs)
 
 	test.EventuallyIntMetric(
-		t, totalBlocks*txPerBlock+1, env.signVerifierManager.config.metrics.sigverifierTransactionProcessedTotal,
+		t, totalBlocks*txPerBlock+1, env.signVerifierManager.config.metrics.verifiers.processedTotal,
 		30*time.Second, 10*time.Millisecond,
 	)
 }

--- a/service/coordinator/validator_committer_manager.go
+++ b/service/coordinator/validator_committer_manager.go
@@ -96,7 +96,7 @@ func (vcm *validatorCommitterManager) run(ctx context.Context) error {
 	defer connection.CloseConnectionsLog(connections...)
 	for i, conn := range connections {
 		label := conn.CanonicalTarget()
-		c.metrics.vcservicesConnection.Disconnected(label)
+		c.metrics.vcs.connection.Disconnected(label)
 
 		vc := newValidatorCommitter(conn, c.metrics, c.policyMgr)
 		vcm.validatorCommitter[i] = vc
@@ -133,7 +133,7 @@ func (vc *validatorCommitter) sendTransactionsAndForwardStatus(
 	outputValidatedTxsNode channel.Writer[dependencygraph.TxNodeBatch],
 	outputTxsStatus *txStatusQueue,
 ) error {
-	defer vc.metrics.vcservicesConnection.Disconnected(vc.conn.CanonicalTarget())
+	defer vc.metrics.vcs.connection.Disconnected(vc.conn.CanonicalTarget())
 
 	g, gCtx := errgroup.WithContext(ctx)
 
@@ -143,7 +143,7 @@ func (vc *validatorCommitter) sendTransactionsAndForwardStatus(
 	}
 
 	// if the stream is started, the connection has been established.
-	vc.metrics.vcservicesConnection.Connected(vc.conn.CanonicalTarget())
+	vc.metrics.vcs.connection.Connected(vc.conn.CanonicalTarget())
 
 	// NOTE: sendTransactionsToVCService and receiveStatusAndForwardToOutput must
 	//       always return an error on exist.
@@ -276,7 +276,7 @@ func (vc *validatorCommitter) receiveStatusAndForwardToOutput(
 		}
 		logger.Debugf("Forwarded batch with %d TX statuses back to coordinator", len(txsStatus.Status))
 
-		promutil.AddToCounter(vc.metrics.vcserviceTransactionProcessedTotal, len(txsStatus.Status))
+		promutil.AddToCounter(vc.metrics.vcs.processedTotal, len(txsStatus.Status))
 
 		if len(txsNode) > 0 && !outputTxsNode.Write(txsNode) {
 			vc.addTxsBeingValidated(txsNode)
@@ -295,7 +295,7 @@ func (vc *validatorCommitter) recoverPendingTransactions(inputTxsNode channel.Wr
 		return
 	}
 
-	promutil.AddToCounter(vc.metrics.vcservicesRetriedTransactionTotal, len(pendingTxs))
+	promutil.AddToCounter(vc.metrics.vcs.retriedTotal, len(pendingTxs))
 	inputTxsNode.Write(pendingTxs)
 }
 

--- a/service/coordinator/validator_committer_manager_test.go
+++ b/service/coordinator/validator_committer_manager_test.go
@@ -54,13 +54,18 @@ func newVcMgrTestEnv(t *testing.T, numVCService int) *vcMgrTestEnv {
 	outputTxs := make(chan dependencygraph.TxNodeBatch, 10)
 	outputTxsStatus := newTxStatusQueue(10)
 
+	metrics := newPerformanceMetrics(&channels{
+		sigVerifierToVCServiceValidatedTxs: inputTxs,
+		vcServiceToDepGraphValidatedTxs:    outputTxs,
+		vcServiceToCoordinatorTxStatus:     outputTxsStatus,
+	})
 	vcm := newValidatorCommitterManager(
 		&validatorCommitterManagerConfig{
 			clientConfig:                   test.ServerToMultiClientConfig(test.InsecureTLSConfig, servers.Configs...),
 			incomingTxsForValidationCommit: inputTxs,
 			outgoingValidatedTxsNode:       outputTxs,
 			outgoingTxsStatus:              outputTxsStatus,
-			metrics:                        newPerformanceMetrics(),
+			metrics:                        metrics,
 			policyMgr:                      svEnv.policyManager,
 		},
 	)
@@ -73,7 +78,7 @@ func newVcMgrTestEnv(t *testing.T, numVCService int) *vcMgrTestEnv {
 	// Waiting for all the connections ensures the validatorCommitter slice is fully populated,
 	// as newSvMgrTestEnv does for the verifiers.
 	monitoring.WaitForConnections(
-		t, vcm.config.metrics.Provider, "coordinator_vcservice_connection_status", numVCService,
+		t, metrics.Provider, "coordinator_vcservice_connection_status", numVCService,
 	)
 
 	return &vcMgrTestEnv{
@@ -96,7 +101,7 @@ func (e *vcMgrTestEnv) requireConnectionMetrics(
 	sv := e.validatorCommitterManager.validatorCommitter[vcIndex]
 	monitoring.RequireConnectionMetrics(
 		t, sv.conn.CanonicalTarget(),
-		sv.metrics.vcservicesConnection,
+		sv.metrics.vcs.connection,
 		monitoring.ExpectedConn{Status: expectedConnStatus, FailureTotal: expectedConnFailureTotal},
 	)
 }
@@ -104,7 +109,7 @@ func (e *vcMgrTestEnv) requireConnectionMetrics(
 func (e *vcMgrTestEnv) requireRetriedTxsTotal(t *testing.T, expectedRetriedTxsTotal int) {
 	t.Helper()
 	test.EventuallyIntMetric(
-		t, expectedRetriedTxsTotal, e.validatorCommitterManager.config.metrics.vcservicesRetriedTransactionTotal,
+		t, expectedRetriedTxsTotal, e.validatorCommitterManager.config.metrics.vcs.retriedTotal,
 		5*time.Second, 250*time.Millisecond,
 	)
 }
@@ -132,7 +137,7 @@ func TestValidatorCommitterManagerX(t *testing.T) {
 		test.RequireProtoElementsMatch(t, expectedTxsStatus, outTxsStatus.Status)
 
 		test.EventuallyIntMetric(
-			t, 5, env.validatorCommitterManager.config.metrics.vcserviceTransactionProcessedTotal,
+			t, 5, env.validatorCommitterManager.config.metrics.vcs.processedTotal,
 			2*time.Second, 100*time.Millisecond,
 		)
 
@@ -165,7 +170,7 @@ func TestValidatorCommitterManagerX(t *testing.T) {
 
 		test.EventuallyIntMetric(
 			t, 5+totalBlocks*txPerBlock,
-			env.validatorCommitterManager.config.metrics.vcserviceTransactionProcessedTotal,
+			env.validatorCommitterManager.config.metrics.vcs.processedTotal,
 			2*time.Second, 100*time.Millisecond,
 		)
 
@@ -316,7 +321,7 @@ func TestValidatorCommitterManagerRecovery(t *testing.T) {
 	}
 	test.RequireProtoElementsMatch(t, expectedTxsStatus, actualTxsStatus)
 
-	txProcessedTotalMetric := env.validatorCommitterManager.config.metrics.vcserviceTransactionProcessedTotal
+	txProcessedTotalMetric := env.validatorCommitterManager.config.metrics.vcs.processedTotal
 	txTotal := test.GetIntMetricValue(t, txProcessedTotalMetric)
 
 	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Minute)
@@ -341,7 +346,7 @@ func TestValidatorCommitterManagerRecovery(t *testing.T) {
 func TestValidatorCommitterAddAndRecoverPendingTxs(t *testing.T) {
 	t.Parallel()
 	// The connection is unused: neither call below touches the stream.
-	vc := newValidatorCommitter(nil, newPerformanceMetrics(), newPolicyManager())
+	vc := newValidatorCommitter(nil, newTestPerfMetrics(), newPolicyManager())
 
 	txsNode := dependencygraph.TxNodeBatch{
 		{VCTx: &servicepb.VcTx{Ref: committerpb.NewTxRef("tx 1", 1, 0)}},
@@ -356,7 +361,7 @@ func TestValidatorCommitterAddAndRecoverPendingTxs(t *testing.T) {
 
 	require.ElementsMatch(t, txsNode, <-recovered)
 	require.Zero(t, vc.txBeingValidated.Count())
-	test.RequireIntMetricValue(t, len(txsNode), vc.metrics.vcservicesRetriedTransactionTotal)
+	test.RequireIntMetricValue(t, len(txsNode), vc.metrics.vcs.retriedTotal)
 }
 
 func (e *vcMgrTestEnv) readOutputTxsStatus(t *testing.T) *committerpb.TxStatusBatch {

--- a/utils/monitoring/provider.go
+++ b/utils/monitoring/provider.go
@@ -86,6 +86,16 @@ func (p *Provider) NewGauge(opts prometheus.GaugeOpts) prometheus.Gauge {
 	return g
 }
 
+// NewGaugeFunc creates a new prometheus gauge whose value is reported by calling fn on every
+// scrape. Use it instead of a NewGauge that a dedicated goroutine samples on a timer: the value
+// is exact rather than as fresh as the sampling interval, and no goroutine is needed. fn is
+// called by the scrape handler, so it must be cheap and safe for concurrent use.
+func (p *Provider) NewGaugeFunc(opts prometheus.GaugeOpts, fn func() float64) prometheus.GaugeFunc {
+	g := prometheus.NewGaugeFunc(opts, fn)
+	p.registry.MustRegister(g)
+	return g
+}
+
 // NewGaugeVec creates a new prometheus gauge vector.
 func (p *Provider) NewGaugeVec(opts prometheus.GaugeOpts, labels []string) *prometheus.GaugeVec {
 	gv := prometheus.NewGaugeVec(opts, labels)


### PR DESCRIPTION

#### Type of change

- Bug fix
- Improvement (improvement to code, performance, etc)
- Breaking change
- Test update

#### Description

- Register the metric set common to both service managers from a single `newManagerMetrics`,
  instantiated once per manager, so the verifier and vcservice series can no longer be given
  each other's subsystem.
- Rename `retired_transaction_total` to `transaction_retried_total` and shorten the queue-size
  gauge names. Dashboards querying the old names need updating; see the mapping below.
- Report the queue depths with `prometheus.NewGaugeFunc`, through a new
  `monitoring.Provider.NewGaugeFunc`, and drop `Service.monitorQueues` along with its goroutine
  and ticker. The reported value is now exact at scrape time instead of up to one sampling
  interval stale. `queue-monitor-sampling-time` is unchanged and still used by the dependency
  graph, which keeps its own sampler.
- `scripts/metrics_doc_extract.py`: follow a metric helper defined in the file being parsed (it
  resolved only `package.Func` against `utils/<package>/metrics.go`), recognise `NewGaugeFunc`,
  and skip a definition whose namespace is still `params.Namespace` — it is emitted once per call
  site with the namespace substituted.
- `TestManagerMetricsSubsystem` asserts on the exported series names. The existing tests asserted
  on the `perfMetrics` fields, which is why they passed while the series were swapped.

#### Additional details (Optional)

Metric name changes, for dashboard migration. The first two rows also change meaning, since the
counters were reporting each other's manager:

| before | after |
|---|---|
| `coordinator_vcservice_retired_transaction_total` (held verifier retries) | `coordinator_verifier_transaction_retried_total` |
| `coordinator_verifier_retired_transaction_total` (held vcservice retries) | `coordinator_vcservice_transaction_retried_total` |
| `coordinator_verifier_input_tx_batch_queue_size` | `coordinator_verifier_input_batch_queue_size` |
| `coordinator_verifier_output_validated_tx_batch_queue_size` | `coordinator_verifier_output_batch_queue_size` |
| `coordinator_vcservice_output_validated_tx_batch_queue_size` | `coordinator_vcservice_output_batch_queue_size` |

`coordinator_vcservice_input_batch_queue_size` is new. It observes the same channel as
`coordinator_verifier_output_batch_queue_size`, which is the queue between the two managers.

`coordinator_vcservice_output_tx_status_batch_queue_size` keeps its name. It has no verifier
counterpart, so it stays a coordinator-level metric rather than part of the shared set.

#### Related issues

- resolves #720


