### PR TITLE
[sidecar, skills] Assert notifier metrics as eventually consistent

### DIFF
--- a/.bob/skills/tests/SKILL.md
+++ b/.bob/skills/tests/SKILL.md
@@ -424,6 +424,27 @@ require.Greater(t, count, 500)
     - [`test.GetIntMetricValue()`](../../utils/test/metrics.go:92) for capturing baseline values or when using with `require.Eventually()` for complex conditions
     - [`test.GetMetricValue()`](../../utils/test/metrics.go:69) for float metrics (histograms, summaries) or when you need the raw float value
 
+   Metrics are only **eventually consistent**: a metric is never required to be an exact in-time
+   representation of the truth, only to have been consistent with reality at some point and to
+   converge to it. So a metric updated by a worker goroutine must be asserted with
+   `test.EventuallyIntMetric()` — even when the test has already observed the worker's *effect*
+   (a response on a channel, a committed block). Observing the effect does not order the metric
+   update: the worker typically publishes the effect first and updates the metric a few
+   instructions later, and on a loaded CI runner it can be descheduled in between. Reserve
+   `test.RequireIntMetricValue()` for values no concurrent goroutine is touching, such as the
+   initial state before any work is submitted.
+
+   But an eventual assertion only proves a value was **reached**, so it is vacuous when the
+   expected value is the one the metric already holds — it passes on the first tick, before the
+   work it is meant to verify has happened. When a step must leave a metric *unchanged* (a gauge
+   that goes up and back down, a counter the step must not touch), don't assert it on its own with
+   an eventual helper. Either gate on a metric the step does change and then assert the unchanged
+   one with `test.RequireIntMetricValue()`, which fails the moment it moved, or assert the changed
+   and unchanged values as one `require.EventuallyWithT()` condition so they must hold at the same
+   instant — polling stays sound there, because the changed value cannot reach its expected state
+   until the step completes, and that is what keeps the unchanged ones meaningful. For "must never
+   exceed" claims, use `require.Never()` (see below).
+
 2. **Capture Baseline Values**: When testing incremental changes, capture the metric value before the operation:
 
    ```go
@@ -527,13 +548,14 @@ test.EventuallyIntMetric(t, preValue+5, metrics.transactionReceivedTotal,
     5*time.Second, 100*time.Millisecond)
 ```
 
-#### Pattern 2: Multiple Labeled Metrics
+#### Pattern 2: Several Metrics Updated by a Worker
 
 ```go
-test.RequireIntMetricValue(t, 30, metrics.notifierPendingTxIDs)
-test.RequireIntMetricValue(t, 6, metrics.notifierUniquePendingTxIDs)
-test.RequireIntMetricValue(t, 10, metrics.notifierTxIDsStatusDeliveries)
-test.RequireIntMetricValue(t, 0, metrics.notifierTxIDsTimeoutDeliveries)
+// The notifier's worker updates these after it delivers the notification the test just read,
+// so they are only eventually consistent with it.
+test.EventuallyIntMetric(t, 30, metrics.notifierPendingTxIDs, 5*time.Second, 100*time.Millisecond)
+test.EventuallyIntMetric(t, 6, metrics.notifierUniquePendingTxIDs, 5*time.Second, 100*time.Millisecond)
+test.EventuallyIntMetric(t, 10, metrics.notifierTxIDsStatusDeliveries, 5*time.Second, 100*time.Millisecond)
 ```
 
 #### Pattern 3: Queue Size Monitoring

--- a/service/sidecar/notify_test.go
+++ b/service/sidecar/notify_test.go
@@ -161,10 +161,12 @@ func TestNotifierDirect(t *testing.T) {
 		require.False(t, ok, "should not receive notification")
 	}
 
+	// The notifier's worker updates the metrics after it applies a request or delivers a
+	// notification, so they are only eventually consistent with what the response queues show.
 	// Verify pending txIDs: 5 queues * 6 unique txIDs = 30 pending subscriptions
 	// Unique pending: only 6 unique txIDs across all queues (first request adds 6, rest add 0)
