### PR TITLE
[serve, connection] Hand the pre-allocated listener over to its consumer

### DIFF
--- a/utils/connection/client_test.go
+++ b/utils/connection/client_test.go
@@ -103,12 +103,14 @@ func TestGRPCRetry(t *testing.T) {
 	require.Error(t, err)
 }
 
-// reserveWhileServerDown re-reserves the server's gRPC port the moment it is stopped, so a parallel
-// test cannot grab the just-freed ephemeral port while the server is down.
+// reserveWhileServerDown re-reserves the server's ports the moment it is stopped, so a parallel test
+// cannot grab the just-freed ephemeral ports while the server is down. The server is stopped
+// asynchronously (by canceling its context), so it may still hold the ports; the reservation retries
+// the bind until it releases them.
 func reserveWhileServerDown(t *testing.T, sc *serve.Config) {
 	t.Helper()
-	serve.ClosePreAllocatedListener(&sc.GRPC)
 	serve.PreAllocateListener(t, &sc.GRPC)
+	serve.PreAllocateListener(t, &sc.HTTP)
 	require.True(t, test.CheckServerStopped(t, sc.GRPC.Endpoint.Address()),
 		"a reservation-only port must not answer gRPC health checks")
 }

--- a/utils/serve/start_serve.go
+++ b/utils/serve/start_serve.go
@@ -221,9 +221,13 @@ func (s *Servers) Stop() {
 
 // Listener instantiates a [net.Listener] and updates the config port with the effective port.
 // If the port is predefined, it retries to bind to the port until successful or until the context ends.
+// A pre-allocated listener is handed over to the caller, which becomes its sole owner. The config
+// drops its reference so that releasing a reservation can never close a listener that a server is
+// already serving on.
 func (c *ServerConfig) Listener(ctx context.Context) (net.Listener, error) {
-	if c.preAllocatedListener != nil {
-		return c.preAllocatedListener, nil
+	if preAllocated := c.preAllocatedListener; preAllocated != nil {
+		c.preAllocatedListener = nil
+		return preAllocated, nil
 	}
 
 	var listener net.Listener

--- a/utils/serve/test_exports.go
+++ b/utils/serve/test_exports.go
@@ -16,7 +16,8 @@ import (
 )
 
 // PreAllocateListener allocates a port and binds ahead of server initialization.
-// It stores the listener object internally for reuse by later listener calls.
+// It stores the listener object internally until a server takes it (see [ServerConfig.Listener]),
+// which keeps the port held so that no other process can claim it in the meantime.
 func PreAllocateListener(tb testing.TB, c *ServerConfig) net.Listener {
 	tb.Helper()
 	if c.preAllocatedListener != nil {


### PR DESCRIPTION
#### Type of change

- Bug fix
- Test update

#### Description

- `ServerConfig.Listener` now clears the config's reference to the pre-allocated listener when it
  hands it to a server, making the server its sole owner. Releasing a reservation
  (`ClosePreAllocatedListener`) can therefore no longer close a listener a server is accepting on,
  and a non-nil `preAllocatedListener` now means exactly "the config holds this port".
- `reserveWhileServerDown` drops its `ClosePreAllocatedListener` call: once the restarted server has
  taken the reservation there is nothing left to close, and re-reserving the same port retries
  through `ListenRetryExecute` until the stopping server releases it, so the helper no longer
  depends on the asynchronous stop having completed first.
- `reserveWhileServerDown` also reserves the HTTP port, which was left free for the whole outage.

#### Additional details (Optional)

To observe the failure, start a server on a pre-allocated listener, cancel its context and
immediately close the reservation, in a loop: the asynchronous `Stop` usually fires grpc-go's quit
event first, but when the close wins, `Serve` returns
`accept tcp 127.0.0.1:<port>: use of closed network connection`.

#### Related issues

- resolves #746
