### PR TITLE
[utils] Correct the comments on writing to an optional channel output

### DIFF
--- a/utils/channel/reader_writer.go
+++ b/utils/channel/reader_writer.go
@@ -75,6 +75,8 @@ func NewReader[T any](ctx context.Context, input <-chan T) Reader[T] {
 }
 
 // NewWriter instantiate a Writer.
+// A nil output always fails to write: the value cannot be delivered, so callers that leave an
+// output unset because it is optional must ignore the result.
 func NewWriter[T any](ctx context.Context, output chan<- T) Writer[T] {
 	return &channel[T]{
 		ctx:    ctx,

--- a/utils/deliver/delivery.go
+++ b/utils/deliver/delivery.go
@@ -130,7 +130,8 @@ func toQueueWithoutReconnect(ctx context.Context, p *Parameters) error {
 		p.NextBlockNum++
 		backoff = nil
 
-		// Write will be no-op if the output buffer is nil.
+		// Both outputs are optional. Write reports false for one that was not set, since the
+		// value is dropped rather than delivered, so the result is deliberately ignored here.
 		outputBlock.Write(block)
 		outputBlockWithSourceID.Write(&BlockWithSourceID{
 			SourceID: p.SourceID,

--- a/utils/deliverorderer/orderer.go
+++ b/utils/deliverorderer/orderer.go
@@ -177,7 +177,8 @@ func (d *ftDelivery) processBlocks(ctx context.Context) error {
 	for ctx.Err() == nil {
 		deliverBlock, err := d.processNextBlock(ctx)
 		if deliverBlock != nil {
-			// Write will be no-op if the output buffer is nil.
+			// Both outputs are optional. Write reports false for one that was not set, since
+			// the value is dropped rather than delivered, so the result is ignored here.
 			deliveryBlockOutput.Write(deliverBlock.Block)
 			deliveryBlockOutputWithSourceID.Write(deliverBlock)
 		}


### PR DESCRIPTION

#### Type of change

- Documentation update

#### Description

- `deliver` and `deliverorderer` treat a nil output channel as an output the caller does not want.
  The comments claimed the write "will be no-op if the output buffer is nil", which is wrong
  twice over: a send on a nil channel blocks forever rather than doing nothing, and
  `channel.Write` in fact reports such a write as failed. Both call sites ignore the result, so the
  behavior was always correct — only the comments were not.
- Document the same contract on `channel.NewWriter`, where it belongs, so it is not re-derived at
  each call site.

#### Related issues

- resolves #722


