### PR TITLE
[loadgen] Key-generation metrics

### DIFF
--- a/docs/metrics_reference.md
+++ b/docs/metrics_reference.md
@@ -144,15 +144,18 @@ The following Query Service metrics are exported for consumption by Prometheus.
 
 The following Load Generator metrics are exported for consumption by Prometheus.
 
-| Name                                        | Type      | Labels | Description                                                                 |
-|---------------------------------------------|-----------|--------|-----------------------------------------------------------------------------|
-| loadgen_block_sent_total                    | counter   |        | Total number of blocks sent by the block generator                          |
-| loadgen_block_received_total                | counter   |        | Total number of blocks received by the block generator                      |
-| loadgen_transaction_sent_total              | counter   |        | Total number of transactions sent by the block generator                    |
-| loadgen_transaction_received_total          | counter   |        | Total number of transactions received by the block generator                |
-| loadgen_transaction_committed_total         | counter   |        | Total number of transaction commit statuses received by the block generator |
-| loadgen_transaction_aborted_total           | counter   |        | Total number of transaction abort statuses received by the block generator  |
-| loadgen_valid_transaction_latency_seconds   | histogram |        | Latency of valid transactions in seconds                                    |
-| loadgen_invalid_transaction_latency_seconds | histogram |        | Latency of invalid transactions in seconds                                  |
+| Name                                        | Type      | Labels | Description                                                                                                                                                                                   |
+|---------------------------------------------|-----------|--------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| loadgen_block_sent_total                    | counter   |        | Total number of blocks sent by the block generator                                                                                                                                            |
+| loadgen_block_received_total                | counter   |        | Total number of blocks received by the block generator                                                                                                                                        |
+| loadgen_transaction_sent_total              | counter   |        | Total number of transactions sent by the block generator                                                                                                                                      |
+| loadgen_transaction_received_total          | counter   |        | Total number of transactions received by the block generator                                                                                                                                  |
+| loadgen_transaction_committed_total         | counter   |        | Total number of transaction commit statuses received by the block generator                                                                                                                   |
+| loadgen_transaction_aborted_total           | counter   |        | Total number of transaction abort statuses received by the block generator                                                                                                                    |
+| loadgen_valid_transaction_latency_seconds   | histogram |        | Latency of valid transactions in seconds                                                                                                                                                      |
+| loadgen_invalid_transaction_latency_seconds | histogram |        | Latency of invalid transactions in seconds                                                                                                                                                    |
+| loadgen_created_keys_total                  | counter   |        | Total number of new keys the workload has introduced, each counted once when it is first created; some may never be committed (for example, when the transaction that creates the key aborts) |
+| loadgen_referenced_read_keys_total          | counter   |        | Total number of read-only accesses that reused an already-created key instead of introducing a new one                                                                                        |
+| loadgen_referenced_write_keys_total         | counter   |        | Total number of write accesses (read-write and blind-write) that reused an already-created key instead of introducing a new one                                                               |
 
 ---

--- a/loadgen/client.go
+++ b/loadgen/client.go
@@ -56,17 +56,16 @@ var logger = flogging.MustGetLogger("load-gen-client")
 func NewLoadGenClient(conf *ClientConfig) (*Client, error) {
 	logger.Debugf("Config passed: %s", &utils.LazyJSON{O: conf})
 
-	// The shared transaction-index counter is created before the stream: the stream's workers reserve
-	// their index ranges from it. It depends only on the transaction profile, not on the crypto
-	// artifacts below.
-	txCounter := workload.NewTxCounter()
+	// Created before both the metrics and the stream because both share it; it needs only the transaction
+	// profile, so it can be built ahead of the crypto artifacts below.
+	txCounter := workload.NewTxCounter(conf.LoadProfile.Transaction)
 	c := &Client{
 		conf: conf,
 		resources: adapters.ClientResources{
 			Profile: conf.LoadProfile,
 			Stream:  conf.Stream,
 			Limit:   conf.Limit,
-			Metrics: metrics.NewLoadgenServiceMetrics(&conf.Monitoring),
+			Metrics: metrics.NewLoadgenServiceMetrics(&conf.Monitoring, txCounter),
 		},
 		healthcheck: serve.DefaultHealthCheckService(),
 	}

--- a/loadgen/metrics/metrics.go
+++ b/loadgen/metrics/metrics.go
@@ -13,6 +13,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	promgo "github.com/prometheus/client_model/go"
 
+	"github.com/hyperledger/fabric-x-committer/loadgen/workload"
 	"github.com/hyperledger/fabric-x-committer/utils/monitoring"
 	"github.com/hyperledger/fabric-x-committer/utils/monitoring/promutil"
 )
