### PR TITLE
fix config_tx_id validation

### DIFF
--- a/docs/sidecar.md
+++ b/docs/sidecar.md
@@ -263,6 +263,8 @@ enum Status {
 }
 ```
 
+Config envelopes are exempt from the `MALFORMED_MISSING_TX_ID` filter: a CONFIG TX's outer envelope does not carry a TxID (it is created and signed by the consensus leader), and the orderer already validated the config. The sidecar applies it as-is, extracting the client's TxID from the `ConfigEnvelope.LastUpdate` field when needed for client notification.
+
 #### System namespace transaction forms
 
 The sidecar applies additional form checks for system namespaces before forwarding transactions to the coordinator.

--- a/service/sidecar/mapping.go
+++ b/service/sidecar/mapping.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hyperledger/fabric-x-committer/api/servicepb"
 	"github.com/hyperledger/fabric-x-committer/service/verifier/policy"
 	"github.com/hyperledger/fabric-x-committer/utils"
+	"github.com/hyperledger/fabric-x-committer/utils/retry"
 	"github.com/hyperledger/fabric-x-committer/utils/serialization"
 )
 
@@ -106,7 +107,8 @@ func mapBlock(block *common.Block, txIDToHeight *utils.SyncMap[string, servicepb
 		logger.Debugf("Mapping transaction [blk,tx] = [%d,%d]", blockNumber, msgIndex)
 		err := mappedBlock.mapMessage(uint32(msgIndex), msg) //nolint:gosec // int -> uint32.
 		if err != nil {
-			// This can never occur unless there is a bug in the relay.
+			// This can never occur unless there is a bug in the relay or a
+			// mapping error which indicates a bad block.
 			return nil, err
 		}
 	}
@@ -129,10 +131,17 @@ func (b *blockMappingResult) mapMessage(msgIndex uint32, msg []byte) error {
 	}
 	switch common.HeaderType(envLite.HeaderType) {
 	case common.HeaderType_CONFIG:
-		// extracts configId from config.LastUpdate.TxId, which is the client's TxID.
-		ref.TxId = envLite.TxID
+		// TxID is extracted from the ConfigEnvelope.LastUpdate field.
+		ref.TxId = extractConfigTxID(envLite.Data)
 		if ref.TxId == "" {
-			ref.TxId = extractConfigTxID(envLite.Data)
+			return b.rejectNonDBStatusTx(ref, committerpb.Status_MALFORMED_MISSING_TX_ID, "no TX ID")
+		}
+		// We must validate the config TX here. If the mapping fails, it will be retried with a
+		// backoff error, which restarts the block source feed from one block before and
+		// tries again, finally failing if the parsing keeps failing.
+		if err := policy.ValidateConfigTx(msg); err != nil {
+			return errors.Join(retry.ErrBackOff,
+				fmt.Errorf("invalid config TX [%s]: %w", ref.TxId, err))
 		}
 		b.isConfig = true
 		return b.appendTx(ref, configTx(msg))
@@ -288,10 +297,12 @@ func debugTx(ref *committerpb.TxRef, format string, a ...any) {
 func extractConfigTxID(value []byte) string {
 	configEnv, err := protoutil.UnmarshalConfigEnvelope(value)
 	if err != nil {
+		logger.Warnf("Failed to unmarshal config envelope: %v", err)
 		return ""
 	}
 	chdr, err := protoutil.ChannelHeader(configEnv.LastUpdate)
 	if err != nil {
+		logger.Warnf("Failed to extract channel header from config envelope: %v", err)
 		return ""
 	}
 	return chdr.TxId

--- a/service/sidecar/mapping.go
+++ b/service/sidecar/mapping.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hyperledger/fabric-protos-go-apiv2/common"
 	"github.com/hyperledger/fabric-x-common/api/applicationpb"
 	"github.com/hyperledger/fabric-x-common/api/committerpb"
+	"github.com/hyperledger/fabric-x-common/protoutil"
 	"go.uber.org/zap/zapcore"
 
 	"github.com/hyperledger/fabric-x-committer/api/servicepb"
@@ -126,19 +127,20 @@ func (b *blockMappingResult) mapMessage(msgIndex uint32, msg []byte) error {
 	if envErr != nil {
 		return b.rejectNonDBStatusTx(ref, committerpb.Status_MALFORMED_BAD_ENVELOPE, envErr.Error())
 	}
-	if envLite.TxID == "" || !utf8.ValidString(envLite.TxID) {
-		return b.rejectNonDBStatusTx(ref, committerpb.Status_MALFORMED_MISSING_TX_ID, "no TX ID")
-	}
-	ref.TxId = envLite.TxID
-
 	switch common.HeaderType(envLite.HeaderType) {
 	case common.HeaderType_CONFIG:
-		if err := policy.ValidateConfigTx(msg); err != nil {
-			return b.rejectTx(ref, committerpb.Status_MALFORMED_CONFIG_TX_INVALID, err.Error())
+		// extracts configId from config.LastUpdate.TxId, which is the client's TxID.
+		ref.TxId = envLite.TxID
+		if ref.TxId == "" {
+			ref.TxId = extractConfigTxID(envLite.Data)
 		}
 		b.isConfig = true
 		return b.appendTx(ref, configTx(msg))
 	case common.HeaderType_MESSAGE:
+		if envLite.TxID == "" || !utf8.ValidString(envLite.TxID) {
+			return b.rejectNonDBStatusTx(ref, committerpb.Status_MALFORMED_MISSING_TX_ID, "no TX ID")
+		}
+		ref.TxId = envLite.TxID
 		tx, err := serialization.UnmarshalTx(envLite.Data)
 		if err != nil {
 			return b.rejectTx(ref, committerpb.Status_MALFORMED_BAD_ENVELOPE_PAYLOAD, err.Error())
@@ -279,6 +281,20 @@ func debugTx(ref *committerpb.TxRef, format string, a ...any) {
 		txID = ref.TxId
 	}
 	logger.Debugf("ID [%s]: %s", txID, fmt.Sprintf(format, a...))
+}
+
+// extractConfigTxID returns the client's TxID from a config envelope. The outer envelope of a
+// config TX carries no TxID (it is created and signed by the consensus leader).
+func extractConfigTxID(value []byte) string {
+	configEnv, err := protoutil.UnmarshalConfigEnvelope(value)
+	if err != nil {
+		return ""
+	}
+	chdr, err := protoutil.ChannelHeader(configEnv.LastUpdate)
+	if err != nil {
+		return ""
+	}
+	return chdr.TxId
 }
 
 func configTx(value []byte) *applicationpb.Tx {

--- a/service/sidecar/mapping_test.go
+++ b/service/sidecar/mapping_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hyperledger/fabric-x-committer/api/servicepb"
 	"github.com/hyperledger/fabric-x-committer/loadgen/workload"
 	"github.com/hyperledger/fabric-x-committer/utils"
+	"github.com/hyperledger/fabric-x-committer/utils/retry"
 	"github.com/hyperledger/fabric-x-committer/utils/test"
 )
 
@@ -111,28 +112,52 @@ func TestBlockMapping(t *testing.T) {
 	require.Equal(t, int32(expectedBlockSize), mappedBlock.withStatus.pendingCount.Load())
 }
 
-func TestConfigTxMapping(t *testing.T) {
-	t.Parallel()
+// configEnvelopeForTest returns a CONFIG envelope wrapping the given ConfigEnvelope, with an
+// outer channel header that carries no TxID (the outer envelope of a CONFIG TX is created and
+// signed by the consensus leader, so its TxID must not be used).
+func configEnvelopeForTest(t *testing.T, configEnv *common.ConfigEnvelope) []byte {
+	t.Helper()
+	outerChdr := protoutil.MakeChannelHeader(common.HeaderType_CONFIG, 1, testChannelID, 0)
+	outerSigHdr := protoutil.MakeSignatureHeader(nil, protoutil.CreateNonceOrPanic())
+	return protoutil.MarshalOrPanic(&common.Envelope{Payload: protoutil.MarshalOrPanic(&common.Payload{
+		Header: protoutil.MakePayloadHeader(outerChdr, outerSigHdr),
+		Data:   protoutil.MarshalOrPanic(configEnv),
+	})})
+}
 
-	const clientTxID = "client-config-txid"
+// lastUpdateForTest returns a CONFIG_UPDATE envelope carrying the given client TxID.
+func lastUpdateForTest(t *testing.T, clientTxID string) *common.Envelope {
+	t.Helper()
 	lastUpdateChdr := protoutil.MakeChannelHeader(common.HeaderType_CONFIG_UPDATE, 1, testChannelID, 0)
 	lastUpdateChdr.TxId = clientTxID
 	lastUpdateSigHdr := protoutil.MakeSignatureHeader(nil, protoutil.CreateNonceOrPanic())
-	lastUpdate := &common.Envelope{Payload: protoutil.MarshalOrPanic(&common.Payload{
+	return &common.Envelope{Payload: protoutil.MarshalOrPanic(&common.Payload{
 		Header: protoutil.MakePayloadHeader(lastUpdateChdr, lastUpdateSigHdr),
 		Data:   []byte("config-update"),
 	})}
+}
 
-	outerChdr := protoutil.MakeChannelHeader(common.HeaderType_CONFIG, 1, testChannelID, 0)
-	outerSigHdr := protoutil.MakeSignatureHeader(nil, protoutil.CreateNonceOrPanic())
-	outerEnv := &common.Envelope{Payload: protoutil.MarshalOrPanic(&common.Payload{
-		Header: protoutil.MakePayloadHeader(outerChdr, outerSigHdr),
-		Data:   protoutil.MarshalOrPanic(&common.ConfigEnvelope{LastUpdate: lastUpdate}),
-	})}
+func TestConfigTxMapping(t *testing.T) {
+	t.Parallel()
+
+	const clientTxID = "some-client-config-txid-2027-12-01"
+
+	// The config TX must pass policy.ValidateConfigTx, so we build the envelope on top of
+	// a real, valid config block. The outer envelope of a CONFIG TX carries no TxID (it is
+	// created and signed by the consensus leader); the client's TxID is extracted from the
+	// ConfigEnvelope.LastUpdate field when needed for client notification.
+	configBlock := createConfigBlockForTest(t)
+	env, err := protoutil.UnmarshalEnvelope(configBlock.Data.Data[0])
+	require.NoError(t, err)
+	payload, err := protoutil.UnmarshalPayload(env.Payload)
+	require.NoError(t, err)
+	configEnv, err := protoutil.UnmarshalConfigEnvelope(payload.Data)
+	require.NoError(t, err)
+	configEnv.LastUpdate = lastUpdateForTest(t, clientTxID)
 
 	block := &common.Block{
-		Header: &common.BlockHeader{Number: 0},
-		Data:   &common.BlockData{Data: [][]byte{protoutil.MarshalOrPanic(outerEnv)}},
+		Header: &common.BlockHeader{Number: 1},
+		Data:   &common.BlockData{Data: [][]byte{configEnvelopeForTest(t, configEnv)}},
 	}
 
 	var txIDToHeight utils.SyncMap[string, servicepb.Height]
@@ -144,6 +169,58 @@ func TestConfigTxMapping(t *testing.T) {
 	require.Equal(t, clientTxID, mappedBlock.block.Txs[0].Ref.TxId)
 	require.Equal(t, committerpb.ConfigNamespaceID, mappedBlock.block.Txs[0].Content.Namespaces[0].NsId)
 	require.Equal(t, []byte(committerpb.ConfigKey), mappedBlock.block.Txs[0].Content.Namespaces[0].BlindWrites[0].Key)
+}
+
+// TestConfigTxMappingMissingTxID verifies that a CONFIG TX from which no client TxID can be
+// extracted is rejected with MALFORMED_MISSING_TX_ID (a non-DB status)
+func TestConfigTxMappingMissingTxID(t *testing.T) {
+	t.Parallel()
+
+	// A config envelope whose LastUpdate carries no TxID, so no client TxID can be extracted.
+	configBlock := createConfigBlockForTest(t)
+	env, err := protoutil.UnmarshalEnvelope(configBlock.Data.Data[0])
+	require.NoError(t, err)
+	payload, err := protoutil.UnmarshalPayload(env.Payload)
+	require.NoError(t, err)
+	configEnv, err := protoutil.UnmarshalConfigEnvelope(payload.Data)
+	require.NoError(t, err)
+	configEnv.LastUpdate = lastUpdateForTest(t, "")
+
+	block := &common.Block{
+		Header: &common.BlockHeader{Number: 1},
+		Data:   &common.BlockData{Data: [][]byte{configEnvelopeForTest(t, configEnv)}},
+	}
+
+	var txIDToHeight utils.SyncMap[string, servicepb.Height]
+	mappedBlock, err := mapBlock(block, &txIDToHeight)
+	require.NoError(t, err)
+	require.NotNil(t, mappedBlock)
+	require.False(t, mappedBlock.isConfig)
+	require.Empty(t, mappedBlock.block.Txs)
+	require.Len(t, mappedBlock.withStatus.txStatus, 1)
+	require.Equal(t, committerpb.Status_MALFORMED_MISSING_TX_ID, mappedBlock.withStatus.txStatus[0])
+}
+
+// TestConfigTxMappingInvalid verifies that a CONFIG TX that cannot be parsed into a valid
+// bundle fails the mapping with a backoff error, which restarts the block source feed from one
+// block before and tries again.
+func TestConfigTxMappingInvalid(t *testing.T) {
+	t.Parallel()
+
+	// The config envelope parses (so a client TxID is available from LastUpdate), but its
+	// Config is nil, which cannot be parsed into a valid bundle.
+	configEnv := &common.ConfigEnvelope{LastUpdate: lastUpdateForTest(t, "client-config-txid")}
+
+	block := &common.Block{
+		Header: &common.BlockHeader{Number: 1},
+		Data:   &common.BlockData{Data: [][]byte{configEnvelopeForTest(t, configEnv)}},
+	}
+
+	var txIDToHeight utils.SyncMap[string, servicepb.Height]
+	mappedBlock, err := mapBlock(block, &txIDToHeight)
+	require.Error(t, err)
+	require.Nil(t, mappedBlock)
+	require.ErrorIs(t, err, retry.ErrBackOff)
 }
 
 func TestSystemNamespaceFormValidation(t *testing.T) {

--- a/service/sidecar/mapping_test.go
+++ b/service/sidecar/mapping_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hyperledger/fabric-protos-go-apiv2/common"
 	"github.com/hyperledger/fabric-x-common/api/applicationpb"
 	"github.com/hyperledger/fabric-x-common/api/committerpb"
+	"github.com/hyperledger/fabric-x-common/protoutil"
 	"github.com/stretchr/testify/require"
 
 	"github.com/hyperledger/fabric-x-committer/api/servicepb"
@@ -108,6 +109,41 @@ func TestBlockMapping(t *testing.T) {
 	require.Len(t, mappedBlock.block.Rejected, expectedRejected)
 	//nolint:gosec // int -> int32
 	require.Equal(t, int32(expectedBlockSize), mappedBlock.withStatus.pendingCount.Load())
+}
+
+func TestConfigTxMapping(t *testing.T) {
+	t.Parallel()
+
+	const clientTxID = "client-config-txid"
+	lastUpdateChdr := protoutil.MakeChannelHeader(common.HeaderType_CONFIG_UPDATE, 1, testChannelID, 0)
+	lastUpdateChdr.TxId = clientTxID
+	lastUpdateSigHdr := protoutil.MakeSignatureHeader(nil, protoutil.CreateNonceOrPanic())
+	lastUpdate := &common.Envelope{Payload: protoutil.MarshalOrPanic(&common.Payload{
+		Header: protoutil.MakePayloadHeader(lastUpdateChdr, lastUpdateSigHdr),
+		Data:   []byte("config-update"),
+	})}
+
+	outerChdr := protoutil.MakeChannelHeader(common.HeaderType_CONFIG, 1, testChannelID, 0)
+	outerSigHdr := protoutil.MakeSignatureHeader(nil, protoutil.CreateNonceOrPanic())
+	outerEnv := &common.Envelope{Payload: protoutil.MarshalOrPanic(&common.Payload{
+		Header: protoutil.MakePayloadHeader(outerChdr, outerSigHdr),
+		Data:   protoutil.MarshalOrPanic(&common.ConfigEnvelope{LastUpdate: lastUpdate}),
+	})}
+
+	block := &common.Block{
+		Header: &common.BlockHeader{Number: 0},
+		Data:   &common.BlockData{Data: [][]byte{protoutil.MarshalOrPanic(outerEnv)}},
+	}
+
+	var txIDToHeight utils.SyncMap[string, servicepb.Height]
+	mappedBlock, err := mapBlock(block, &txIDToHeight)
+	require.NoError(t, err)
+	require.NotNil(t, mappedBlock)
+	require.True(t, mappedBlock.isConfig)
+	require.Len(t, mappedBlock.block.Txs, 1)
+	require.Equal(t, clientTxID, mappedBlock.block.Txs[0].Ref.TxId)
+	require.Equal(t, committerpb.ConfigNamespaceID, mappedBlock.block.Txs[0].Content.Namespaces[0].NsId)
+	require.Equal(t, []byte(committerpb.ConfigKey), mappedBlock.block.Txs[0].Content.Namespaces[0].BlindWrites[0].Key)
 }
 
 func TestSystemNamespaceFormValidation(t *testing.T) {

--- a/service/sidecar/relay.go
+++ b/service/sidecar/relay.go
@@ -141,7 +141,8 @@ func (r *relay) preProcessBlock(
 		start := time.Now()
 		mappedBlock, err := mapBlock(block, &r.txIDToHeight)
 		if err != nil {
-			// This can never occur unless there is a bug in the relay.
+			// This can never occur unless there is a bug in the relay or a
+			// mapping error which indicates a bad block.
 			return err
 		}
 		promutil.Observe(r.metrics.blockMappingInRelaySeconds, time.Since(start))

--- a/service/sidecar/sidecar.go
+++ b/service/sidecar/sidecar.go
@@ -402,7 +402,8 @@ func appendMissingBlock(
 	var txIDToHeight utils.SyncMap[string, servicepb.Height]
 	mappedBlock, err := mapBlock(blk, &txIDToHeight)
 	if err != nil {
-		// This can never occur unless there is a bug in the relay.
+		// This can never occur unless there is a bug in the relay or a
+		// mapping error which indicates a bad block.
 		return err
 	}
 


### PR DESCRIPTION
#### Type of change
- Bug fix
 
#### Description

- no TxID check for CONFIG case, moved to MESSAGE case only. As config TX don't have outer TxID in channel header.
- CONFIG case no longer runs policy validation as it is already done by the orderer.
- add txID from config.LastUpdate to TxRef for notification.
- Updated tests for `service/sidecar/mapping_test.go`
- Docs update.

#### Related issues

Fixes issue: https://github.com/hyperledger/fabric-x-committer/issues/752
