### PR TITLE
[docs] Scan every metrics file when generating the reference

### DIFF
--- a/docs/metrics_reference.md
+++ b/docs/metrics_reference.md
@@ -52,23 +52,39 @@ The following Sidecar metrics are exported for consumption by Prometheus.
 
 The following Coordinator metrics are exported for consumption by Prometheus.
 
-| Name                                                    | Type    | Labels      | Description                                                                                                |
-|---------------------------------------------------------|---------|-------------|------------------------------------------------------------------------------------------------------------|
-| coordinator_grpc_received_transaction_total             | counter |             | Total number of transactions received by the coordinator service from the client.                          |
-| coordinator_grpc_committed_transaction_total            | counter | status      | Total number of transactions committed status sent by the coordinator service to the client.               |
-| coordinator_verifier_connection_status                  | gauge   | grpc_target | Connection status to verifier service by grpc target (1 = connected, 0 = disconnected).                    |
-| coordinator_verifier_connection_failure_total           | counter | grpc_target | Total number of connection failures to verifier service. Short-lived failures may not always be captured.  |
-| coordinator_verifier_transaction_processed_total        | counter |             | Total number of transactions processed by the manager.                                                     |
-| coordinator_verifier_transaction_retried_total          | counter |             | Total number of transactions retried by the manager.                                                       |
-| coordinator_verifier_input_batch_queue_size             | gauge   |             | Size of the input batch queue of the manager.                                                              |
-| coordinator_verifier_output_batch_queue_size            | gauge   |             | Size of the output batch queue of the manager.                                                             |
-| coordinator_vcservice_connection_status                 | gauge   | grpc_target | Connection status to vcservice service by grpc target (1 = connected, 0 = disconnected).                   |
-| coordinator_vcservice_connection_failure_total          | counter | grpc_target | Total number of connection failures to vcservice service. Short-lived failures may not always be captured. |
-| coordinator_vcservice_transaction_processed_total       | counter |             | Total number of transactions processed by the manager.                                                     |
-| coordinator_vcservice_transaction_retried_total         | counter |             | Total number of transactions retried by the manager.                                                       |
-| coordinator_vcservice_input_batch_queue_size            | gauge   |             | Size of the input batch queue of the manager.                                                              |
-| coordinator_vcservice_output_batch_queue_size           | gauge   |             | Size of the output batch queue of the manager.                                                             |
-| coordinator_vcservice_output_tx_status_batch_queue_size | gauge   |             | Size of the output transaction status batch queue of the validation and committer service manager.         |
+| Name                                                                                   | Type      | Labels      | Description                                                                                                   |
+|----------------------------------------------------------------------------------------|-----------|-------------|---------------------------------------------------------------------------------------------------------------|
+| coordinator_grpc_received_transaction_total                                            | counter   |             | Total number of transactions received by the coordinator service from the client.                             |
+| coordinator_grpc_committed_transaction_total                                           | counter   | status      | Total number of transactions committed status sent by the coordinator service to the client.                  |
+| coordinator_verifier_connection_status                                                 | gauge     | grpc_target | Connection status to verifier service by grpc target (1 = connected, 0 = disconnected).                       |
+| coordinator_verifier_connection_failure_total                                          | counter   | grpc_target | Total number of connection failures to verifier service. Short-lived failures may not always be captured.     |
+| coordinator_verifier_transaction_processed_total                                       | counter   |             | Total number of transactions processed by the manager.                                                        |
+| coordinator_verifier_transaction_retried_total                                         | counter   |             | Total number of transactions retried by the manager.                                                          |
+| coordinator_verifier_input_batch_queue_size                                            | gauge     |             | Size of the input batch queue of the manager.                                                                 |
+| coordinator_verifier_output_batch_queue_size                                           | gauge     |             | Size of the output batch queue of the manager.                                                                |
+| coordinator_vcservice_connection_status                                                | gauge     | grpc_target | Connection status to vcservice service by grpc target (1 = connected, 0 = disconnected).                      |
+| coordinator_vcservice_connection_failure_total                                         | counter   | grpc_target | Total number of connection failures to vcservice service. Short-lived failures may not always be captured.    |
+| coordinator_vcservice_transaction_processed_total                                      | counter   |             | Total number of transactions processed by the manager.                                                        |
+| coordinator_vcservice_transaction_retried_total                                        | counter   |             | Total number of transactions retried by the manager.                                                          |
+| coordinator_vcservice_input_batch_queue_size                                           | gauge     |             | Size of the input batch queue of the manager.                                                                 |
+| coordinator_vcservice_output_batch_queue_size                                          | gauge     |             | Size of the output batch queue of the manager.                                                                |
+| coordinator_vcservice_output_tx_status_batch_queue_size                                | gauge     |             | Size of the output transaction status batch queue of the validation and committer service manager.            |
+| coordinator_local_dependency_graph_input_tx_batch_queue_size                           | gauge     |             | Size of the input transaction batch queue of the local dependency graph manager                               |
+| coordinator_global_dependency_graph_input_tx_batch_queue_size                          | gauge     |             | Size of the input transaction batch queue of the global dependency graph manager                              |
+| coordinator_global_dependency_graph_size                                               | gauge     |             | Size of the global dependency graph manager in terms of the number of transactions waiting to be processed    |
+| coordinator_local_dependency_graph_tx_processed_total                                  | counter   |             | Total number of new transactions processed by the local dependency graph manager                              |
+| coordinator_global_dependency_graph_tx_processed_total                                 | counter   |             | Total number of new transactions processed by the global dependency graph manager                             |
+| coordinator_global_dependency_graph_validated_tx_processed_total                       | counter   |             | Total number of validated transactions processed by the global dependency graph manager                       |
+| coordinator_global_dependency_graph_construction_seconds                               | histogram |             | Time spent adding a transaction batch to the global dependency graph in the global dependency graph manager   |
+| coordinator_global_dependency_graph_constructor_wait_for_lock_seconds                  | histogram |             | Time spent waiting for the lock in the constructor of the global dependency graph manager                     |
+| coordinator_global_dependency_graph_add_tx_batch_to_graph_seconds                      | histogram |             | Time spent adding a transaction batch to the graph in the global dependency graph manager                     |
+| coordinator_global_dependency_graph_update_dependency_detector_seconds                 | histogram |             | Time spent updating the dependency detector with a transaction batch in the global dependency graph manager   |
+| coordinator_global_dependency_graph_validated_tx_batch_processing_seconds              | histogram |             | Time spent processing a validated transaction batch in the global dependency graph manager                    |
+| coordinator_global_dependency_graph_validated_tx_batch_processor_wait_for_lock_seconds | histogram |             | Time spent waiting for the lock in the validated transaction processor of the global dependency graph manager |
+| coordinator_global_dependency_graph_remove_dependents_of_validated_tx_batch_seconds    | histogram |             | Time spent removing the dependents of a validated transaction batch in the global dependency graph manager    |
+| coordinator_global_dependency_graph_add_freed_tx_batch_seconds                         | histogram |             | Time spent adding a freed transaction batch to a queue in the global dependency graph manager                 |
+| coordinator_global_dependency_graph_output_freed_tx_batch_seconds                      | histogram |             | Time spent outputting a freed transaction batch in the global dependency graph manager                        |
+| coordinator_dependency_graph_dependent_transactions_queue_size                         | gauge     |             | The number of transactions currently waiting on dependencies.                                                 |
 
 ## Verifier Metrics
 