-	test.RequireIntMetricValue(t, 30, m.notifierPendingTxIDs)
-	test.RequireIntMetricValue(t, 6, m.notifierUniquePendingTxIDs)
+	test.EventuallyIntMetric(t, 30, m.notifierPendingTxIDs, 5*time.Second, 100*time.Millisecond)
+	test.EventuallyIntMetric(t, 6, m.notifierUniquePendingTxIDs, 5*time.Second, 100*time.Millisecond)
 
 	t.Log("Submitting events - expecting notifications")
 	expected := []*committerpb.TxStatus{
@@ -182,9 +184,9 @@ func TestNotifierDirect(t *testing.T) {
 
 	// Verify metrics: 2 statuses delivered to 5 queues = 10 deliveries, pending 30-10=20
 	// Unique pending: 6-2=4 (txIDs "1" and "2" removed from map)
-	test.RequireIntMetricValue(t, 20, m.notifierPendingTxIDs)
-	test.RequireIntMetricValue(t, 4, m.notifierUniquePendingTxIDs)
-	test.RequireIntMetricValue(t, 10, m.notifierTxIDsStatusDeliveries)
+	test.EventuallyIntMetric(t, 20, m.notifierPendingTxIDs, 5*time.Second, 100*time.Millisecond)
+	test.EventuallyIntMetric(t, 4, m.notifierUniquePendingTxIDs, 5*time.Second, 100*time.Millisecond)
+	test.EventuallyIntMetric(t, 10, m.notifierTxIDsStatusDeliveries, 5*time.Second, 100*time.Millisecond)
 
 	t.Log("Not expecting more notifications")
 	time.Sleep(3 * time.Second)
@@ -220,9 +222,9 @@ func TestNotifierDirect(t *testing.T) {
 
 	// Verify metrics: 2 more statuses to 5 queues = 10 more deliveries, pending 20-10=10
 	// Unique pending: 4-2=2 (txIDs "3" and "4" removed from map, "5" and "6" remain)
-	test.RequireIntMetricValue(t, 10, m.notifierPendingTxIDs)
-	test.RequireIntMetricValue(t, 2, m.notifierUniquePendingTxIDs)
-	test.RequireIntMetricValue(t, 20, m.notifierTxIDsStatusDeliveries)
+	test.EventuallyIntMetric(t, 10, m.notifierPendingTxIDs, 5*time.Second, 100*time.Millisecond)
+	test.EventuallyIntMetric(t, 2, m.notifierUniquePendingTxIDs, 5*time.Second, 100*time.Millisecond)
+	test.EventuallyIntMetric(t, 20, m.notifierTxIDsStatusDeliveries, 5*time.Second, 100*time.Millisecond)
 
 	t.Log("Submitting requests with short timeout - expecting notifications")
 	timeoutIDs := []string{"5", "6", "7", "8"}
@@ -248,9 +250,16 @@ func TestNotifierDirect(t *testing.T) {
 	// Verify timeout metrics: 4 txIDs timed out for 5 queues = 20 timeout deliveries
 	// pending was 10 + 5*4 = 30, now 30-20 = 10 (original "5" and "6" still pending)
 	// Unique pending: was 2+2=4 (first timeout req added "7", "8"), now 4-2=2 ("7", "8" fully removed)
-	test.RequireIntMetricValue(t, 10, m.notifierPendingTxIDs)
-	test.RequireIntMetricValue(t, 2, m.notifierUniquePendingTxIDs)
-	test.RequireIntMetricValue(t, 20, m.notifierTxIDsTimeoutDeliveries)
+	// This step ends with both gauges back at the values they already held, so an eventual
+	// assertion on a gauge alone could be satisfied before the timeouts were recorded, proving
+	// nothing. The timeout counter is the only value the step changes, and it reaches 20 only
+	// once all 20 timeouts were recorded — requiring all three at the same instant is therefore
+	// what makes the two gauges meaningful here.
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		require.Equal(ct, 10, test.GetIntMetricValue(t, m.notifierPendingTxIDs))
+		require.Equal(ct, 2, test.GetIntMetricValue(t, m.notifierUniquePendingTxIDs))
+		require.Equal(ct, 20, test.GetIntMetricValue(t, m.notifierTxIDsTimeoutDeliveries))
+	}, 5*time.Second, 100*time.Millisecond)
 
 	t.Log("Submitting event with duplicate request - expecting single notification")
 	expected = []*committerpb.TxStatus{
@@ -267,9 +276,9 @@ func TestNotifierDirect(t *testing.T) {
 
 	// Verify metrics: 1 status to 5 queues = 5 deliveries, pending 10-5=5
 	// Unique pending: 2-1=1 (txID "5" removed, "6" remains)
-	test.RequireIntMetricValue(t, 5, m.notifierPendingTxIDs)
-	test.RequireIntMetricValue(t, 1, m.notifierUniquePendingTxIDs)
-	test.RequireIntMetricValue(t, 25, m.notifierTxIDsStatusDeliveries)
+	test.EventuallyIntMetric(t, 5, m.notifierPendingTxIDs, 5*time.Second, 100*time.Millisecond)
+	test.EventuallyIntMetric(t, 1, m.notifierUniquePendingTxIDs, 5*time.Second, 100*time.Millisecond)
+	test.EventuallyIntMetric(t, 25, m.notifierTxIDsStatusDeliveries, 5*time.Second, 100*time.Millisecond)
 
 	t.Log("Submitting duplicated event - expecting single notification")
 	expected = []*committerpb.TxStatus{
@@ -288,9 +297,9 @@ func TestNotifierDirect(t *testing.T) {
 
 	// Final metrics: 1 more status to 5 queues = 5 more deliveries, pending 5-5=0
 	// Unique pending: 1-1=0 (txID "6" removed, all done)
-	test.RequireIntMetricValue(t, 0, m.notifierPendingTxIDs)
-	test.RequireIntMetricValue(t, 0, m.notifierUniquePendingTxIDs)
-	test.RequireIntMetricValue(t, 30, m.notifierTxIDsStatusDeliveries)
+	test.EventuallyIntMetric(t, 0, m.notifierPendingTxIDs, 5*time.Second, 100*time.Millisecond)
+	test.EventuallyIntMetric(t, 0, m.notifierUniquePendingTxIDs, 5*time.Second, 100*time.Millisecond)
+	test.EventuallyIntMetric(t, 30, m.notifierTxIDsStatusDeliveries, 5*time.Second, 100*time.Millisecond)
 
 	t.Log("Submitting request exceeding per-request limit - expecting rejection")
 	perRequestLimit := env.n.maxTxIDsPerRequest


### PR DESCRIPTION
#### Type of change

- Test update
- Documentation update

#### Description

- `TestNotifierDirect`: the metric assertions that follow a response read now use
  `test.EventuallyIntMetric`. Only the initial-state block keeps `test.RequireIntMetricValue`,
  where nothing is in flight yet.
- The timeout step is asserted as a single `require.EventuallyWithT` condition. That step ends
  with both gauges back at the values they already held, so asserting them on their own would not
  prove the timeouts were recorded; the timeout counter is the only value the step changes, and
  requiring all three at the same instant is what keeps the gauges meaningful.
- `tests` skill: state that a metric is only eventually consistent with the worker's observable
  effect, and that an eventual assertion is vacuous when the expected value is the one the metric
  already holds. Its "Pattern 2" example was the racy form of these very assertions.

#### Related issues

- resolves #690