@@ -31,6 +32,11 @@ type (
 		validLatency              prometheus.Histogram
 		invalidLatency            prometheus.Histogram
 
+		// Scrape-time counters read from the shared tx-index counter; no caller updates them.
+		createdKeysTotal         prometheus.CounterFunc
+		referencedReadKeysTotal  prometheus.CounterFunc
+		referencedWriteKeysTotal prometheus.CounterFunc
+
 		latencyTracker *latencyReceiverSender
 	}
 
@@ -42,6 +48,9 @@ type (
 		TransactionsReceived  uint64
 		TransactionsCommitted uint64
 		TransactionsAborted   uint64
+		CreatedKeys           uint64
+		ReferencedReadKeys    uint64
+		ReferencedWriteKeys   uint64
 	}
 
 	// TxStatus is used to report a batch item.
@@ -51,8 +60,9 @@ type (
 	}
 )
 
-// NewLoadgenServiceMetrics creates a new PerfMetrics instance.
-func NewLoadgenServiceMetrics(c *Config) *PerfMetrics {
+// NewLoadgenServiceMetrics creates a new PerfMetrics instance. The key-generation counters read from the
+// shared counter at scrape time via KeyStats.
+func NewLoadgenServiceMetrics(c *Config, counter *workload.TxCounter) *PerfMetrics {
 	p := monitoring.NewProvider()
 	latencyTracker := newLatencyReceiverSender(&c.Latency)
 	return &PerfMetrics{
@@ -100,6 +110,25 @@ func NewLoadgenServiceMetrics(c *Config) *PerfMetrics {
 			Help:      "Latency of invalid transactions in seconds",
 			Buckets:   latencyTracker.buckets,
 		}),
+		createdKeysTotal: p.NewCounterFunc(prometheus.CounterOpts{
+			Namespace: "loadgen",
+			Name:      "created_keys_total",
+			Help: "Total number of new keys the workload has introduced, each counted once when it is " +
+				"first created; some may never be committed (for example, when the transaction that " +
+				"creates the key aborts)",
+		}, func() float64 { return float64(counter.KeyStats().KeyFrontier) }),
+		referencedReadKeysTotal: p.NewCounterFunc(prometheus.CounterOpts{
+			Namespace: "loadgen",
+			Name:      "referenced_read_keys_total",
+			Help: "Total number of read-only accesses that reused an already-created key instead of " +
+				"introducing a new one",
+		}, func() float64 { return float64(counter.KeyStats().ReferencedReadKeys) }),
+		referencedWriteKeysTotal: p.NewCounterFunc(prometheus.CounterOpts{
+			Namespace: "loadgen",
+			Name:      "referenced_write_keys_total",
+			Help: "Total number of write accesses (read-write and blind-write) that reused an " +
+				"already-created key instead of introducing a new one",
+		}, func() float64 { return float64(counter.KeyStats().ReferencedWriteKeys) }),
 	}
 }
 
@@ -112,10 +141,15 @@ func (c *PerfMetrics) GetState() MetricState {
 		TransactionsReceived:  getCounterValue(c.transactionReceivedTotal),
 		TransactionsCommitted: getCounterValue(c.transactionCommittedTotal),
 		TransactionsAborted:   getCounterValue(c.transactionAbortedTotal),
+		CreatedKeys:           getCounterValue(c.createdKeysTotal),
+		ReferencedReadKeys:    getCounterValue(c.referencedReadKeysTotal),
+		ReferencedWriteKeys:   getCounterValue(c.referencedWriteKeysTotal),
 	}
 }
 