--- a/scripts/metrics_doc.sh
+++ b/scripts/metrics_doc.sh
@@ -13,9 +13,11 @@ extract_metrics_script="${repo_root_dir}/scripts/metrics_doc_extract.py"
 metrics_doc="${repo_root_dir}/docs/metrics_reference.md"
 python_cmd="${python3:-${PYTHON_CMD}}"
 
+# generate_service_doc <service name> <metrics file>... - one section per service, over one or
+# more metrics files, for a service whose metrics are split across packages.
 generate_service_doc() {
   local service_name="$1"
-  local metrics_file="$2"
+  shift
 
   cat <<EOF
 ## ${service_name} Metrics
@@ -25,8 +27,11 @@ The following ${service_name} metrics are exported for consumption by Prometheus
 | Name | Type | Labels | Description |
 | ---- | ---- | ------ | ----------- |
 EOF
-  # Parses a Go metrics file and outputs markdown table rows.
-  ${python_cmd} "${extract_metrics_script}" "${repo_root_dir}/${metrics_file}"
+  # Parses the Go metrics files and outputs markdown table rows.
+  local metrics_file
+  for metrics_file in "$@"; do
+    ${python_cmd} "${extract_metrics_script}" "${repo_root_dir}/${metrics_file}"
+  done
   echo ""
 }
 
@@ -44,7 +49,9 @@ SPDX-License-Identifier: Apache-2.0
 EOF
 
   generate_service_doc "Sidecar" "service/sidecar/metrics.go"
-  generate_service_doc "Coordinator" "service/coordinator/metrics.go"
+  generate_service_doc "Coordinator" \
+    "service/coordinator/metrics.go" \
+    "service/coordinator/dependencygraph/metrics.go"
   generate_service_doc "Verifier" "service/verifier/metrics.go"
   generate_service_doc "Validator-Committer" "service/vc/metrics.go"
   generate_service_doc "Query Service" "service/query/metrics.go"


### PR DESCRIPTION
#### Type of change

- Bug fix
- Documentation update

#### Description

- `generate_service_doc` took a single metrics file, so a service whose metrics are split across
  packages was only partly documented. It now takes one or more, and the Coordinator section covers
  `service/coordinator/dependencygraph/metrics.go` as well.
- That adds the dependency graph's 16 metrics to `docs/metrics_reference.md`. No series is renamed
  or removed; the diff is larger than 16 rows only because the table is re-padded.

#### Additional details (Optional)

The gap was invisible to CI: `make check-metrics-doc` regenerates the doc and compares it to the
committed one, so a metrics file that is never scanned agrees with itself. Nothing else in the
tree is affected — `metrics_doc_extract.py` already parsed this file correctly, it was simply never
handed to it.

#### Related issues

- resolves #732
- part of #730

Signed-off-by: Liran Funaro <liran.funaro@gmail.com>

