### PR TITLE
[docs, skills] Fix stale metric names and config-default guidance

### DIFF
--- a/.bob/skills/development/SKILL.md
+++ b/.bob/skills/development/SKILL.md
@@ -213,7 +213,8 @@ Every `.go` file follows this order (model: `service/coordinator/coordinator.go`
 
 ### Split a package into role-named files
 
-`config.go` (Config + `Default*` consts), `metrics.go` (`perfMetrics` + `newXxxMetrics`),
+`config.go` (Config with mapstructure/`default`/validate tags), `metrics.go`
+(`perfMetrics` + `newXxxMetrics`),
 `<service>.go` (the server, constructor, lifecycle, gRPC handlers), then one file per
 pipeline component/manager (`preparer.go`, `validator.go`, `committer.go`, `database.go`).
 Keep files moderate (~200–750 lines); give a large concern its own file. Tests are
@@ -388,8 +389,9 @@ Quick essentials:
 - Pass wide dependency lists as a `*xxxConfig` struct, not many positional args (the
   `revive` `argument-limit` is 4).
 - Config structs use `mapstructure:"kebab-case"` + `validate:"..."` tags — **no `yaml`
-  tags**. Every field needs a `Default*` const and a `v.SetDefault(...)` in
-  `cmd/config/viper.go`, plus an entry in the sample YAML under `cmd/config/samples/`.
+  tags**. Give every field its default in a `default:"..."` tag — `cmd/config/config_preload.go`
+  registers them with viper automatically — plus an entry in the sample YAML under
+  `cmd/config/samples/`.
 - Adding a `loadgen` `workload.Profile` field also means updating
   `loadgen_shared.yaml.tmpl` and the env-override test.
 

--- a/.bob/skills/development/references/service-construction.md
+++ b/.bob/skills/development/references/service-construction.md
@@ -189,24 +189,25 @@ type Config struct {
 	Verifier           connection.MultiClientConfig `mapstructure:"verifier"`
 	ValidatorCommitter connection.MultiClientConfig `mapstructure:"validator-committer"`
 	DependencyGraph    *DependencyGraphConfig       `mapstructure:"dependency-graph" validate:"required"`
-	ChannelBufferSizePerGoroutine int          `mapstructure:"per-channel-buffer-size-per-goroutine" validate:"required,gt=0"`
-	QueueMonitorSamplingTime      time.Duration `mapstructure:"queue-monitor-sampling-time" validate:"required,gt=0"`
+	// Every scalar carries its default in a `default` tag, not a Default* const.
+	ChannelBufferSizePerGoroutine int `mapstructure:"per-channel-buffer-size-per-goroutine" default:"10" validate:"gt=0"`
+	QueueMonitorSamplingTime time.Duration `mapstructure:"queue-monitor-sampling-time" default:"100ms" validate:"gt=0"`
 }
-
-const (
-	DefaultServerPort             = 6001
-	DefaultDatabaseMaxConnections = 20
-)
 ```
 
 The full pipeline (keep every stage in sync when adding a field):
 
 ```
-Config struct (mapstructure) → viper default → sample YAML → env var → decoder hook → docs
+Config struct (mapstructure + default tag) → sample YAML → env var → decoder hook → docs
 ```
 
-- Register defaults in `cmd/config/viper.go` via `v.SetDefault("kebab.key", Default*)`;
-  env vars use prefix `SC_<SERVICE>_` with `-`/`.`→`_`.
+- Give every field its default in a `default:"..."` tag. `setDefaultsAndEnv`
+  (`cmd/config/config_preload.go:27`) walks the struct **type** and registers each tag as a
+  viper default, so a new field needs no manual `v.SetDefault`. Env vars use prefix
+  `SC_<SERVICE>_` with `-`/`.`→`_`, applied by the same walk.
+- `cmd/config/viper.go` holds only what a tag cannot express: the `server.*` limits for
+  client-facing services (`setClientFacingServerLimits`) and each service's default endpoint
+  (`setEndpoint`).
 - `readYamlAndSetupLogging[T]` (`cmd/config/app_config.go:90`) reads YAML, applies the
   `SC_<SVC>_YAML` override, and unmarshals + `validate.Struct`s three structs: logging,
   `serve.Config`, and your `T`.
@@ -223,6 +224,11 @@ holds typed prometheus fields. `newXxxMetrics()` calls `monitoring.NewProvider()
 `p.NewCounter/NewGauge/NewHistogram(...)` (each auto-registers). Give every metric
 `Namespace`/`Subsystem`/`Name`/`Help`. Update metrics at runtime only through `promutil`
 helpers (`AddToCounter`, `SetGauge`, `Observe`), never raw prometheus calls.
+
+For a gauge that merely reports a value already available on demand — a channel length, a
+queue depth — use `p.NewGaugeFunc(opts, fn)` instead of a `NewGauge` that a goroutine sets
+on a ticker. The value is then exact at scrape time and costs no goroutine. `fn` runs on the
+scrape path, so keep it cheap and concurrency-safe.
 
 ```go
 // service/vc/metrics.go:15
@@ -256,13 +262,13 @@ Pass dependencies as config. Open connections **in `Run`**, using the `utils/con
 dialers, and always `defer connection.CloseConnectionsLog(conn...)`:
 
 ```go
-// service/coordinator/validator_committer_manager.go:96
-commonConn, err := connection.NewLoadBalancedConnection(c.clientConfig)
+// service/coordinator/validator_committer_api.go:39
+conn, err := connection.NewLoadBalancedConnection(conf)
 if err != nil {
-	return fmt.Errorf("failed to create connection to validator persisters: %w", err)
+	return nil, fmt.Errorf("failed to create connection to validator persisters: %w", err)
 }
-defer connection.CloseConnectionsLog(commonConn)
-vcm.commonClient = servicepb.NewValidationAndCommitServiceClient(commonConn)
+// The caller owns the connection and defers connection.CloseConnectionsLog(conn).
+client := servicepb.NewValidationAndCommitServiceClient(conn)
 ```
 
 - `NewSingleConnection` — one peer; `NewLoadBalancedConnection` — round-robin over
@@ -296,14 +302,15 @@ return serve.StartAndServe(ctx, service, serverConfig)
 
 ## 9. New-service checklist
 
-1. `service/<name>/config.go` — `Config` (mapstructure + validate tags), `Default*` consts.
+1. `service/<name>/config.go` — `Config` (mapstructure + `default` + validate tags).
    Serving knobs go in `serve.Config`, not here.
 2. `service/<name>/metrics.go` — `perfMetrics` embedding `*monitoring.Provider`;
    `new<X>Metrics()` using `p.New*`.
 3. `service/<name>/<name>.go` — struct embedding `Unimplemented<X>Server` +
    `config`/`metrics`/`healthcheck`/`ready`; `New<X>Service(cfg)`; `Run` / `WaitForReady`
    / `RegisterService`; gRPC handlers using `grpcerror.Wrap*`. Package logger at top.
-4. `cmd/config/viper.go` — register every default with `v.SetDefault`.
+4. `cmd/config/viper.go` — only for what a `default` tag cannot express: the service's
+   default endpoint, and `server.*` limits if it is client-facing.
 5. `cmd/config/app_config.go` — `Read<X>YamlAndSetupLogging` via `readYamlAndSetupLogging[<X>.Config]`.
 6. `cmd/committer/config.go` + `start_cmd.go` — add the service to config dispatch and the
    `startService` switch → `serve.StartAndServe`.

--- a/.bob/skills/pr-review/SKILL.md
+++ b/.bob/skills/pr-review/SKILL.md
@@ -420,10 +420,10 @@ Config struct (mapstructure) → Viper defaults → CLI flags → Sample YAML �
 
 **Key files:** `service/*/config.go`, `cmd/config/viper.go`, `cmd/config/cobra_flags.go`, `cmd/config/samples/*.yaml`, `cmd/config/config_decoder.go`, `docs/setup.md`
 
-### Viper Defaults
+### Config Defaults
 
-- ✅ Every new `mapstructure` field has a `v.SetDefault()` in `cmd/config/viper.go`; defaults are production-safe; duration fields use `time.Duration` values
-- ❌ Flag missing defaults; zero-value defaults where zero means "disabled"; duration defaults as strings
+- ✅ Every new `mapstructure` field carries a `default:"..."` tag (registered with viper by `cmd/config/config_preload.go`); defaults are production-safe; duration defaults are parseable durations such as `100ms`
+- ❌ Flag missing defaults; zero-value defaults where zero means "disabled"; a manual `v.SetDefault` in `cmd/config/viper.go` where a `default` tag would do (that file is only for the service endpoint and `server.*` limits)
 
 ### Sample YAML
 

--- a/docs/performance-tuning.md
+++ b/docs/performance-tuning.md
@@ -47,9 +47,9 @@ Monitor queue length gauges to find the bottleneck. A growing queue means the do
 | `sidecar_relay_input_block_queue_size` | Block Ingestion | Coordinator not consuming blocks fast enough |
 | `sidecar_relay_waiting_transactions_queue_size` | Relay | Transactions waiting for commit statuses to return |
 | `sidecar_relay_output_committed_block_queue_size` | Committed Blocks | Committed blocks backing up; downstream consumers slow |
-| `coordinator_sigverifier_input_tx_batch_queue_size` | Signature Verification | Verifiers cannot keep up; add instances or CPU |
-| `coordinator_sigverifier_output_validated_tx_batch_queue_size` | Verified → VC | VC services not consuming verified transactions fast enough |
-| `coordinator_vcservice_output_validated_tx_batch_queue_size` | VC → Dep Graph | Dependency graph not processing validated results fast enough |
+| `coordinator_verifier_input_batch_queue_size` | Signature Verification | Verifiers cannot keep up; add instances or CPU |
+| `coordinator_verifier_output_batch_queue_size` | Verified → VC | VC services not consuming verified transactions fast enough |
+| `coordinator_vcservice_output_batch_queue_size` | VC → Dep Graph | Dependency graph not processing validated results fast enough |
 | `coordinator_vcservice_output_tx_status_batch_queue_size` | Status Response | Status responses backing up between VC and Coordinator |
 | `vcservice_preparer_input_queue_size` | VC Preparation | Preparer workers saturated |
 | `vcservice_validator_input_queue_size` | VC Validation | DB validation queries too slow; check connections or co-location |

--- a/docs/sidecar-block-diagram.md
+++ b/docs/sidecar-block-diagram.md
@@ -575,10 +575,10 @@ The sidecar tracks recovery-related metrics:
 ```
 Metrics:
 - sidecar_coordinator_connection_status
-  └─► Labels: {status="connected|disconnected"}
+  └─► Labels: {grpc_target="<endpoint>"}; 1 = connected, 0 = disconnected
 
-- sidecar_coordinator_connection_failures_total
-  └─► Increments on each connection failure
+- sidecar_coordinator_connection_failure_total
+  └─► Labels: {grpc_target="<endpoint>"}; increments on each connection failure
 
 - sidecar_ledger_block_height
   └─► Current block store height


### PR DESCRIPTION

#### Type of change

- Documentation update

#### Description

Docs:

- `docs/performance-tuning.md` — three of the four coordinator rows in "Key queues to watch" named
  metrics that are not exported. `coordinator_vcservice_output_validated_tx_batch_queue_size` was
  renamed by #724; the two `coordinator_sigverifier_*` names never existed under any release, as
  the subsystem has always been `verifier`.
- `docs/sidecar-block-diagram.md` — the recovery-metrics block named
  `sidecar_coordinator_connection_failures_total`, which is `..._connection_failure_total`, and
  gave both connection metrics a `status="connected|disconnected"` label. They are labelled
  `grpc_target`; connectedness is the gauge's value, not a label.

Skills:

- `development`, `pr-review` — both instructed that every new config field needs a `Default*` const
  and a `v.SetDefault()` in `cmd/config/viper.go`. Neither is how this repo works: no `Default*`
  const exists anywhere, and defaults come from a `default:"..."` struct tag that
  `setDefaultsAndEnv` (`cmd/config/config_preload.go:27`) registers with viper by walking the
  struct type. `cmd/config/viper.go` holds only what a tag cannot express — the service endpoint
  and the `server.*` limits for client-facing services. An agent or reviewer following the old
  text would add a const and a `SetDefault` call the codebase does not use, and would flag a
  correct change as missing a default.
- `development` — the coordinator `Config` snippet misquoted both scalar fields as
  `validate:"required,gt=0"` and invented two `Default*` consts; corrected to the real tags. The
  `NewLoadBalancedConnection` example still cited `validator_committer_manager.go:96`, which moved
  to `validator_committer_api.go:39` in #713.
- `development` — record `Provider.NewGaugeFunc`, added in #724, as the way to report a value that
  is already available on demand (a channel length, a queue depth) instead of a `NewGauge` that a
  goroutine sets on a ticker.

#### Additional details (Optional)

Found by running the `doc-audit` skill over #724, #725 and #726. Tier A was clean: the metrics, CLI
and sample-tree docs are current, and every `cmd/config/samples/*.yaml` still loads. Only two of
these corrections trace to those merges — the renamed queue gauge and the new `NewGaugeFunc`
helper; the rest are pre-existing errors found in the same files and fixed while in the area.

Every metric named in the two docs now resolves against `docs/metrics_reference.md`, and no skill
still claims a `Default*` const or a manual `v.SetDefault` is required.

#### Related issues

- follows up on #724
- related to #681


