### PR TITLE
[coordinator] Align VC and verifier manager stream behavior

### DIFF
--- a/service/coordinator/signature_verifier_manager.go
+++ b/service/coordinator/signature_verifier_manager.go
@@ -278,20 +278,13 @@ func (sv *signatureVerifier) receiveStatusAndForwardToOutput(
 	for {
 		response, err := stream.Recv()
 		if err != nil {
-			if grpcerror.HasCode(err, codes.InvalidArgument) {
-				// While it is unlikely that svm would send an invalid policy, it could happen
-				// if the stored policy in the database is corrupted or maliciously altered, or
-				// if there is a bug in the committer that modifies the policy bytes.
-				return errors.Join(retry.ErrNonRetryable, err)
-			}
-			// The stream ended or the SVM was closed.
-			return errors.Wrap(err, "receive from stream ended with error")
+			return classifyStreamRecvError(err)
 		}
 
 		logger.Debugf("New batch came from sv to sv manager, contains %d items", len(response.Status))
 
 		validatedTxs := sv.fetchAndDeleteTxBeingValidated(response)
-		if !outputValidatedTxs.Write(validatedTxs) {
+		if len(validatedTxs) > 0 && !outputValidatedTxs.Write(validatedTxs) {
 			// Since transactions are loaded and deleted from txBeingValidated before their
 			// validation results are queued, we must re-queue the transaction to txBeingValidated
 			// if its result cannot be added to the outputValidatedTxs queue.
@@ -350,4 +343,17 @@ func (sv *signatureVerifier) addTxsBeingValidated(txBatch dependencygraph.TxNode
 	for _, txNode := range txBatch {
 		sv.txBeingValidated[*servicepb.NewHeightFromTxRef(txNode.VCTx.Ref)] = txNode
 	}
+}
+
+// classifyStreamRecvError maps a receive error from a service stream to a retry decision, for both
+// the signature verifier and the validator committer manager. An InvalidArgument is not
+// retryable: it means the request we sent can never be accepted, which points at corrupted or
+// altered state, or at a bug in the committer. Every other error ends the stream and
+// is retried under the sustain policy.
+func classifyStreamRecvError(err error) error {
+	if grpcerror.HasCode(err, codes.InvalidArgument) {
+		return errors.Join(retry.ErrNonRetryable, err)
+	}
+	// The stream ended or the manager was closed.
+	return errors.Wrap(err, "receive from stream ended with error")
 }

--- a/service/coordinator/stream_error_test.go
+++ b/service/coordinator/stream_error_test.go
@@ -1,0 +1,59 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package coordinator
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/hyperledger/fabric-x-committer/utils/retry"
+)
+
+// TestClassifyStreamRecvError covers the retry decision both managers make on a receive error.
+// The verifier manager treated InvalidArgument as non-retryable while the validator committer
+// manager retried it forever, so the two managers are now bound to the same classification.
+func TestClassifyStreamRecvError(t *testing.T) {
+	t.Parallel()
+	// Non-retryable: the request can never be accepted, so retrying cannot help.
+	for _, tc := range []struct {
+		name string
+		err  error
+	}{
+		{name: "invalid argument", err: status.Error(codes.InvalidArgument, "bad policy")},
+		{
+			name: "invalid argument wrapped",
+			err:  errors.Wrap(status.Error(codes.InvalidArgument, "bad policy"), "receive failed"),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := classifyStreamRecvError(tc.err)
+			require.ErrorIs(t, err, retry.ErrNonRetryable)
+		})
+	}
+	// Retryable: a transient or terminal stream condition that a new stream may recover from.
+	for _, tc := range []struct {
+		name string
+		err  error
+	}{
+		{name: "unavailable", err: status.Error(codes.Unavailable, "connection refused")},
+		{name: "canceled", err: status.Error(codes.Canceled, "context canceled")},
+		{name: "internal", err: status.Error(codes.Internal, "boom")},
+		{name: "plain error", err: errors.New("EOF")},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			err := classifyStreamRecvError(tc.err)
+			require.NotErrorIs(t, err, retry.ErrNonRetryable)
+			require.ErrorContains(t, err, "receive from stream ended with error")
+		})
+	}
+}

--- a/service/coordinator/validator_committer_manager.go
+++ b/service/coordinator/validator_committer_manager.go
@@ -157,6 +157,13 @@ func (vc *validatorCommitter) sendTransactionsAndForwardStatus(
 		//       transaction from the stream and removing it from txBeingValidated, if the stream context is
 		//       canceled before we can write to these two channels, the validation results are lost forever.
 		//       Similarly, the first argument, i.e., context should not be stream context.
+		//       Binding them to the stream would also make the re-queue in
+		//       receiveStatusAndForwardToOutput reachable on every stream failure: a batch whose
+		//       statuses were already queued would be re-sent, the vcservice would re-emit those
+		//       statuses, and Service.numTxsInProgress would be decremented twice for one
+		//       transaction. That breaks the numTxsInProgress >= readyCount >= 0 invariant that
+		//       NoPendingTransactionProcessing relies on to report idle, so the sidecar could
+		//       never re-establish its stream.
 		return vc.receiveStatusAndForwardToOutput(ctx, stream, outputValidatedTxsNode, outputTxsStatus)
 	})
 