-func getCounterValue(c prometheus.Counter) uint64 {
+// getCounterValue reads a counter-typed metric's value. The parameter is prometheus.Metric so it accepts
+// both plain counters and CounterFuncs.
+func getCounterValue(c prometheus.Metric) uint64 {
 	gm := promgo.Metric{}
 	if err := c.Write(&gm); err != nil {
 		logger.Warnf("Failed reading counter value: %v", err)

--- a/loadgen/workload/stream_test.go
+++ b/loadgen/workload/stream_test.go
@@ -84,7 +84,7 @@ func BenchmarkGenTx(b *testing.B) {
 	flogging.ActivateSpec("fatal")
 	//nolint:thelper // false positive.
 	genericBench(b, func(b *testing.B, p *Profile) {
-		t, err := NewTxStream(p, defaultBenchStreamOptions(), NewTxCounter())
+		t, err := NewTxStream(p, defaultBenchStreamOptions(), NewTxCounter(p.Transaction))
 		require.NoError(b, err)
 
 		ctx := b.Context()
@@ -192,7 +192,7 @@ func testTxProfiles(t *testing.T) (profiles []*Profile) {
 
 func startTxGeneratorUnderTest(t *testing.T, profile *Profile, options *StreamOptions) *TxStream {
 	t.Helper()
-	g, err := NewTxStream(profile, options, NewTxCounter())
+	g, err := NewTxStream(profile, options, NewTxCounter(profile.Transaction))
 	require.NoError(t, err)
 	test.RunServiceForTest(t.Context(), t, g.Run, nil)
 	return g
@@ -202,7 +202,7 @@ func startTxGeneratorUnderTest(t *testing.T, profile *Profile, options *StreamOp
 // single-generator case for tests and benchmarks.
 func firstGen(tb testing.TB, p *Profile) *IndependentTxGenerator {
 	tb.Helper()
-	gens, err := newIndependentTxGenerators(p, NewTxCounter())
+	gens, err := newIndependentTxGenerators(p, NewTxCounter(p.Transaction))
 	require.NoError(tb, err)
 	require.NotEmpty(tb, gens)
 	return gens[0]
@@ -222,6 +222,80 @@ func TestGenValidTx(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestTxStreamKeyStats(t *testing.T) {
+	t.Parallel()
+	p := DefaultProfile(1)
+	p.Transaction.ReadOnlyCount = 1
+	p.Transaction.ReadWriteCount = 2
+	p.Transaction.BlindWriteCount = 1
+	p.Transaction.KeyBackrefRate = 2.5 // 2.5 backrefs / tx of 4 slots => 1.5 fresh keys / tx
+	p.Transaction.TxReferenceGap = 5
+	p.Transaction.KeyLookbackWindow = 100
+
+	counter := NewTxCounter(p.Transaction)
+	s, err := NewTxStream(p, defaultStreamOptions(), counter)
+	require.NoError(t, err)
+	require.Equal(t, KeyStats{}, counter.KeyStats(), "nothing generated yet")
+
+	const n = 100
+	s.gens[0].buildBatch(n) // advances the shared counter by n
+
+	w := uint64(p.Transaction.ReadWriteCount + p.Transaction.BlindWriteCount)
+	ro := uint64(p.Transaction.ReadOnlyCount)
+	require.Equal(t, KeyStats{
+		KeyFrontier:         150,       // floor(100*1.5)
+		ReferencedReadKeys:  n * ro,    // every read-only slot reuses a key
+		ReferencedWriteKeys: n*w - 150, // the write slots that didn't create reuse a key
+	}, counter.KeyStats())
+}
+
+// TestTxStreamKeyStatsAboveWriteCap covers a new-key rate above the write-slot count: the surplus new
+// keys fall on read-only slots, and the reference counts must not underflow.
+func TestTxStreamKeyStatsAboveWriteCap(t *testing.T) {
+	t.Parallel()
+	p := DefaultProfile(1)
+	p.Transaction.ReadOnlyCount = 2
+	p.Transaction.ReadWriteCount = 1
+	p.Transaction.BlindWriteCount = 1
+	p.Transaction.KeyBackrefRate = 1 // 1 backref / tx of 4 slots => 3 fresh keys / tx > 2 write slots
+	p.Transaction.TxReferenceGap = 0
+	p.Transaction.KeyLookbackWindow = 8
+	require.NoError(t, p.Transaction.Validate())
+
+	counter := NewTxCounter(p.Transaction)
+	s, err := NewTxStream(p, defaultStreamOptions(), counter)
+	require.NoError(t, err)
+	const n = 100
+	s.gens[0].buildBatch(n)
+	// 300 new keys but only N*W=200 write slots to create them; the surplus 100 fall on read-only slots,
+	// leaving 200-100=100 read-only slots reusing keys and none on the write slots.
+	require.Equal(t, KeyStats{
+		KeyFrontier:         300,
+		ReferencedReadKeys:  100,
+		ReferencedWriteKeys: 0,
+	}, counter.KeyStats())
+}
+
+// TestTxStreamKeyStatsHistorical covers the default backref rate of zero: every slot introduces a fresh
+// key, so there are no references and every slot counts as created (N*slotsPerTx).
+func TestTxStreamKeyStatsHistorical(t *testing.T) {
+	t.Parallel()
+	p := DefaultProfile(1)
+	p.Transaction.ReadOnlyCount = 1
+	p.Transaction.ReadWriteCount = 2
+	p.Transaction.BlindWriteCount = 1
+	// KeyBackrefRate defaults to 0 => every slot is a fresh key, no references.
+
+	counter := NewTxCounter(p.Transaction)
+	s, err := NewTxStream(p, defaultStreamOptions(), counter)
+	require.NoError(t, err)
+	const n = 100
+	s.gens[0].buildBatch(n)
+	w := uint64(p.Transaction.ReadWriteCount + p.Transaction.BlindWriteCount)
+	slotsPerTx := w + uint64(p.Transaction.ReadOnlyCount)
+	require.Equal(t, KeyStats{KeyFrontier: n * slotsPerTx}, counter.KeyStats())
 }
 
 func TestGenValidBlock(t *testing.T) {

--- a/loadgen/workload/test_export.go
+++ b/loadgen/workload/test_export.go
@@ -24,7 +24,7 @@ func GenerateTransactions(tb testing.TB, p *Profile, count int) []*servicepb.Loa
 		p = DefaultProfile(1)
 	}
 	p.Workers = 1
-	g, err := newIndependentTxGenerators(p, NewTxCounter())
+	g, err := newIndependentTxGenerators(p, NewTxCounter(p.Transaction))
 	require.NoError(tb, err)
 	require.Len(tb, g, 1)
 	require.Positive(tb, count)

--- a/loadgen/workload/tx_counter.go
+++ b/loadgen/workload/tx_counter.go
@@ -8,21 +8,48 @@ package workload
 
 import "sync/atomic"
 
-// TxCounter is the shared global transaction-index counter. Every worker generator reserves its
-// consecutive range of indices from this one counter (a single atomic increment per batch); sharing the
-// counter is what makes the generated multiset worker-count invariant (workers are pure parallelism). It
-// is created before the stream and shared with it.
+// TxCounter is the shared transaction-index counter. All workers draw their index ranges from this one
+// counter, which is what makes the generated transaction multiset independent of the worker count. It also
+// holds the profile so KeyStats can report the key-generation counts without reaching into the stream.
 type TxCounter struct {
+	profile TransactionProfile
 	counter atomic.Uint64
 }
 
 // NewTxCounter creates the shared transaction counter.
-func NewTxCounter() *TxCounter {
-	return &TxCounter{}
+func NewTxCounter(profile TransactionProfile) *TxCounter {
+	return &TxCounter{profile: profile}
 }
 
 // reserve reserves n consecutive transaction indices with a single atomic increment and returns the base
 // index of the reserved range: the caller owns [base, base+n).
 func (c *TxCounter) reserve(n uint64) uint64 {
 	return c.counter.Add(n) - n
+}
+
+// KeyStats is a cumulative, monotone snapshot of the workload's key-generation counts, so its fields can
+// back counter metrics directly.
+type KeyStats struct {
+	KeyFrontier         uint64 // keys introduced so far, including ones read or written but never committed
+	ReferencedReadKeys  uint64 // read-only slots that reused an existing key
+	ReferencedWriteKeys uint64 // write slots that reused an existing key
+}
+
+// KeyStats computes the current key-generation counts from the counter value.
+func (c *TxCounter) KeyStats() KeyStats {
+	p := c.profile
+	n := c.counter.Load()
+	w := uint64(p.ReadWriteCount) + uint64(p.BlindWriteCount)
+	slotsPerTx := w + uint64(p.ReadOnlyCount)
+	// Each tx introduces slotsPerTx - KeyBackrefRate new keys on average; the rest of its slots reuse keys.
+	newKeysRate := float64(slotsPerTx) - p.KeyBackrefRate
+	created := uint64(max(0, committedFrontier(n, newKeysRate)))
+	// New keys fill write slots first; any surplus falls on read-only slots. Clamping at n*w keeps the two
+	// reference counts below from underflowing when new keys outnumber the write slots.
+	writeCreates := min(n*w, created)
+	return KeyStats{
+		KeyFrontier:         created,
+		ReferencedReadKeys:  n*uint64(p.ReadOnlyCount) - (created - writeCreates),
+		ReferencedWriteKeys: n*w - writeCreates,
+	}
 }

--- a/loadgen/workload/tx_rand_test.go
+++ b/loadgen/workload/tx_rand_test.go
@@ -265,7 +265,7 @@ func TestGeneratorStreamWorkerCountInvariant(t *testing.T) {
 	idSet := func(workers uint32) map[string]struct{} {
 		p := DefaultProfile(workers)
 		p.Transaction.ReadWriteCount = 2
-		counter := NewTxCounter()
+		counter := NewTxCounter(p.Transaction)
 		gens, err := newIndependentTxGenerators(p, counter)
 		require.NoError(t, err)
 		ids := make(map[string]struct{}, total)

--- a/utils/monitoring/provider.go
+++ b/utils/monitoring/provider.go
@@ -79,6 +79,14 @@ func (p *Provider) NewCounterVec(opts prometheus.CounterOpts, labels []string) *
 	return cv
 }
 
+// NewCounterFunc registers a counter whose value is computed at scrape time by function. Use it for a
+// cumulative total derived from other state rather than incremented via Add.
+func (p *Provider) NewCounterFunc(opts prometheus.CounterOpts, function func() float64) prometheus.CounterFunc {
+	c := prometheus.NewCounterFunc(opts, function)
+	p.registry.MustRegister(c)
+	return c
+}
+
 // NewGauge creates a new prometheus gauge.
 func (p *Provider) NewGauge(opts prometheus.GaugeOpts) prometheus.Gauge {
 	g := prometheus.NewGauge(opts)


### PR DESCRIPTION
#### Type of change

- New feature

#### Description

- Expose the load generator's key-generation counts as scrape-time Prometheus counters, derived on demand from the shared transaction-index counter (no caller updates them):
  - `loadgen_created_keys_total` — committable keys introduced (the frontier C(N)).
  - `loadgen_referenced_read_keys_total` — existing (backward) read-only key references.
  - `loadgen_referenced_write_keys_total` — existing write-slot key references (read-write + blind-write).
- Add `TxCounter.KeyStats` (the source of the three totals), a `monitoring.Provider.NewCounterFunc` helper, and register the three counters in `NewLoadgenServiceMetrics`.
- Regenerate the metrics reference.

#### Additional details (Optional)

The three values are cumulative monotone totals, so they are counters rather than gauges, computed at scrape time from the counter via `CounterFunc` — no goroutine samples them and no caller increments them.

Split out of #718 to keep the workload-model change focused.

#### Related issues

- related to #678
- related to #671
