### PR TITLE
[verifier] Report the per-stream executor queues

### DIFF
--- a/.bob/skills/development/references/service-construction.md
+++ b/.bob/skills/development/references/service-construction.md
@@ -233,6 +233,7 @@ call site was deleted, so two gauges silently read zero. Instead:
 |---|---|
 | Length of a channel that lives as long as the service | `p.NewChannelLenGauge(opts, ch)` |
 | Length of a channel replaced at runtime (per session) | `p.NewAtomicChannelLenGauge(opts, &ptr)`; the owner `Store`s the current channel |
+| Length of a channel that exists once per stream or worker, several live at a time | `p.NewChannelLenGaugeVec[T](opts, []string{"stream"})`; `Register`/`Unregister` per stream, and the operator sums over the label |
 | Anything else already computable (a map size, a struct field) | `p.NewGaugeFunc(opts, fn)` — `fn` runs on the scrape path, so keep it cheap, non-blocking and nil-safe |
 
 `promutil.SetGauge` / `AddToGauge` remain correct for a gauge whose value is *maintained*
@@ -281,6 +282,10 @@ func newVCServiceMetrics(q *queues) *perfMetrics {
 	}
 }
 ```
+
+With the `Vec` form, always `Unregister` when the stream ends — a series left behind keeps
+reporting the depth of a queue nothing drains, which reads as a stuck worker. Pair the
+`Register` with a `defer`.
 
 Reuse `monitoring.ThroughputMetrics` / `ConnectionMetrics` bundles where they fit
 (`utils/monitoring/metrics.go`). Run `make generate-metrics-doc` after changes.

--- a/docs/metrics_reference.md
+++ b/docs/metrics_reference.md
@@ -104,16 +104,19 @@ The following Coordinator metrics are exported for consumption by Prometheus.
 
 The following Verifier metrics are exported for consumption by Prometheus.
 
-| Name                                              | Type      | Labels        | Description                                                                                  |
-|---------------------------------------------------|-----------|---------------|----------------------------------------------------------------------------------------------|
-| verifier_server_tx_input_throughput               | counter   |               | Incoming requests for a component                                                            |
-| verifier_server_tx_output_throughput              | counter   |               | Outgoing responses for a component                                                           |
-| verifier_server_grpc_requests_total               | counter   | method        | Number of RPCs started by the service                                                        |
-| verifier_server_grpc_requests_latency_seconds     | histogram | method status | The latency (seconds) of requests by the service, by method and gRPC status code             |
-| verifier_server_grpc_stream_duration_seconds      | histogram | method status | The duration (seconds) a stream was active from start to end, by method and gRPC status code |
-| verifier_server_grpc_active_streams               | gauge     | method        | Number of gRPC streams currently open on the server                                          |
-| verifier_server_grpc_active_connections           | gauge     |               | Number of client connections currently open on the server                                    |
-| verifier_server_parallel_executor_active_requests | gauge     |               | The total number of active requests                                                          |
+| Name                                                       | Type      | Labels        | Description                                                                                  |
+|------------------------------------------------------------|-----------|---------------|----------------------------------------------------------------------------------------------|
+| verifier_server_parallel_executor_input_queue_size         | gauge     | stream        | Size of a stream's queue of transactions waiting to be verified.                             |
+| verifier_server_parallel_executor_output_single_queue_size | gauge     | stream        | Size of a stream's queue of verified transactions waiting to be batched.                     |
+| verifier_server_parallel_executor_output_queue_size        | gauge     | stream        | Size of a stream's queue of status batches waiting to be sent.                               |
+| verifier_server_tx_input_throughput                        | counter   |               | Incoming requests for a component                                                            |
+| verifier_server_tx_output_throughput                       | counter   |               | Outgoing responses for a component                                                           |
+| verifier_server_grpc_requests_total                        | counter   | method        | Number of RPCs started by the service                                                        |
+| verifier_server_grpc_requests_latency_seconds              | histogram | method status | The latency (seconds) of requests by the service, by method and gRPC status code             |
+| verifier_server_grpc_stream_duration_seconds               | histogram | method status | The duration (seconds) a stream was active from start to end, by method and gRPC status code |
+| verifier_server_grpc_active_streams                        | gauge     | method        | Number of gRPC streams currently open on the server                                          |
+| verifier_server_grpc_active_connections                    | gauge     |               | Number of client connections currently open on the server                                    |
+| verifier_server_parallel_executor_active_requests          | gauge     |               | The total number of active requests                                                          |
 
 ## Validator-Committer Metrics
 

--- a/docs/performance-tuning.md
+++ b/docs/performance-tuning.md
@@ -54,11 +54,17 @@ Monitor queue length gauges to find the bottleneck. A growing queue means the do
 | `coordinator_verifier_output_batch_queue_size` | Verified → VC | VC services not consuming verified transactions fast enough |
 | `coordinator_vcservice_output_batch_queue_size` | VC → Dep Graph | Dependency graph not processing validated results fast enough |
 | `coordinator_vcservice_output_tx_status_batch_queue_size` | Status Response | Status responses backing up between VC and Coordinator |
+| `sum(verifier_server_parallel_executor_input_queue_size)` | Verification | Verifier workers saturated across all streams |
 | `vcservice_batcher_input_queue_size` | VC Intake | Coordinator submitting faster than the VC batches; first queue to fill |
 | `vcservice_preparer_input_queue_size` | VC Preparation | Preparer workers saturated |
 | `vcservice_validator_input_queue_size` | VC Validation | DB validation queries too slow; check connections or co-location |
 | `vcservice_committer_input_queue_size` | VC Commit | DB commit throughput is the bottleneck; most common |
 | `vcservice_txstatus_output_queue_size` | VC Status Output | Status responses backing up; Coordinator not consuming fast enough |
+
+A queue that exists once per stream carries a `stream` label, so read it as a total with
+`sum(<metric>)` or per worker with `max(<metric>)` — a single saturated worker matters even when
+the total looks healthy. A stream's series disappears when the stream ends, so `sum` covers only
+the live streams.
 
 ## 3. Sidecar
 

--- a/service/verifier/metrics.go
+++ b/service/verifier/metrics.go
@@ -7,25 +7,63 @@ SPDX-License-Identifier: Apache-2.0
 package verifier
 
 import (
+	"github.com/hyperledger/fabric-x-common/api/committerpb"
 	"github.com/prometheus/client_golang/prometheus"
 
+	"github.com/hyperledger/fabric-x-committer/api/servicepb"
 	"github.com/hyperledger/fabric-x-committer/utils/monitoring"
 	"github.com/hyperledger/fabric-x-committer/utils/serve"
 )
 
-const namespace = "verifier_server"
+const (
+	namespace = "verifier_server"
+
+	subsystemParallelExecutor = "parallel_executor"
+)
 
 type metrics struct {
 	*monitoring.Provider
 	verifierServerTxs *monitoring.ThroughputMetrics
 	serverMetrics     *serve.ServerMetrics
 	activeRequests    prometheus.Gauge
+
+	// A parallel executor, and therefore its queues, exists per stream. The queues are reported
+	// per stream and summed by the operator, e.g.
+	// sum(verifier_server_parallel_executor_input_queue_size).
+	executorInputQueueSize        *monitoring.ChannelLenGaugeVec[*servicepb.TxWithRef]
+	executorOutputSingleQueueSize *monitoring.ChannelLenGaugeVec[*verificationOutput]
+	executorOutputQueueSize       *monitoring.ChannelLenGaugeVec[[]*committerpb.TxStatus]
 }
 
 func newMonitoring() *metrics {
 	p := monitoring.NewProvider()
+	streamLabels := []string{"stream"}
 	return &metrics{
 		Provider: p,
+		executorInputQueueSize: p.NewChannelLenGaugeVec[*servicepb.TxWithRef](
+			prometheus.GaugeOpts{
+				Namespace: namespace,
+				Subsystem: subsystemParallelExecutor,
+				Name:      "input_queue_size",
+				Help:      "Size of a stream's queue of transactions waiting to be verified.",
+			}, streamLabels,
+		),
+		executorOutputSingleQueueSize: p.NewChannelLenGaugeVec[*verificationOutput](
+			prometheus.GaugeOpts{
+				Namespace: namespace,
+				Subsystem: subsystemParallelExecutor,
+				Name:      "output_single_queue_size",
+				Help:      "Size of a stream's queue of verified transactions waiting to be batched.",
+			}, streamLabels,
+		),
+		executorOutputQueueSize: p.NewChannelLenGaugeVec[[]*committerpb.TxStatus](
+			prometheus.GaugeOpts{
+				Namespace: namespace,
+				Subsystem: subsystemParallelExecutor,
+				Name:      "output_queue_size",
+				Help:      "Size of a stream's queue of status batches waiting to be sent.",
+			}, streamLabels,
+		),
 		verifierServerTxs: monitoring.NewThroughputMetrics(p, monitoring.MetricsParameters{
 			Namespace: namespace,
 			Subsystem: "tx",
@@ -36,9 +74,25 @@ func newMonitoring() *metrics {
 		}),
 		activeRequests: p.NewGauge(prometheus.GaugeOpts{
 			Namespace: namespace,
-			Subsystem: "parallel_executor",
+			Subsystem: subsystemParallelExecutor,
 			Name:      "active_requests",
 			Help:      "The total number of active requests",
 		}),
 	}
+}
+
+// registerExecutorQueues starts reporting one stream's executor queues. The caller must
+// unregister them when the stream ends, otherwise the series keeps reporting a queue nothing
+// drains.
+func (m *metrics) registerExecutorQueues(streamID string, e *parallelExecutor) {
+	m.executorInputQueueSize.Register(e.inputCh, streamID)
+	m.executorOutputSingleQueueSize.Register(e.outputSingleCh, streamID)
+	m.executorOutputQueueSize.Register(e.outputCh, streamID)
+}
+
+// unregisterExecutorQueues removes the series of a stream that has ended.
+func (m *metrics) unregisterExecutorQueues(streamID string) {
+	m.executorInputQueueSize.Unregister(streamID)
+	m.executorOutputSingleQueueSize.Unregister(streamID)
+	m.executorOutputQueueSize.Unregister(streamID)
 }

--- a/service/verifier/verifier_server.go
+++ b/service/verifier/verifier_server.go
@@ -8,6 +8,8 @@ package verifier
 
 import (
 	"context"
+	"strconv"
+	"sync/atomic"
 
 	"github.com/cockroachdb/errors"
 	"github.com/hyperledger/fabric-lib-go/common/flogging"
@@ -29,6 +31,9 @@ type Server struct {
 	config      *Config
 	metrics     *metrics
 	healthcheck *health.Server
+	// nextStreamID labels the per-stream queue metrics. Only uniqueness among the live streams
+	// matters, since a stream's series is removed when it ends.
+	nextStreamID atomic.Uint64
 }
 
 var (
@@ -73,6 +78,10 @@ func (s *Server) StartStream(stream servicepb.Verifier_StartStreamServer) error 
 
 	// We create a new executor for each stream to avoid answering to the wrong stream.
 	executor := newParallelExecutor(s.config)
+	streamID := strconv.FormatUint(s.nextStreamID.Add(1), 10)
+	s.metrics.registerExecutorQueues(streamID, executor)
+	defer s.metrics.unregisterExecutorQueues(streamID)
+
 	g, gCtx := errgroup.WithContext(stream.Context())
 	g.Go(func() error {
 		return s.handleInputs(gCtx, stream, executor)

--- a/service/verifier/verifier_server_test.go
+++ b/service/verifier/verifier_server_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hyperledger/fabric-x-common/common/policydsl"
 	"github.com/hyperledger/fabric-x-common/protoutil"
 	"github.com/hyperledger/fabric-x-common/utils/testcrypto"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/hyperledger/fabric-x-committer/api/servicepb"
@@ -494,6 +495,58 @@ func requireTestCase(
 	require.NotNil(t, resp)
 	test.RequireProtoEqual(t, tt.req.Ref, resp.Ref)
 	require.Equal(t, tt.expectedStatus.String(), resp.Status.String())
+}
+
+// TestExecutorQueueMetricsPerStream asserts the per-stream executor queues are reported one
+// series per live stream, and that a stream that ends takes its series with it. A leftover series
+// would keep reporting the depth of a queue nothing drains, which reads as a stuck worker.
+func TestExecutorQueueMetricsPerStream(t *testing.T) {
+	t.Parallel()
+	config, serverConfig := defaultConfigWithTLS(test.InsecureTLSConfig)
+	c := newTestState(t, config, serverConfig)
+
+	firstCtx, cancelFirst := context.WithCancel(t.Context())
+	defer cancelFirst()
+	_, err := c.Client.StartStream(firstCtx)
+	require.NoError(t, err)
+
+	secondCtx, cancelSecond := context.WithCancel(t.Context())
+	defer cancelSecond()
+	_, err = c.Client.StartStream(secondCtx)
+	require.NoError(t, err)
+
+	// Both streams report their own input queue, under distinct labels.
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		require.Len(ct, executorQueueStreamLabels(t, c.Service), 2)
+	}, testTimeout, 50*time.Millisecond)
+
+	cancelFirst()
+
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		require.Len(ct, executorQueueStreamLabels(t, c.Service), 1)
+	}, testTimeout, 50*time.Millisecond)
+}
+
+// executorQueueStreamLabels returns the stream label of every exported executor input queue.
+func executorQueueStreamLabels(t *testing.T, s *Server) []string {
+	t.Helper()
+	families, err := s.metrics.Registry().Gather()
+	require.NoError(t, err)
+
+	var streams []string
+	for _, family := range families {
+		if family.GetName() != "verifier_server_parallel_executor_input_queue_size" {
+			continue
+		}
+		for _, metric := range family.GetMetric() {
+			for _, label := range metric.GetLabel() {
+				if label.GetName() == "stream" {
+					streams = append(streams, label.GetValue())
+				}
+			}
+		}
+	}
+	return streams
 }
 
 // State test state.

--- a/utils/monitoring/channel_len_gauge_vec.go
+++ b/utils/monitoring/channel_len_gauge_vec.go
@@ -1,0 +1,90 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package monitoring
+
+import (
+	"strings"
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// ChannelLenGaugeVec reports the length of each registered channel as its own series, labelled by
+// the values it was registered under. Use it for a queue that exists per stream or per worker,
+// where the set of live queues changes at runtime: a series exists only while its channel is
+// registered, so a finished stream leaves no stale reading behind, and an operator sums over the
+// label to get the total across workers.
+type ChannelLenGaugeVec[T any] struct {
+	desc      *prometheus.Desc
+	labels    []string
+	mu        sync.RWMutex
+	channels  map[string]channelWithLabels[T]
+	separator string
+}
+
+type channelWithLabels[T any] struct {
+	ch          <-chan T
+	labelValues []string
+}
+
+// NewChannelLenGaugeVec creates a gauge collector for a queue that exists once per stream or
+// worker. Registering and unregistering a channel adds and removes its series.
+func (p *Provider) NewChannelLenGaugeVec[T any](
+	opts prometheus.GaugeOpts,
+	labels []string,
+) *ChannelLenGaugeVec[T] {
+	c := &ChannelLenGaugeVec[T]{
+		desc: prometheus.NewDesc(
+			prometheus.BuildFQName(opts.Namespace, opts.Subsystem, opts.Name),
+			opts.Help,
+			labels,
+			opts.ConstLabels,
+		),
+		labels:   labels,
+		channels: make(map[string]channelWithLabels[T]),
+		// A separator that cannot appear in a label value keeps the map key unambiguous.
+		separator: "\x00",
+	}
+	p.registry.MustRegister(c)
+	return c
+}
+
+// Register starts reporting ch under the given label values. Registering the same label values
+// again replaces the channel, so the values must identify the queue uniquely: two live queues
+// sharing them would otherwise export one series and hide the other.
+func (c *ChannelLenGaugeVec[T]) Register(ch <-chan T, labelValues ...string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.channels[strings.Join(labelValues, c.separator)] = channelWithLabels[T]{
+		ch:          ch,
+		labelValues: labelValues,
+	}
+}
+
+// Unregister stops reporting the channel registered under the given label values, removing its
+// series. It is safe to call for label values that were never registered.
+func (c *ChannelLenGaugeVec[T]) Unregister(labelValues ...string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	delete(c.channels, strings.Join(labelValues, c.separator))
+}
+
+// Describe implements prometheus.Collector.
+func (c *ChannelLenGaugeVec[T]) Describe(out chan<- *prometheus.Desc) {
+	out <- c.desc
+}
+
+// Collect implements prometheus.Collector. It reports one gauge per registered channel.
+func (c *ChannelLenGaugeVec[T]) Collect(out chan<- prometheus.Metric) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	for _, entry := range c.channels {
+		out <- prometheus.MustNewConstMetric(
+			c.desc, prometheus.GaugeValue, float64(len(entry.ch)), entry.labelValues...,
+		)
+	}
+}

--- a/utils/monitoring/channel_len_gauge_vec_test.go
+++ b/utils/monitoring/channel_len_gauge_vec_test.go
@@ -1,0 +1,85 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package monitoring_test
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger/fabric-x-committer/utils/test"
+)
+
+func TestChannelLenGaugeVec(t *testing.T) {
+	t.Parallel()
+
+	env := newMetricsProviderTestEnv(t, test.InsecureTLSConfig, test.InsecureTLSConfig)
+
+	vec := env.provider.NewChannelLenGaugeVec[int](prometheus.GaugeOpts{
+		Namespace: "verifier_server",
+		Subsystem: "parallel_executor",
+		Name:      "stream_input_queue_size",
+		Help:      "Size of a stream's queue of transactions waiting to be verified",
+	}, []string{"stream"})
+
+	// With nothing registered the collector exports no series at all, rather than a zero.
+	require.NotContains(t, env.getMetrics(t), "verifier_server_parallel_executor_stream_input_queue_size")
+
+	first, second := make(chan int, 4), make(chan int, 4)
+	vec.Register(first, "1")
+	vec.Register(second, "2")
+	first <- 1
+	first <- 2
+	second <- 1
+
+	// Each queue is its own series, so an operator can sum them or read one worker.
+	env.checkMetrics(
+		t,
+		`verifier_server_parallel_executor_stream_input_queue_size{stream="1"} 2`,
+		`verifier_server_parallel_executor_stream_input_queue_size{stream="2"} 1`,
+	)
+
+	<-first
+	env.checkMetrics(t, `verifier_server_parallel_executor_stream_input_queue_size{stream="1"} 1`)
+
+	// A stream that ends takes its series with it. Were it left behind it would report the depth
+	// of a queue nothing drains any more, which reads as a stuck worker.
+	vec.Unregister("1")
+	metrics := env.getMetrics(t)
+	require.NotContains(t, metrics, `stream_input_queue_size{stream="1"}`)
+	require.Contains(t, metrics, `verifier_server_parallel_executor_stream_input_queue_size{stream="2"} 1`)
+
+	// Unregistering something that was never registered is a no-op.
+	require.NotPanics(t, func() { vec.Unregister("nonexistent") })
+}
+
+func TestChannelLenGaugeVecReRegister(t *testing.T) {
+	t.Parallel()
+
+	env := newMetricsProviderTestEnv(t, test.InsecureTLSConfig, test.InsecureTLSConfig)
+
+	vec := env.provider.NewChannelLenGaugeVec[int](prometheus.GaugeOpts{
+		Namespace: "sidecar",
+		Subsystem: "notifier",
+		Name:      "stream_block_queue_size",
+		Help:      "Size of one stream's queue of blocks waiting to be sent",
+	}, []string{"stream"})
+
+	// Re-registering the same label values replaces the channel rather than exporting the label
+	// twice, which prometheus would reject as a duplicate series mid-scrape.
+	old := make(chan int, 4)
+	old <- 1
+	old <- 2
+	vec.Register(old, "1")
+	env.checkMetrics(t, `sidecar_notifier_stream_block_queue_size{stream="1"} 2`)
+
+	fresh := make(chan int, 4)
+	fresh <- 1
+	vec.Register(fresh, "1")
+	env.checkMetrics(t, `sidecar_notifier_stream_block_queue_size{stream="1"} 1`)
+}

--- a/utils/monitoring/provider_test.go
+++ b/utils/monitoring/provider_test.go
@@ -359,3 +359,9 @@ func (e *metricsProviderTestEnv) checkMetrics(t *testing.T, expected ...string) 
 	t.Helper()
 	test.CheckMetrics(t, e.url, e.clientTLSConfig, expected...)
 }
+
+// getMetrics returns the whole exposition, for asserting that a series is absent.
+func (e *metricsProviderTestEnv) getMetrics(t *testing.T) string {
+	t.Helper()
+	return test.GetMetricsFromURL(t, e.url, e.clientTLSConfig)
+}

--- a/utils/test/metrics.go
+++ b/utils/test/metrics.go
@@ -67,7 +67,7 @@ func NewMetricsConnectionParameters(
 // CheckMetrics checks the metrics endpoint for the expected metrics.
 func CheckMetrics(t *testing.T, url string, tlsConfig *tls.Config, expectedMetrics ...string) {
 	t.Helper()
-	metricsOutput := getMetricsFromURL(t, url, tlsConfig)
+	metricsOutput := GetMetricsFromURL(t, url, tlsConfig)
 	for _, expected := range expectedMetrics {
 		require.Contains(t, metricsOutput, expected)
 	}
@@ -120,7 +120,7 @@ func getMetricSeries(
 ) []*promgo.Metric {
 	t.Helper()
 	parser := expfmt.NewTextParser(model.UTF8Validation)
-	families, err := parser.TextToMetricFamilies(strings.NewReader(getMetricsFromURL(t, params.URL, params.TLSConfig)))
+	families, err := parser.TextToMetricFamilies(strings.NewReader(GetMetricsFromURL(t, params.URL, params.TLSConfig)))
 	require.NoError(t, err)
 
 	family := families[params.MetricName]
@@ -152,7 +152,9 @@ func labelsMatch(m *promgo.Metric, want map[string]string) bool {
 	return true
 }
 
-func getMetricsFromURL(t TestingT, url string, tlsConfig *tls.Config) string {
+// GetMetricsFromURL returns the whole prometheus exposition served at url. Prefer CheckMetrics
+// or GetMetricValueFromURL for asserting on a series; use this to assert one is absent.
+func GetMetricsFromURL(t TestingT, url string, tlsConfig *tls.Config) string {
 	t.Helper()
 	client := &http.Client{
 		Transport: &http.Transport{


### PR DESCRIPTION

#### Type of change

- New feature

#### Description

- Add `monitoring.ChannelLenGaugeVec[T]`, a collector for a queue that exists once per stream or
  worker. `Register`/`Unregister` add and remove a channel and `Collect` reads each live one, so
  cardinality follows the number of live streams and a finished stream leaves no series behind.
  Re-registering the same label values replaces the channel, since prometheus rejects a duplicate
  series mid-scrape.
- Report the verifier's three `parallelExecutor` queues through it, one series per stream. A new
  executor exists per stream, so a gauge closing over a single channel cannot address them.
  `StartStream` registers them when it creates the executor and unregisters them on return.

#### Additional details (Optional)

`prometheus` has no `GaugeFuncVec`, which is why this is a custom `Collector` rather than another
wrapper over `NewGaugeFunc`. The `stream` label is a counter, unique only among the live streams,
which is all it needs to be since a series exists only while its stream does.

Read these with `sum()` for the total across streams or `max()` to catch one saturated worker
while the total still looks healthy; `sum` covers only the live streams.

#### Related issues

- resolves partly #734
- related to #730


> [!NOTE]
> Rebased onto main now that #736 has merged; the diff shown is this change alone.