@@ -175,6 +182,10 @@ func (vc *validatorCommitter) sendTransactionsToVCService(
 		}
 
 		logger.Debugf("New TX node came from dependency graph manager to vc manager")
+		if len(txsNode) == 0 {
+			continue
+		}
+
 		vc.addTxsBeingValidated(txsNode)
 		txBatch := make([]*servicepb.VcTx, len(txsNode))
 		for i, txNode := range txsNode {
@@ -233,8 +244,7 @@ func (vc *validatorCommitter) receiveStatusAndForwardToOutput(
 	for {
 		txsStatus, err := stream.Recv()
 		if err != nil {
-			// The stream ended or the SVM was closed.
-			return errors.Wrap(err, "receive from stream ended with error")
+			return classifyStreamRecvError(err)
 		}
 
 		logger.Debugf("Batch contains %d TX statuses", len(txsStatus.Status))

--- a/service/coordinator/validator_committer_manager_test.go
+++ b/service/coordinator/validator_committer_manager_test.go
@@ -172,6 +172,33 @@ func TestValidatorCommitterManagerX(t *testing.T) {
 		ensureZeroWaitingTxs(env)
 	})
 
+	t.Run("an empty batch is not sent to the vcservice", func(t *testing.T) {
+		t.Parallel()
+		env := newVcMgrTestEnv(t, 1)
+
+		// The first batch of a stream goes through splitAndSendToVC, which already sends nothing
+		// for an empty batch, so send a real batch first to get past that path.
+		first, firstStatus := createInputTxsNodeForTest(t, 2, 0, 1)
+		env.inputTxs <- first
+		require.ElementsMatch(t, first, <-env.outputTxs)
+		test.RequireProtoElementsMatch(t, firstStatus, env.readOutputTxsStatus(t).Status)
+		require.Equal(t, uint32(1), env.mockVcService.NumBatchesReceived.Load())
+
+		// An empty batch reaches the manager when every status in a verifier response was
+		// untracked. It must not be marshalled and sent as an empty VcBatch.
+		env.inputTxs <- dependencygraph.TxNodeBatch{}
+
+		// A real batch behind it proves the empty one was skipped rather than merely delayed:
+		// had it been sent, it would have been counted before this one.
+		second, secondStatus := createInputTxsNodeForTest(t, 3, 0, 2)
+		env.inputTxs <- second
+		require.ElementsMatch(t, second, <-env.outputTxs)
+		test.RequireProtoElementsMatch(t, secondStatus, env.readOutputTxsStatus(t).Status)
+
+		require.Equal(t, uint32(2), env.mockVcService.NumBatchesReceived.Load())
+		ensureZeroWaitingTxs(env)
+	})
+
 	t.Run("send batches to ensure all vcservices are used", func(t *testing.T) {
 		t.Parallel()
 		env := newVcMgrTestEnv(t, 2)


### PR DESCRIPTION

#### Type of change

- Bug fix
- Test update

#### Description

- Bind both managers to one receive-error classification, `classifyStreamRecvError`. The VC
  manager previously retried an `InvalidArgument` under the sustain policy forever; the verifier
  manager already treated it as non-retryable.
- Skip empty batches in the VC send loop instead of marshalling and sending an empty `VcBatch`.
- Do not forward an empty batch from the verifier's receive loop to the VC manager, which is
  where those empty batches came from. The VC manager already guards its own output this way.
- Record at the VC's receive goroutine what breaks if the two output writes are bound to the
  stream context rather than the manager's: the re-queue becomes reachable on every stream
  failure, the statuses of a re-queued batch are delivered twice, and
  `Service.numTxsInProgress` is decremented twice for one transaction. The existing NOTE stated
  the requirement but not its consequence, which is what makes it easy to undo.

#### Additional details (Optional)

`TestValidatorCommitterManagerX/an_empty_batch_is_not_sent_to_the_vcservice` sends a real batch
first, because the first batch of a stream goes through `splitAndSendToVC`, which already sends
nothing for an empty batch — the empty send is only reachable once that path is behind us. With
the guard removed the test observes three batches on the wire instead of two.

No behavior changed for the failed-forward re-queue itself. The status write is already attempted
first and returns early on failure, so the nodes are never forwarded for a batch whose statuses
were dropped; the reverse ordering cannot be fixed by ordering and is instead held unreachable by
the context wiring, which is what the NOTE now explains.

This touches the same receive and send loops as #724, so whichever merges second needs a trivial
rebase.

#### Related issues

- resolves #721


