### PR TITLE
[query] Fix batcher reference leak when a view is retired mid-query

### DIFF
--- a/service/query/batcher.go
+++ b/service/query/batcher.go
@@ -72,6 +72,9 @@ type (
 
 		// batcher is initialized lazily upon the first query.
 		batcher *batcher
+		// retired is set once the view was ended or timed out, and its batcher
+		// reference, if any, was released.
+		retired bool
 	}
 	batcher struct {
 		m sync.Mutex
@@ -144,6 +147,7 @@ func (q *viewsBatcher) makeView(viewID string, p *committerpb.ViewParameters) er
 		v.m.Lock()
 		b := v.batcher
 		v.batcher = nil
+		v.retired = true
 		v.m.Unlock()
 		if b != nil {
 			b.leave()
@@ -164,6 +168,13 @@ func (q *viewsBatcher) getBatcher(ctx context.Context, view *committerpb.View) (
 
 	v.m.Lock()
 	defer v.m.Unlock()
+	// The view might have been retired after its holder was fetched, but before we acquired its
+	// lock. As the retirement is marked under the same lock, an assignment either precedes the
+	// retirement, which then releases it, or is rejected here. An unpaired assignment would have
+	// leaked the batcher, and its open DB transaction, for the service's lifetime.
+	if v.retired {
+		return nil, ErrInvalidOrStaleView
+	}
 	if v.batcher == nil {
 		if _, err := q.updateOrCreateBatcher(ctx, v); err != nil {
 			return nil, err

--- a/service/query/query_service_test.go
+++ b/service/query/query_service_test.go
@@ -350,6 +350,73 @@ func TestMakeViewLimitReached(t *testing.T) {
 	require.ErrorIs(t, err, ErrTooManyActiveViews)
 }
 
+// TestGetBatcherOnRetiredView covers the race in which a view is retired, either ended or
+// timed out, after a query fetched its holder from the map, but before the query assigned it
+// a batcher. Such an assignment has no matching release, so the batcher and its open DB
+// transaction would have remained alive for the service's lifetime.
+func TestGetBatcherOnRetiredView(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name        string
+		viewTimeout time.Duration
+		endView     bool
+	}{
+		{name: "ended view", viewTimeout: time.Minute, endView: true},
+		{name: "timed out view", viewTimeout: 500 * time.Millisecond},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			viewID := "view-id"
+			vb := newViewsBatcherForTest(t)
+			require.NoError(t, vb.makeView(viewID, defaultViewParams(tc.viewTimeout)))
+
+			// A query resolves the view's holder just before the view is retired.
+			v, ok := vb.viewIDToViewHolder.Load(viewID)
+			require.True(t, ok)
+
+			if tc.endView {
+				require.NoError(t, vb.removeViewID(viewID))
+			}
+			requireRetiredView(t, v)
+
+			// The retirement also unlists the view, so we relist its holder to emulate a query
+			// that resolved the holder before the retirement, and resumes only now.
+			vb.viewIDToViewHolder.Store(viewID, v)
+			b, err := vb.getBatcher(t.Context(), &committerpb.View{Id: viewID})
+			require.ErrorIs(t, err, ErrInvalidOrStaleView)
+			require.Nil(t, b)
+			require.Equal(t, 0, vb.viewParametersToLatestBatcher.Count())
+			test.RequireIntMetricValue(t, 0, vb.metrics.processingSessions.WithLabelValues(sessionViews))
+		})
+	}
+}
+
+// TestBatcherReleasedOnViewRetirement covers the opposite ordering of the same race: a batcher
+// assigned just before its view is retired must be released by the retirement.
+func TestBatcherReleasedOnViewRetirement(t *testing.T) {
+	t.Parallel()
+	viewID := "view-id"
+	vb := newViewsBatcherForTest(t)
+	require.NoError(t, vb.makeView(viewID, defaultViewParams(time.Minute)))
+
+	v, ok := vb.viewIDToViewHolder.Load(viewID)
+	require.True(t, ok)
+	b, err := vb.getBatcher(t.Context(), &committerpb.View{Id: viewID})
+	require.NoError(t, err)
+	require.NotNil(t, b)
+	require.False(t, b.isStale())
+
+	require.NoError(t, vb.removeViewID(viewID))
+	requireRetiredView(t, v)
+
+	// The view held the batcher's only reference, so releasing it cancels the batcher,
+	// which in turn rolls back its transaction and unlists it.
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		require.True(ct, b.isStale())
+		require.Equal(ct, 0, vb.viewParametersToLatestBatcher.Count())
+	}, 5*time.Second, 10*time.Millisecond)
+}
+
 func TestQueryMetrics(t *testing.T) {
 	t.Parallel()
 	env := newQueryServiceTestEnv(t, nil)
@@ -755,6 +822,32 @@ func defaultViewParams(timeout time.Duration) *committerpb.ViewParameters {
 		NonDeferrable:       false,
 		TimeoutMilliseconds: uint64(timeout.Milliseconds()), //nolint:gosec
 	}
+}
+
+// newViewsBatcherForTest creates a views batcher with no DB pool.
+// It is sufficient for view and batcher lifecycle tests, as the transaction
+// is created lazily, only when a query is executed.
+func newViewsBatcherForTest(t *testing.T) *viewsBatcher {
+	t.Helper()
+	return &viewsBatcher{
+		ctx: t.Context(),
+		config: &Config{
+			MaxAggregatedViews:    5,
+			ViewAggregationWindow: time.Minute,
+		},
+		metrics: newQueryServiceMetrics(),
+	}
+}
+
+// requireRetiredView waits for the view's retirement, which makeView performs
+// asynchronously once the view's context ends.
+func requireRetiredView(t *testing.T, v *viewHolder) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		v.m.Lock()
+		defer v.m.Unlock()
+		return v.retired
+	}, 5*time.Second, 10*time.Millisecond)
 }
 
 //nolint:ireturn // returning a gRPC client interface is intentional for test purpose.


### PR DESCRIPTION
#### Type of change

- Bug fix
- Test update

#### Description

- Mark a `viewHolder` as `retired` under its lock when the view is ended or times out, and
  reject `getBatcher()` on a retired view with `ErrInvalidOrStaleView`. As both the retirement
  and the batcher assignment are made under the view's lock, an assignment either precedes the
  retirement, which then releases it, or is rejected.
- Add unit tests for both orderings of the race: a query that assigns a batcher only after its
  view was retired, either ended or timed out, and a batcher assigned just before the retirement.

#### Additional details (Optional)

The tests relist the retired view's holder in `viewIDToViewHolder` to emulate a query that
resolved the holder before the retirement, as such a query cannot be descheduled deterministically.

#### Related issues

- resolves #740


