### PR TITLE
feat: add support to import genesis datafile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ venv
 site/
 graphify-out/
 docs/superpowers/
+/committer

--- a/cmd/committer/main.go
+++ b/cmd/committer/main.go
@@ -7,12 +7,14 @@ SPDX-License-Identifier: Apache-2.0
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
 
 	"github.com/hyperledger/fabric-x-committer/cmd/cliutil"
+	"github.com/hyperledger/fabric-x-committer/service/vc"
 )
 
 func main() {
@@ -25,13 +27,102 @@ func main() {
 }
 
 func committerCMD() *cobra.Command {
+	var snapshotPath, activationPath, verificationPath, configPath string
 	cmd := &cobra.Command{
 		Use:   cliutil.CommitterName,
 		Short: fmt.Sprintf("Fabric-X %s.", cliutil.CommitterName),
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			operations := 0
+			for _, path := range []string{snapshotPath, activationPath, verificationPath} {
+				if path != "" {
+					operations++
+				}
+			}
+			if operations > 1 {
+				return fmt.Errorf("--init-from-snapshot, --activate-migration, and --verify-migration are mutually exclusive")
+			}
+			switch {
+			case snapshotPath != "":
+				return initFromSnapshot(cmd.Context(), cmd, configPath, snapshotPath)
+			case activationPath != "":
+				return activateMigration(cmd.Context(), cmd, configPath, activationPath)
+			case verificationPath != "":
+				return verifyMigration(cmd.Context(), cmd, configPath, verificationPath)
+			default:
+				return cmd.Help()
+			}
+		},
 	}
+	cmd.Flags().StringVar(&snapshotPath, "init-from-snapshot", "", "initialize VC state from a genesis-data file")
+	cmd.Flags().StringVar(&activationPath, "activate-migration", "", "activate an already verified genesis-data migration")
+	cmd.Flags().StringVar(&verificationPath, "verify-migration", "", "compare a genesis-data migration with live VC state")
+	cmd.Flags().StringVarP(&configPath, "config", "c", "", "set the validator-committer config file path")
 	cmd.AddCommand(cliutil.VersionCmd())
 	cmd.AddCommand(startCMD())
 	cmd.AddCommand(healthcheckCMD())
 	cmd.AddCommand(databaseInitializationCMD())
 	return cmd
+}
+
+func verifyMigration(ctx context.Context, cmd *cobra.Command, configPath, snapshotPath string) error {
+	conf, _, err := readConfig(vcService, configPath)
+	if err != nil {
+		return err
+	}
+	result, err := vc.VerifySnapshot(ctx, conf.(*vc.Config), snapshotPath)
+	if err != nil {
+		return err
+	}
+	cmd.Printf("Migration ID: %s\n", result.MigrationID)
+	cmd.Printf("Migration status: %s\n", result.MigrationStatus)
+	cmd.Printf("Source: channel %s block %d\n", result.SourceChannel, result.SourceBlockNumber)
+	cmd.Printf("Target anchor: %d\n", result.TargetAnchor)
+	cmd.Printf("Target configuration SHA-256: %s\n", result.TargetConfigSHA256)
+	cmd.Printf("Namespace map SHA-256: %s\n", result.NamespaceMapSHA256)
+	cmd.Printf("Target policies SHA-256: %s\n", result.TargetPolicySHA256)
+	cmd.Printf("Public state: %d records SHA-256 %s\n", result.PublicStateCount, result.PublicStateSHA256)
+	cmd.Printf("Transaction IDs: %d records SHA-256 %s\n", result.TransactionIDCount, result.TransactionIDSHA256)
+	cmd.Println("Integrity: verified")
+	return nil
+}
+
+func activateMigration(ctx context.Context, cmd *cobra.Command, configPath, snapshotPath string) error {
+	conf, _, err := readConfig(vcService, configPath)
+	if err != nil {
+		return err
+	}
+	result, err := vc.ActivateSnapshot(ctx, conf.(*vc.Config), snapshotPath)
+	if err != nil {
+		return err
+	}
+	cmd.Printf("Migration ID: %s\n", result.MigrationID)
+	cmd.Printf("Target anchor: %d\n", result.TargetAnchor)
+	if result.AlreadyActive {
+		cmd.Println("Status: already active")
+	} else {
+		cmd.Println("Status: active")
+	}
+	return nil
+}
+
+func initFromSnapshot(ctx context.Context, cmd *cobra.Command, configPath, snapshotPath string) error {
+	conf, _, err := readConfig(vcService, configPath)
+	if err != nil {
+		return err
+	}
+	result, err := vc.InitFromSnapshot(ctx, conf.(*vc.Config), snapshotPath)
+	if err != nil {
+		return err
+	}
+	cmd.Printf("Migration ID: %s\n", result.MigrationID)
+	cmd.Printf("Source: channel %s block %d\n", result.SourceChannel, result.SourceBlockNumber)
+	cmd.Printf("Target anchor: %d\n", result.TargetAnchor)
+	cmd.Printf("Imported: %d public records, %d transaction IDs\n", result.PublicStateCount, result.TransactionIDs)
+	if result.AlreadyImported {
+		cmd.Println("Status: already verified")
+	} else {
+		cmd.Println("Status: verified")
+	}
+	return nil
 }

--- a/cmd/committer/start_cmd_test.go
+++ b/cmd/committer/start_cmd_test.go
@@ -39,19 +39,29 @@ func TestCommitterCMD(t *testing.T) {
 	}
 	commonTests := []cliutil.CommandTest{
 		{
-			Name:         "print version",
+			Name:         "when version is requested, it prints the version",
 			Args:         []string{"version"},
 			CmdStdOutput: cliutil.FullCommitterVersion(),
 		},
 		{
-			Name: "trailing flag args for version",
+			Name: "when version has an unknown flag, it rejects the flag",
 			Args: []string{"version", "--test"},
 			Err:  errors.New("unknown flag: --test"),
 		},
 		{
-			Name: "trailing command args for version",
+			Name: "when version has a trailing command, it rejects the command",
 			Args: []string{"version", "test"},
 			Err:  fmt.Errorf(`unknown command "test" for "%v version"`, cliutil.CommitterName),
+		},
+		{
+			Name: "when migration operations are combined, it rejects the command",
+			Args: []string{"--init-from-snapshot", "snapshot.fxgenesis", "--activate-migration", "snapshot.fxgenesis"},
+			Err:  errors.New("--init-from-snapshot, --activate-migration, and --verify-migration are mutually exclusive"),
+		},
+		{
+			Name: "when a migration operation is combined with a subcommand, it rejects the command",
+			Args: []string{"--init-from-snapshot", "snapshot.fxgenesis", "version"},
+			Err:  errors.New("unknown flag: --init-from-snapshot"),
 		},
 	}
 	for _, test := range commonTests {
@@ -75,10 +85,10 @@ func TestCommitterCMD(t *testing.T) {
 		{Cmd: []string{"start", verifierService}, Name: serviceNames[verifierService], Templ: config.TemplateVerifier},
 		{Cmd: []string{"start", queryService}, Name: serviceNames[queryService], Templ: config.TemplateQueryService},
 	} {
-		t.Run(serviceCase.Name, func(t *testing.T) {
+		t.Run("when starting "+serviceCase.Name+", it serves the component", func(t *testing.T) {
 			cases := []cliutil.CommandTest{
 				{
-					Name:              "start",
+					Name:              "when configuration is valid, it starts the service",
 					Args:              serviceCase.Cmd,
 					CmdLoggerOutputs:  []string{"Serving", s.ThisService.GrpcEndpoint.String()},
 					CmdStdOutput:      fmt.Sprintf("Starting %v", serviceCase.Name),

--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
+	github.com/syndbg/fabric-x-migrate-poc v0.0.0
 	github.com/yugabyte/pgx/v5 v5.7.6-yb-1
 	go.uber.org/mock v0.6.0
 	go.uber.org/zap v1.28.0
@@ -43,6 +44,10 @@ require (
 	google.golang.org/grpc v1.82.0
 	google.golang.org/protobuf v1.36.11
 )
+
+// TODO: replace this local PoC module with the accepted schema package in
+// github.com/hyperledger/fabric-x-common before merge.
+replace github.com/syndbg/fabric-x-migrate-poc => ../fabric-x-migrate-poc
 
 tool (
 	github.com/Kunde21/markdownfmt/v3/cmd/markdownfmt

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/viper v1.21.0
 	github.com/stretchr/testify v1.11.1
-	github.com/syndbg/fabric-x-migrate-poc v0.0.0
+	github.com/syndbg/fabric-x-migrate-poc v0.0.0-20260809225224-81fc4c1a969c // TODO: move the accepted schema package to fabric-x-common before merge.
 	github.com/yugabyte/pgx/v5 v5.7.6-yb-1
 	go.uber.org/mock v0.6.0
 	go.uber.org/zap v1.28.0
@@ -44,10 +44,6 @@ require (
 	google.golang.org/grpc v1.82.0
 	google.golang.org/protobuf v1.36.11
 )
-
-// TODO: replace this local PoC module with the accepted schema package in
-// github.com/hyperledger/fabric-x-common before merge.
-replace github.com/syndbg/fabric-x-migrate-poc => ../fabric-x-migrate-poc
 
 tool (
 	github.com/Kunde21/markdownfmt/v3/cmd/markdownfmt

--- a/go.sum
+++ b/go.sum
@@ -348,6 +348,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
+github.com/syndbg/fabric-x-migrate-poc v0.0.0-20260809225224-81fc4c1a969c h1:Dk7b8SufVRheEY4+U7RbXkcwrdnq4S5p7mfFjqBR3gc=
+github.com/syndbg/fabric-x-migrate-poc v0.0.0-20260809225224-81fc4c1a969c/go.mod h1:jr54+P7oKyuIjYWOlXd90nbUZYliEo4iAYZQ8bWrmIc=
 github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d h1:vfofYNRScrDdvS342BElfbETmL1Aiz3i2t0zfRj16Hs=
 github.com/syndtr/goleveldb v1.0.1-0.20220721030215-126854af5e6d/go.mod h1:RRCYJbIwD5jmqPI9XoAFR0OcDxqUctll6zUj/+B4S48=
 github.com/tailscale/depaware v0.0.0-20210622194025-720c4b409502/go.mod h1:p9lPsd+cx33L3H9nNoecRRxPssFKUwwI50I3pZ0yT+8=

--- a/integration/migration/fabric_network_test.go
+++ b/integration/migration/fabric_network_test.go
@@ -1,0 +1,315 @@
+//go:build integration
+
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package migration_test
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+const fabricSourceVersion = "3.1.5"
+
+func captureFabricSnapshots(t *testing.T, repository, stateDB string, channels ...string) map[string]string {
+	t.Helper()
+	return newFabricNetwork(t, repository, stateDB).capture(channels...)
+}
+
+type fabricNetwork struct {
+	t       *testing.T
+	root    string
+	home    string
+	samples string
+	version string
+	stateDB string
+}
+
+func newFabricNetwork(t *testing.T, repository, stateDB string) *fabricNetwork {
+	t.Helper()
+	root := t.TempDir()
+	home := os.Getenv("FABRIC_SOURCE_HOME")
+	if home == "" {
+		home = filepath.Join(repository, ".cache", "fabric", fabricSourceVersion)
+	}
+	ensureFabricRelease(t, home, fabricSourceVersion)
+	samples := ensureFabricSamples(t, repository)
+	_, sourceFile, _, ok := runtime.Caller(0)
+	require.True(t, ok)
+	setup := filepath.Join(filepath.Dir(sourceFile), "testdata")
+	for _, name := range []string{"compose.yaml", "configtx.yaml", "crypto-config.yaml", "collections.json"} {
+		content, err := os.ReadFile(filepath.Join(setup, name))
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(filepath.Join(root, name), content, 0o600))
+	}
+	fabric := &fabricNetwork{t: t, root: root, home: home, samples: samples, version: fabricSourceVersion, stateDB: stateDB}
+	fabric.run(fabric.bin("cryptogen"), "generate", "--config="+filepath.Join(root, "crypto-config.yaml"), "--output="+fabric.crypto())
+	t.Cleanup(func() { fabric.compose("down", "--volumes", "--remove-orphans") })
+	return fabric
+}
+
+func (f *fabricNetwork) capture(channels ...string) map[string]string {
+	f.t.Helper()
+	for _, channel := range channels {
+		command := f.command(f.bin("configtxgen"), "-profile", "MigrationChannel", "-channelID", channel, "-outputBlock", filepath.Join(f.root, channel+".block"))
+		command.Env = append(command.Env, "FABRIC_CFG_PATH="+f.root)
+		f.runCommand(command)
+	}
+	f.compose("up", "-d")
+	require.Eventually(f.t, func() bool {
+		return f.peerCommand("channel", "list").Run() == nil
+	}, time.Minute, time.Second)
+
+	for _, channel := range channels {
+		f.joinChannel(channel)
+	}
+	f.deploy(channels)
+
+	snapshots := make(map[string]string, len(channels))
+	for _, channel := range channels {
+		snapshots[channel] = f.snapshot(channel)
+	}
+	return snapshots
+}
+
+func (f *fabricNetwork) joinChannel(channel string) {
+	f.t.Helper()
+	admin := []string{
+		"-o", "localhost:18053",
+		"--ca-file", f.ordererCA(),
+		"--client-cert", f.crypto("ordererOrganizations", "example.com", "orderers", "orderer.example.com", "tls", "server.crt"),
+		"--client-key", f.crypto("ordererOrganizations", "example.com", "orderers", "orderer.example.com", "tls", "server.key"),
+	}
+	f.run(f.bin("osnadmin"), append([]string{"channel", "join", "--channelID", channel, "--config-block", filepath.Join(f.root, channel+".block")}, admin...)...)
+	f.runPeer("channel", "join", "-b", filepath.Join(f.root, channel+".block"))
+	require.Eventually(f.t, func() bool {
+		args := append([]string{"channel", "fetch", "newest", filepath.Join(f.root, channel+"-newest.block"), "-c", channel}, f.ordererArgs()...)
+		return f.peerCommand(args...).Run() == nil
+	}, time.Minute, time.Second)
+}
+
+func (f *fabricNetwork) deploy(channels []string) {
+	f.t.Helper()
+	chaincodes := []struct {
+		name        string
+		path        string
+		collections string
+		packageID   string
+	}{
+		{name: "basic", path: filepath.Join(f.samples, "asset-transfer-basic", "chaincode-go")},
+		{name: "private", path: filepath.Join(f.samples, "asset-transfer-private-data", "chaincode-go"), collections: filepath.Join(f.root, "collections.json")},
+	}
+	for i := range chaincodes {
+		packagePath := filepath.Join(f.root, chaincodes[i].name+".tar.gz")
+		label := chaincodes[i].name + "_1.0"
+		f.runPeer("lifecycle", "chaincode", "package", packagePath, "--path", chaincodes[i].path, "--lang", "golang", "--label", label)
+		chaincodes[i].packageID = strings.TrimSpace(f.peerOutput("lifecycle", "chaincode", "calculatepackageid", packagePath))
+		f.runPeer("lifecycle", "chaincode", "install", packagePath)
+	}
+	for _, channel := range channels {
+		for _, chaincode := range chaincodes {
+			approve := append([]string{"lifecycle", "chaincode", "approveformyorg"}, f.ordererArgs()...)
+			approve = append(approve, "--channelID", channel, "--name", chaincode.name, "--version", "1.0", "--package-id", chaincode.packageID, "--sequence", "1")
+			commit := append([]string{"lifecycle", "chaincode", "commit"}, f.ordererArgs()...)
+			commit = append(commit, "--channelID", channel, "--name", chaincode.name, "--version", "1.0", "--sequence", "1", "--peerAddresses", "localhost:18051", "--tlsRootCertFiles", f.peerCA())
+			if chaincode.collections != "" {
+				approve = append(approve, "--collections-config", chaincode.collections)
+				commit = append(commit, "--collections-config", chaincode.collections)
+			}
+			f.runPeer(approve...)
+			f.runPeer(commit...)
+		}
+		invoke := append([]string{"chaincode", "invoke"}, f.ordererArgs()...)
+		f.runPeer(append(invoke, "-C", channel, "-n", "basic", "--peerAddresses", "localhost:18051", "--tlsRootCertFiles", f.peerCA(), "--waitForEvent", "-c", `{"function":"InitLedger","Args":[]}`)...)
+		asset := base64.StdEncoding.EncodeToString([]byte(`{"objectType":"asset","assetID":"asset-private-1","color":"blue","size":5,"appraisedValue":100}`))
+		f.runPeer(append(invoke, "-C", channel, "-n", "private", "--peerAddresses", "localhost:18051", "--tlsRootCertFiles", f.peerCA(), "--waitForEvent", "--transient", fmt.Sprintf(`{"asset_properties":"%s"}`, asset), "-c", `{"function":"CreateAsset","Args":[]}`)...)
+	}
+}
+
+func ensureFabricSamples(t *testing.T, repository string) string {
+	t.Helper()
+	commitBytes, err := os.ReadFile(filepath.Join(repository, "fabric-samples.commit"))
+	require.NoError(t, err)
+	commit := strings.TrimSpace(string(commitBytes))
+	require.NotEmpty(t, commit)
+	destination := filepath.Join(repository, ".cache", "fabric-samples", commit)
+	if output, err := exec.Command("git", "-C", destination, "rev-parse", "HEAD").Output(); err == nil {
+		require.Equal(t, commit, strings.TrimSpace(string(output)))
+		return destination
+	}
+	require.NoError(t, os.MkdirAll(filepath.Dir(destination), 0o700))
+	command := exec.Command("git", "clone", "--filter=blob:none", "--no-checkout", "https://github.com/hyperledger/fabric-samples.git", destination)
+	output, err := command.CombinedOutput()
+	require.NoError(t, err, "%s", output)
+	command = exec.Command("git", "-C", destination, "fetch", "--depth=1", "origin", commit)
+	output, err = command.CombinedOutput()
+	require.NoError(t, err, "%s", output)
+	command = exec.Command("git", "-C", destination, "checkout", "--detach", commit)
+	output, err = command.CombinedOutput()
+	require.NoError(t, err, "%s", output)
+	return destination
+}
+
+func (f *fabricNetwork) snapshot(channel string) string {
+	f.t.Helper()
+	output := f.peerOutput("channel", "getinfo", "-c", channel)
+	start := strings.LastIndex(output, "Blockchain info: ")
+	require.NotEqual(f.t, -1, start, output)
+	var info struct {
+		Height uint64 `json:"height"`
+	}
+	require.NoError(f.t, json.Unmarshal([]byte(strings.TrimSpace(output[start+len("Blockchain info: "):])), &info))
+	require.NotZero(f.t, info.Height)
+	block := strconv.FormatUint(info.Height-1, 10)
+	remote := "/var/hyperledger/production/snapshots/completed/" + channel + "/" + block
+	f.runPeer("snapshot", "submitrequest", "-c", channel, "-b", "0", "--peerAddress", "localhost:18051", "--tlsRootCertFile", f.peerCA())
+	require.Eventually(f.t, func() bool {
+		return f.composeCommand("exec", "-T", "peer", "test", "-f", remote+"/_snapshot_signable_metadata.json").Run() == nil
+	}, time.Minute, time.Second)
+	destination := filepath.Join(f.root, "snapshots", channel, "block-"+block)
+	require.NoError(f.t, os.MkdirAll(destination, 0o700))
+	f.compose("cp", "peer:"+remote+"/.", destination)
+	return destination
+}
+
+func (f *fabricNetwork) bin(name string) string { return filepath.Join(f.home, "bin", name) }
+func (f *fabricNetwork) crypto(parts ...string) string {
+	return filepath.Join(append([]string{f.root, "crypto"}, parts...)...)
+}
+func (f *fabricNetwork) peerCA() string {
+	return f.crypto("peerOrganizations", "org1.example.com", "tlsca", "tlsca.org1.example.com-cert.pem")
+}
+func (f *fabricNetwork) ordererCA() string {
+	return f.crypto("ordererOrganizations", "example.com", "tlsca", "tlsca.example.com-cert.pem")
+}
+func (f *fabricNetwork) ordererArgs() []string {
+	return []string{"--orderer", "localhost:18050", "--ordererTLSHostnameOverride", "orderer.example.com", "--tls", "--cafile", f.ordererCA()}
+}
+func (f *fabricNetwork) runPeer(args ...string) { f.runCommand(f.peerCommand(args...)) }
+func (f *fabricNetwork) peerOutput(args ...string) string {
+	return f.output(f.peerCommand(args...))
+}
+func (f *fabricNetwork) peerCommand(args ...string) *exec.Cmd {
+	command := f.command(f.bin("peer"), args...)
+	command.Env = append(command.Env,
+		"FABRIC_CFG_PATH="+filepath.Join(f.home, "config"),
+		"CORE_PEER_TLS_ENABLED=true",
+		"CORE_PEER_LOCALMSPID=Org1MSP",
+		"CORE_PEER_MSPCONFIGPATH="+f.crypto("peerOrganizations", "org1.example.com", "users", "Admin@org1.example.com", "msp"),
+		"CORE_PEER_ADDRESS=localhost:18051",
+		"CORE_PEER_TLS_ROOTCERT_FILE="+f.peerCA(),
+	)
+	return command
+}
+func (f *fabricNetwork) compose(args ...string) { f.runCommand(f.composeCommand(args...)) }
+func (f *fabricNetwork) composeCommand(args ...string) *exec.Cmd {
+	command := f.command("docker", append([]string{"compose", "-f", filepath.Join(f.root, "compose.yaml")}, args...)...)
+	command.Env = append(command.Env, "FABRIC_VERSION="+f.version, "STATE_DATABASE="+f.stateDB)
+	return command
+}
+func (f *fabricNetwork) run(name string, args ...string) { f.runCommand(f.command(name, args...)) }
+func (f *fabricNetwork) command(name string, args ...string) *exec.Cmd {
+	command := exec.Command(name, args...)
+	command.Dir = f.root
+	command.Env = os.Environ()
+	return command
+}
+func (f *fabricNetwork) runCommand(command *exec.Cmd) {
+	f.t.Helper()
+	output, err := command.CombinedOutput()
+	if err == nil {
+		return
+	}
+	logs, _ := f.composeCommand("logs", "peer", "couchdb").CombinedOutput()
+	require.NoError(f.t, err, "%s failed\n%s\n%s", command.String(), output, logs)
+}
+func (f *fabricNetwork) output(command *exec.Cmd) string {
+	f.t.Helper()
+	output, err := command.CombinedOutput()
+	require.NoError(f.t, err, "%s failed\n%s", command.String(), output)
+	return string(output)
+}
+
+func ensureFabricRelease(t *testing.T, destination, version string) {
+	t.Helper()
+	if _, err := os.Stat(filepath.Join(destination, "bin", "peer")); err == nil {
+		return
+	}
+	require.NoError(t, os.MkdirAll(filepath.Dir(destination), 0o700))
+	temporary := t.TempDir()
+	asset := fmt.Sprintf("hyperledger-fabric-%s-%s-%s.tar.gz", runtime.GOOS, runtime.GOARCH, version)
+	response, err := (&http.Client{Timeout: 5 * time.Minute}).Get("https://github.com/hyperledger/fabric/releases/download/v" + version + "/" + asset)
+	require.NoError(t, err)
+	defer response.Body.Close()
+	require.Equal(t, http.StatusOK, response.StatusCode)
+	require.NoError(t, extractFabricRelease(temporary, response.Body))
+	require.NoError(t, os.RemoveAll(destination))
+	require.NoError(t, os.Rename(temporary, destination))
+}
+
+func extractFabricRelease(destination string, source io.Reader) error {
+	gzipReader, err := gzip.NewReader(source)
+	if err != nil {
+		return err
+	}
+	defer gzipReader.Close()
+	archive := tar.NewReader(gzipReader)
+	for {
+		header, err := archive.Next()
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		name := filepath.Clean(header.Name)
+		if filepath.IsAbs(name) || name == ".." || strings.HasPrefix(name, ".."+string(filepath.Separator)) {
+			return fmt.Errorf("unsafe archive path %q", header.Name)
+		}
+		path := filepath.Join(destination, name)
+		switch header.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(path, os.FileMode(header.Mode)); err != nil {
+				return err
+			}
+		case tar.TypeReg:
+			if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+				return err
+			}
+			file, err := os.OpenFile(path, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, os.FileMode(header.Mode))
+			if err != nil {
+				return err
+			}
+			_, copyErr := io.Copy(file, archive)
+			closeErr := file.Close()
+			if copyErr != nil {
+				return copyErr
+			}
+			if closeErr != nil {
+				return closeErr
+			}
+		default:
+			return fmt.Errorf("unsupported archive entry %q", header.Name)
+		}
+	}
+}

--- a/integration/migration/freezecheck/main.go
+++ b/integration/migration/freezecheck/main.go
@@ -1,0 +1,67 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/types/known/emptypb"
+
+	"github.com/hyperledger/fabric-x-committer/api/servicepb"
+	"github.com/hyperledger/fabric-x-committer/utils/connection"
+)
+
+func main() {
+	if err := checkAnchor(os.Args[1:]); err != nil {
+		_, _ = fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func checkAnchor(args []string) error {
+	if len(args) != 2 {
+		return fmt.Errorf("usage: freezecheck <coordinator-endpoint> <next-block>")
+	}
+	expected, err := strconv.ParseUint(args[1], 10, 64)
+	if err != nil {
+		return fmt.Errorf("invalid next block: %w", err)
+	}
+	tlsCredentials, err := connection.NewClientTLSCredentials(connection.TLSConfig{
+		Mode:        connection.MutualTLSMode,
+		CertPath:    "/client-tls/server.crt",
+		KeyPath:     "/client-tls/server.key",
+		CACertPaths: []string{"/org-tls-ca.pem"},
+	})
+	if err != nil {
+		return err
+	}
+	transportCredentials, err := connection.NewClientGRPCTransportCredentials(tlsCredentials)
+	if err != nil {
+		return err
+	}
+	conn, err := grpc.NewClient(args[0], grpc.WithTransportCredentials(transportCredentials))
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+	next, err := servicepb.NewCoordinatorClient(conn).GetNextBlockNumberToCommit(ctx, &emptypb.Empty{}, grpc.WaitForReady(true))
+	if err != nil {
+		return err
+	}
+	if next.Number != expected {
+		return fmt.Errorf("coordinator expects block %d, want %d", next.Number, expected)
+	}
+	return nil
+}

--- a/integration/migration/migration_test.go
+++ b/integration/migration/migration_test.go
@@ -1,0 +1,689 @@
+//go:build integration
+
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package migration_test
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/hyperledger/fabric-protos-go-apiv2/common"
+	ab "github.com/hyperledger/fabric-protos-go-apiv2/orderer"
+	"github.com/hyperledger/fabric-x-common/api/applicationpb"
+	"github.com/hyperledger/fabric-x-common/api/committerpb"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/emptypb"
+
+	"github.com/hyperledger/fabric-x-committer/api/servicepb"
+	"github.com/hyperledger/fabric-x-committer/loadgen/workload"
+	"github.com/hyperledger/fabric-x-committer/utils/connection"
+	"github.com/hyperledger/fabric-x-committer/utils/ordererdial"
+
+	"github.com/syndbg/fabric-x-migrate-poc/pkg/genesisdata"
+)
+
+func TestInitFromSnapshot(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires Docker and the Fabric-X devnet")
+	}
+
+	_, sourceFile, _, _ := runtime.Caller(0)
+	committerRepo := filepath.Clean(filepath.Join(filepath.Dir(sourceFile), "..", ".."))
+	workspace := filepath.Dir(committerRepo)
+	devnet := filepath.Join(workspace, "fabric-x-samples", "devnet")
+	migrateRepo := filepath.Join(workspace, "fabric-x-migrate-poc")
+	labRepo := filepath.Join(workspace, "fabric-x-migration-lab")
+
+	committerBinary := filepath.Join(t.TempDir(), "committer")
+	build := exec.Command("go", "build", "-o", committerBinary, "./cmd/committer")
+	build.Dir = committerRepo
+	build.Env = append(os.Environ(), "CGO_ENABLED=0", "GOOS=linux", "GOARCH="+runtime.GOARCH)
+	runCommand(t, build)
+	replayBinary := filepath.Join(t.TempDir(), "replayblocks")
+	buildReplay := exec.Command("go", "build", "-o", replayBinary, "./integration/migration/replayblocks")
+	buildReplay.Dir = committerRepo
+	buildReplay.Env = append(os.Environ(), "CGO_ENABLED=0", "GOOS=linux", "GOARCH="+runtime.GOARCH)
+	runCommand(t, buildReplay)
+	freezeBinary := filepath.Join(t.TempDir(), "freezecheck")
+	buildFreeze := exec.Command("go", "build", "-o", freezeBinary, "./integration/migration/freezecheck")
+	buildFreeze.Dir = committerRepo
+	buildFreeze.Env = append(os.Environ(), "CGO_ENABLED=0", "GOOS=linux", "GOARCH="+runtime.GOARCH)
+	runCommand(t, buildFreeze)
+
+	if containerRunning(t, "orderer.example.com") {
+		run(t, "", "docker", "stop", "orderer.example.com")
+		t.Cleanup(func() { run(t, "", "docker", "start", "orderer.example.com") })
+	}
+	t.Cleanup(func() { run(t, devnet, "make", "purge") })
+
+	for _, version := range []string{"2.5.16", "3.1.5"} {
+		t.Run("when source is Fabric "+version+", it imports, activates, and updates migrated state", func(t *testing.T) {
+			snapshotPath := filepath.Join(labRepo, "artifacts", "snapshots", "fabric-"+version, "block-3")
+			exerciseMigration(t, devnet, migrateRepo, committerBinary, freezeBinary, snapshotPath, version, "migration", "migration_basic")
+		})
+	}
+
+	t.Run("when source is Fabric 3.1.5 with CouchDB, it completes the full migration", func(t *testing.T) {
+		snapshotPath := captureFabricSnapshots(t, migrateRepo, "CouchDB", "couchdb")["couchdb"]
+		exerciseMigration(t, devnet, migrateRepo, committerBinary, freezeBinary, snapshotPath, fabricSourceVersion, "couchdb", "couchdb_basic")
+	})
+
+	t.Run("when two channels map to separate networks, it imports both snapshots", func(t *testing.T) {
+		source := filepath.Join(labRepo, "artifacts", "snapshots", "fabric-3.1.5", "block-3")
+		migrationIDs := make([]string, 0, 2)
+		for _, channel := range []string{"payments", "securities"} {
+			t.Run("when source channel is "+channel+", it imports and updates state in a fresh network", func(t *testing.T) {
+				snapshotPath := cloneSnapshotWithChannel(t, source, channel)
+				migrationIDs = append(migrationIDs, exerciseMigration(t, devnet, migrateRepo, committerBinary, freezeBinary, snapshotPath, "3.1.5", channel, channel+"_basic"))
+			})
+		}
+		require.Len(t, migrationIDs, 2)
+		assert.NotEqual(t, migrationIDs[0], migrationIDs[1], "source channels must produce distinct migrations")
+	})
+
+	t.Run("when two committer organizations migrate the same network, it activates and commits on both", func(t *testing.T) {
+		run(t, devnet, "make", "purge")
+		t.Cleanup(func() { run(t, devnet, "make", "purge") })
+		run(t, devnet, "make", "init")
+		run(t, devnet, "make", "start-both")
+		run(t, devnet, "make", "init-namespace-org1", "NS=multi_org_basic")
+
+		snapshotPath := filepath.Join(labRepo, "artifacts", "snapshots", "fabric-3.1.5", "block-3")
+		bundlePath, bundle := exportBundle(t, migrateRepo, snapshotPath, "3.1.5", "basic", "multi_org_basic")
+		anchorHex, anchor := targetAnchor(t, devnet, "committer-db", "multi_org_basic")
+		org2AnchorHex, org2Anchor := targetAnchor(t, devnet, "committer-org2-db", "multi_org_basic")
+		assert.Equal(t, anchorHex, org2AnchorHex)
+		assert.Equal(t, anchor, org2Anchor)
+
+		freezeBothAtAnchor(t, devnet, freezeBinary, anchor)
+		org1Config := writeBootstrapConfig(t, "committer-db:5432")
+		org2Config := writeBootstrapConfig(t, "committer-org2-db:5432")
+		assert.Contains(t, runBootstrap(t, committerBinary, bundlePath, org1Config), "Status: verified")
+		assert.Contains(t, runBootstrap(t, committerBinary, bundlePath, org2Config), "Status: verified")
+		org1Verification := runVerification(t, committerBinary, bundlePath, org1Config)
+		org2Verification := runVerification(t, committerBinary, bundlePath, org2Config)
+		assert.Equal(t, org1Verification, org2Verification, "organizations disagree on migration evidence")
+		verifyDatabase(t, devnet, "committer-db", bundle, "multi_org_basic", anchorHex, anchor, "VERIFIED")
+		verifyDatabase(t, devnet, "committer-org2-db", bundle, "multi_org_basic", anchorHex, anchor, "VERIFIED")
+
+		assert.Contains(t, runActivation(t, committerBinary, bundlePath, org1Config), "Status: active")
+		assert.Contains(t, runActivation(t, committerBinary, bundlePath, org2Config), "Status: active")
+		assert.Equal(t, "ACTIVE", sql(t, devnet, "SELECT status FROM migration_record"))
+		assert.Equal(t, "ACTIVE", sqlDB(t, devnet, "committer-org2-db", "SELECT status FROM migration_record"))
+		startOrderers(t, devnet)
+		composeBoth(t, devnet, "start", "committer-verifier", "committer-validator", "committer-coordinator", "committer-sidecar", "committer-query-service", "committer-org2-verifier", "committer-org2-validator", "committer-org2-coordinator", "committer-org2-sidecar", "committer-org2-query-service")
+		submitPostActivationTransaction(t, devnet, "multi_org_basic", bundle.PublicState[0], "committer-db", "committer-org2-db")
+	})
+
+	t.Run("when a committer database is rebuilt, it reimports at the anchor before replaying later blocks", func(t *testing.T) {
+		run(t, devnet, "make", "purge")
+		t.Cleanup(func() { run(t, devnet, "make", "purge") })
+		run(t, devnet, "make", "init")
+		run(t, devnet, "make", "start")
+		run(t, devnet, "make", "init-namespace-org1", "NS=recovery_basic")
+
+		snapshotPath := filepath.Join(labRepo, "artifacts", "snapshots", "fabric-3.1.5", "block-3")
+		bundlePath, bundle := exportBundle(t, migrateRepo, snapshotPath, "3.1.5", "basic", "recovery_basic")
+		anchorHex, anchor := targetAnchor(t, devnet, "committer-db", "recovery_basic")
+		configPath := writeBootstrapConfig(t, "committer-db:5432")
+
+		freezeAtAnchor(t, devnet, freezeBinary, anchor)
+		assert.Contains(t, runBootstrap(t, committerBinary, bundlePath, configPath), "Status: verified")
+		assert.Contains(t, runActivation(t, committerBinary, bundlePath, configPath), "Status: active")
+		startOrderers(t, devnet)
+		compose(t, devnet, "start", "committer-verifier", "committer-validator", "committer-coordinator", "committer-sidecar", "committer-query-service")
+		txID, value := submitPostActivationTransaction(t, devnet, "recovery_basic", bundle.PublicState[0], "committer-db")
+
+		blockPaths := captureBlocks(t, devnet, anchor+1)
+		laterBlockBytes, err := os.ReadFile(blockPaths[anchor+1])
+		require.NoError(t, err)
+		laterBlock := &common.Block{}
+		require.NoError(t, proto.Unmarshal(laterBlockBytes, laterBlock))
+		require.Equal(t, anchor+1, laterBlock.Header.Number)
+		require.Len(t, laterBlock.Data.Data, 1)
+
+		run(t, devnet, "make", "purge")
+		run(t, devnet, "make", "start")
+		waitForDatabaseAnchor(t, devnet, "committer-db", 0)
+		freezeAtAnchor(t, devnet, freezeBinary, 0)
+		compose(t, devnet, "start", "committer-verifier", "committer-validator", "committer-coordinator")
+		replayBlocks(t, devnet, replayBinary, blockPaths[1:anchor+1])
+		assert.Equal(t, anchorHex, sql(t, devnet, "SELECT encode(value, 'hex') FROM metadata WHERE convert_from(key, 'UTF8') = 'last committed block number'"))
+
+		compose(t, devnet, "stop", "committer-verifier", "committer-validator", "committer-coordinator")
+		assert.Contains(t, runBootstrap(t, committerBinary, bundlePath, configPath), "Status: verified")
+		assert.Contains(t, runActivation(t, committerBinary, bundlePath, configPath), "Status: active")
+		verifyDatabase(t, devnet, "committer-db", bundle, "recovery_basic", anchorHex, anchor, "ACTIVE")
+
+		compose(t, devnet, "start", "committer-verifier", "committer-validator", "committer-coordinator")
+		replayBlocks(t, devnet, replayBinary, blockPaths[anchor+1:])
+		keyHex := hex.EncodeToString(bundle.PublicState[0].Key)
+		assert.Equal(t, hex.EncodeToString(value), sql(t, devnet, "SELECT encode(value, 'hex') FROM ns_recovery_basic WHERE key = decode('"+keyHex+"', 'hex')"))
+		assert.Equal(t, fmt.Sprint(int32(committerpb.Status_COMMITTED)), sql(t, devnet, "SELECT status FROM tx_status WHERE tx_id = decode('"+hex.EncodeToString([]byte(txID))+"', 'hex')"))
+		assert.Equal(t, fmt.Sprint(anchor+1), fmt.Sprint(decodeAnchor(t, sql(t, devnet, "SELECT encode(value, 'hex') FROM metadata WHERE convert_from(key, 'UTF8') = 'last committed block number'"))))
+		assert.Equal(t, fmt.Sprintf("ACTIVE:%d", anchor), sql(t, devnet, "SELECT status||':'||target_anchor FROM migration_record"))
+	})
+}
+
+func exerciseMigration(t *testing.T, devnet, migrateRepo, committerBinary, freezeBinary, snapshotPath, version, sourceChannel, targetNamespace string) string {
+	t.Helper()
+	run(t, devnet, "make", "purge")
+	t.Cleanup(func() { run(t, devnet, "make", "purge") })
+	run(t, devnet, "make", "init")
+	run(t, devnet, "make", "start")
+	run(t, devnet, "make", "init-namespace-org1", "NS="+targetNamespace)
+
+	bundlePath, bundle := exportBundle(t, migrateRepo, snapshotPath, version, "basic", targetNamespace)
+	assert.Equal(t, sourceChannel, bundle.Manifest.Source.Channel)
+
+	anchorHex, anchor := targetAnchor(t, devnet, "committer-db", targetNamespace)
+
+	freezeAtAnchor(t, devnet, freezeBinary, anchor)
+	configPath := writeBootstrapConfig(t, "committer-db:5432")
+	first := runBootstrap(t, committerBinary, bundlePath, configPath)
+	assert.Contains(t, first, "Status: verified")
+	assert.Contains(t, first, fmt.Sprintf("Target anchor: %d", anchor))
+	second := runBootstrap(t, committerBinary, bundlePath, configPath)
+	assert.Contains(t, second, "Status: already verified")
+	verified := runVerification(t, committerBinary, bundlePath, configPath)
+	assert.Contains(t, verified, "Migration status: VERIFIED")
+	assert.Contains(t, verified, "Target configuration SHA-256: "+sql(t, devnet, "SELECT encode(target_config_hash, 'hex') FROM migration_record"))
+	assert.Contains(t, verified, "Namespace map SHA-256: "+sql(t, devnet, "SELECT encode(namespace_map_hash, 'hex') FROM migration_record"))
+	assert.Contains(t, verified, "Target policies SHA-256: "+sql(t, devnet, "SELECT encode(target_policy_hash, 'hex') FROM migration_record"))
+	assert.Contains(t, verified, "Integrity: verified")
+
+	verifyDatabase(t, devnet, "committer-db", bundle, targetNamespace, anchorHex, anchor, "VERIFIED")
+	activation := runActivation(t, committerBinary, bundlePath, configPath)
+	assert.Contains(t, activation, "Status: active")
+	again := runActivation(t, committerBinary, bundlePath, configPath)
+	assert.Contains(t, again, "Status: already active")
+	blocked := runBootstrapFailure(t, committerBinary, bundlePath, configPath)
+	assert.Contains(t, blocked, "ACTIVE; snapshot import is disabled")
+	activeVerification := runVerification(t, committerBinary, bundlePath, configPath)
+	assert.Contains(t, activeVerification, "Migration status: ACTIVE")
+	assert.Contains(t, activeVerification, "Integrity: verified")
+	verifyDatabase(t, devnet, "committer-db", bundle, targetNamespace, anchorHex, anchor, "ACTIVE")
+	startOrderers(t, devnet)
+	compose(t, devnet, "start", "committer-verifier", "committer-validator", "committer-coordinator", "committer-sidecar", "committer-query-service")
+	runVerification(t, committerBinary, bundlePath, configPath)
+	verifyDatabase(t, devnet, "committer-db", bundle, targetNamespace, anchorHex, anchor, "ACTIVE")
+	submitPostActivationTransaction(t, devnet, targetNamespace, bundle.PublicState[0], "committer-db")
+	return bundle.MigrationID
+}
+
+func exportBundle(t *testing.T, migrateRepo, snapshotPath, version, sourceNamespace, targetNamespace string) (string, *genesisdata.File) {
+	t.Helper()
+	bundlePath := filepath.Join(t.TempDir(), targetNamespace+".fxgenesis")
+	run(t, migrateRepo, "go", "run", "./cmd/fabric-x-migrate", "export",
+		"--snapshot", snapshotPath,
+		"--output", bundlePath,
+		"--namespace", sourceNamespace+"="+targetNamespace,
+		"--fabric-version", version,
+	)
+	run(t, migrateRepo, "go", "run", "./cmd/fabric-x-migrate", "verify-source", "--snapshot", snapshotPath, "--input", bundlePath)
+	bundle, err := genesisdata.Read(bundlePath)
+	require.NoError(t, err)
+	require.NotEmpty(t, bundle.PublicState)
+	assert.Equal(t, version, bundle.Manifest.Source.FabricVersion)
+	return bundlePath, bundle
+}
+
+func decodeAnchor(t *testing.T, anchorHex string) uint64 {
+	t.Helper()
+	anchorBytes, err := hex.DecodeString(anchorHex)
+	require.NoError(t, err)
+	require.Len(t, anchorBytes, 8, "invalid target anchor %q", anchorHex)
+	return binary.BigEndian.Uint64(anchorBytes)
+}
+
+func targetAnchor(t *testing.T, devnet, dbService, namespace string) (string, uint64) {
+	t.Helper()
+	var anchorHex string
+	var anchor uint64
+	require.Eventually(t, func() bool {
+		anchorHex = sqlDB(t, devnet, dbService, "SELECT encode(value, 'hex') FROM metadata WHERE convert_from(key, 'UTF8') = 'last committed block number'")
+		anchor = decodeAnchor(t, anchorHex)
+		if sqlDB(t, devnet, dbService, "SELECT count(*) FROM ns__meta WHERE key = convert_to('"+namespace+"', 'UTF8')") != "1" {
+			return false
+		}
+		heightBytes, err := hex.DecodeString(sqlDB(t, devnet, dbService, "SELECT encode(height, 'hex') FROM tx_status ORDER BY height DESC LIMIT 1"))
+		require.NoError(t, err)
+		height, _, err := servicepb.NewHeightFromBytes(heightBytes)
+		require.NoError(t, err)
+		return anchor == height.BlockNum
+	}, time.Minute, time.Second)
+	return anchorHex, anchor
+}
+
+func submitPostActivationTransaction(t *testing.T, devnet, namespace string, imported *genesisdata.StateRecord, dbServices ...string) (string, []byte) {
+	t.Helper()
+	identity := &ordererdial.IdentityConfig{
+		MspID:  "Org1MSP",
+		MSPDir: filepath.Join(devnet, "crypto", "peerOrganizations", "org1.example.com", "users", "User1@org1.example.com", "msp"),
+	}
+	policy := &workload.Policy{Scheme: workload.PolicySchemeMSP, MSPIdentities: []*ordererdial.IdentityConfig{identity}}
+	builder, err := workload.NewTxBuilderFromPolicy(&workload.PolicyProfile{
+		ChannelID: "mychannel",
+		Identity:  identity,
+		NamespacePolicies: map[string]*workload.Policy{
+			committerpb.MetaNamespaceID: policy,
+			namespace:                   policy,
+		},
+	}, nil)
+	require.NoError(t, err)
+
+	version := uint64(0)
+	value := []byte("post-activation-value")
+	tx := builder.MakeTx(&applicationpb.Tx{Namespaces: []*applicationpb.TxNamespace{{
+		NsId:      namespace,
+		NsVersion: 0,
+		ReadWrites: []*applicationpb.ReadWrite{{
+			Key: imported.Key, Version: &version, Value: value,
+		}},
+	}}})
+
+	tlsCredentials, err := connection.NewClientTLSCredentials(connection.TLSConfig{
+		Mode: connection.MutualTLSMode,
+		CertPath: filepath.Join(devnet, "crypto", "peerOrganizations", "org1.example.com", "peers",
+			"fxconfig.org1.example.com", "tls", "server.crt"),
+		KeyPath: filepath.Join(devnet, "crypto", "peerOrganizations", "org1.example.com", "peers",
+			"fxconfig.org1.example.com", "tls", "server.key"),
+		CACertPaths: []string{filepath.Join(devnet, "crypto", "ordererOrganizations", "orderer-org-1", "msp",
+			"tlscacerts", "tlsca.orderer-org-1-cert.pem")},
+	})
+	require.NoError(t, err)
+	transportCredentials, err := connection.NewClientGRPCTransportCredentials(tlsCredentials)
+	require.NoError(t, err)
+	conn, err := grpc.NewClient("localhost:7050", grpc.WithTransportCredentials(transportCredentials))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	ctx, cancel := context.WithTimeout(t.Context(), time.Minute)
+	defer cancel()
+	stream, err := ab.NewAtomicBroadcastClient(conn).Broadcast(ctx)
+	require.NoError(t, err)
+	require.NoError(t, stream.Send(&common.Envelope{Payload: tx.EnvelopePayload, Signature: tx.EnvelopeSignature}))
+	response, err := stream.Recv()
+	require.NoError(t, err)
+	assert.Equal(t, common.Status_SUCCESS, response.Status)
+	require.NoError(t, stream.CloseSend())
+
+	keyHex := hex.EncodeToString(imported.Key)
+	valueHex := hex.EncodeToString(value)
+	txIDHex := hex.EncodeToString([]byte(tx.Id))
+	for _, dbService := range dbServices {
+		require.Eventually(t, func() bool {
+			return sqlDB(t, devnet, dbService, "SELECT encode(value, 'hex') FROM ns_"+namespace+" WHERE key = decode('"+keyHex+"', 'hex')") == valueHex &&
+				sqlDB(t, devnet, dbService, "SELECT status FROM tx_status WHERE tx_id = decode('"+txIDHex+"', 'hex')") == fmt.Sprint(int32(committerpb.Status_COMMITTED))
+		}, time.Minute, time.Second)
+		assert.Equal(t, "t", sqlDB(t, devnet, dbService, "SELECT version > 0 FROM ns_"+namespace+" WHERE key = decode('"+keyHex+"', 'hex')"))
+		assert.Equal(t, "ACTIVE", sqlDB(t, devnet, dbService, "SELECT status FROM migration_record"))
+	}
+	return tx.Id, value
+}
+
+func cloneSnapshotWithChannel(t *testing.T, source, channel string) string {
+	t.Helper()
+	destination := t.TempDir()
+	entries, err := os.ReadDir(source)
+	require.NoError(t, err)
+	for _, entry := range entries {
+		require.False(t, entry.IsDir(), "snapshot fixture contains directory %s", entry.Name())
+		data, err := os.ReadFile(filepath.Join(source, entry.Name()))
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(filepath.Join(destination, entry.Name()), data, 0o600))
+	}
+
+	signablePath := filepath.Join(destination, "_snapshot_signable_metadata.json")
+	var signable map[string]any
+	signableBytes, err := os.ReadFile(signablePath)
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(signableBytes, &signable))
+	signable["channel_name"] = channel
+	signableBytes, err = json.MarshalIndent(signable, "", "    ")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(signablePath, signableBytes, 0o600))
+
+	additionalPath := filepath.Join(destination, "_snapshot_additional_metadata.json")
+	var additional map[string]any
+	additionalBytes, err := os.ReadFile(additionalPath)
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(additionalBytes, &additional))
+	hash := sha256.Sum256(signableBytes)
+	additional["snapshot_hash"] = hex.EncodeToString(hash[:])
+	additionalBytes, err = json.MarshalIndent(additional, "", "    ")
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(additionalPath, additionalBytes, 0o600))
+	return destination
+}
+
+func runBootstrap(t *testing.T, binary, bundle, config string) string {
+	t.Helper()
+	return runCommand(t, offlineCommand(binary, bundle, config, "--init-from-snapshot"))
+}
+
+func runActivation(t *testing.T, binary, bundle, config string) string {
+	t.Helper()
+	return runCommand(t, offlineCommand(binary, bundle, config, "--activate-migration"))
+}
+
+func runVerification(t *testing.T, binary, bundle, config string) string {
+	t.Helper()
+	return runCommand(t, offlineCommand(binary, bundle, config, "--verify-migration"))
+}
+
+func runBootstrapFailure(t *testing.T, binary, bundle, config string) string {
+	t.Helper()
+	return runCommandFailure(t, offlineCommand(binary, bundle, config, "--init-from-snapshot"))
+}
+
+func offlineCommand(binary, bundle, config, operation string) *exec.Cmd {
+	return exec.Command("docker", "run", "--rm", "--network", "fabric-x",
+		"-v", binary+":/committer:ro",
+		"-v", bundle+":/snapshot.fxgenesis:ro",
+		"-v", config+":/config.yaml:ro",
+		"busybox:latest", "/committer",
+		operation, "/snapshot.fxgenesis", "--config", "/config.yaml",
+	)
+}
+
+func verifyDatabase(t *testing.T, devnet, dbService string, bundle *genesisdata.File, targetNamespace, anchorHex string, anchor uint64, status string) {
+	t.Helper()
+	assert.Equal(t, fmt.Sprint(len(bundle.PublicState)), sqlDB(t, devnet, dbService, "SELECT count(*) FROM ns_"+targetNamespace))
+	assert.Equal(t, fmt.Sprint(len(bundle.TransactionIDs)), sqlDB(t, devnet, dbService, "SELECT count(*) FROM migrated_tx_ids"))
+	assert.Equal(t, "0:0", sqlDB(t, devnet, dbService, "SELECT min(version)||':'||max(version) FROM ns_"+targetNamespace))
+	assert.Equal(t, anchorHex, sqlDB(t, devnet, dbService, "SELECT encode(value, 'hex') FROM metadata WHERE convert_from(key, 'UTF8') = 'last committed block number'"))
+	assert.Equal(t, fmt.Sprintf("%s:%d:%d:%d", status, anchor, len(bundle.PublicState), len(bundle.TransactionIDs)), sqlDB(t, devnet, dbService, "SELECT status||':'||target_anchor||':'||public_state_count||':'||transaction_id_count FROM migration_record"))
+	assert.Equal(t, bundle.MigrationID, sqlDB(t, devnet, dbService, "SELECT encode(migration_id, 'hex') FROM migration_record"))
+
+	actualState := strings.Split(sqlDB(t, devnet, dbService, "SELECT encode(key, 'hex')||':'||encode(value, 'hex')||':'||version FROM ns_"+targetNamespace+" ORDER BY key"), "\n")
+	expectedState := make([]string, len(bundle.PublicState))
+	for i, record := range bundle.PublicState {
+		expectedState[i] = fmt.Sprintf("%s:%s:0", hex.EncodeToString(record.Key), hex.EncodeToString(record.Value))
+	}
+	sort.Strings(expectedState)
+	assert.Equal(t, expectedState, actualState, "target state differs from bundle")
+
+	actualTxIDs := strings.Split(sqlDB(t, devnet, dbService, "SELECT encode(tx_id, 'hex') FROM migrated_tx_ids ORDER BY tx_id"), "\n")
+	expectedTxIDs := make([]string, len(bundle.TransactionIDs))
+	for i, record := range bundle.TransactionIDs {
+		expectedTxIDs[i] = hex.EncodeToString([]byte(record.TransactionId))
+	}
+	sort.Strings(expectedTxIDs)
+	assert.Equal(t, expectedTxIDs, actualTxIDs, "target transaction IDs differ from bundle")
+}
+
+func sql(t *testing.T, devnet, query string) string {
+	t.Helper()
+	return sqlDB(t, devnet, "committer-db", query)
+}
+
+func sqlDB(t *testing.T, devnet, dbService, query string) string {
+	t.Helper()
+	return strings.TrimSpace(composeBoth(t, devnet, "exec", "-T", dbService,
+		"psql", "-v", "ON_ERROR_STOP=1", "-U", "sc_user", "-d", "sc_db", "-Atc", query))
+}
+
+func compose(t *testing.T, devnet string, args ...string) string {
+	t.Helper()
+	return run(t, devnet, "docker", append([]string{"compose", "-f", filepath.Join(devnet, "compose.yaml")}, args...)...)
+}
+
+func composeBoth(t *testing.T, devnet string, args ...string) string {
+	t.Helper()
+	return run(t, devnet, "docker", append([]string{"compose", "-f", filepath.Join(devnet, "compose.yaml"), "-f", filepath.Join(devnet, "compose.org2.yaml")}, args...)...)
+}
+
+func freezeAtAnchor(t *testing.T, devnet, freezeBinary string, anchor uint64) {
+	t.Helper()
+	stopOrderers(t, devnet)
+	requireSidecarHeight(t, devnet, "localhost:4001", "org1", "fxconfig", anchor+1)
+	requireCoordinatorAnchor(t, devnet, freezeBinary, "committer-coordinator:9001", "org1", "committer-sidecar", anchor+1)
+	require.Equal(t, anchor, databaseAnchor(t, devnet, "committer-db"))
+	compose(t, devnet, "stop", "committer-sidecar")
+	compose(t, devnet, "stop", "committer-verifier", "committer-validator", "committer-coordinator", "committer-query-service")
+}
+
+func freezeBothAtAnchor(t *testing.T, devnet, freezeBinary string, anchor uint64) {
+	t.Helper()
+	stopOrderers(t, devnet)
+	requireSidecarHeight(t, devnet, "localhost:4001", "org1", "fxconfig", anchor+1)
+	requireSidecarHeight(t, devnet, "localhost:4002", "org2", "committer-org2-sidecar", anchor+1)
+	requireCoordinatorAnchor(t, devnet, freezeBinary, "committer-coordinator:9001", "org1", "committer-sidecar", anchor+1)
+	requireCoordinatorAnchor(t, devnet, freezeBinary, "committer-org2-coordinator:9001", "org2", "committer-org2-sidecar", anchor+1)
+	require.Equal(t, anchor, databaseAnchor(t, devnet, "committer-db"))
+	require.Equal(t, anchor, databaseAnchor(t, devnet, "committer-org2-db"))
+	composeBoth(t, devnet, "stop", "committer-sidecar", "committer-org2-sidecar")
+	composeBoth(t, devnet, "stop", "committer-verifier", "committer-validator", "committer-coordinator", "committer-query-service", "committer-org2-verifier", "committer-org2-validator", "committer-org2-coordinator", "committer-org2-query-service")
+}
+
+func requireSidecarHeight(t *testing.T, devnet, endpoint, org, clientPeer string, expected uint64) {
+	t.Helper()
+	peer := clientPeer + "." + org + ".example.com"
+	tlsDirectory := filepath.Join(devnet, "crypto", "peerOrganizations", org+".example.com", "peers", peer, "tls")
+	tlsCredentials, err := connection.NewClientTLSCredentials(connection.TLSConfig{
+		Mode:        connection.MutualTLSMode,
+		CertPath:    filepath.Join(tlsDirectory, "server.crt"),
+		KeyPath:     filepath.Join(tlsDirectory, "server.key"),
+		CACertPaths: []string{filepath.Join(devnet, "crypto", "peerOrganizations", org+".example.com", "msp", "tlscacerts", "tlsca."+org+".example.com-cert.pem")},
+	})
+	require.NoError(t, err)
+	transportCredentials, err := connection.NewClientGRPCTransportCredentials(tlsCredentials)
+	require.NoError(t, err)
+	conn, err := grpc.NewClient(endpoint, grpc.WithTransportCredentials(transportCredentials))
+	require.NoError(t, err)
+	defer conn.Close()
+	info, err := committerpb.NewBlockQueryServiceClient(conn).GetBlockchainInfo(t.Context(), &emptypb.Empty{})
+	require.NoError(t, err)
+	require.Equal(t, expected, info.Height)
+}
+
+func requireCoordinatorAnchor(t *testing.T, devnet, binary, endpoint, org, clientPeer string, nextBlock uint64) {
+	t.Helper()
+	run(t, devnet, "docker", "run", "--rm", "--network", "fabric-x",
+		"-v", binary+":/freezecheck:ro",
+		"-v", filepath.Join(devnet, "crypto", "peerOrganizations", org+".example.com", "peers", clientPeer+"."+org+".example.com", "tls")+":/client-tls:ro",
+		"-v", filepath.Join(devnet, "crypto", "peerOrganizations", org+".example.com", "msp", "tlscacerts", "tlsca."+org+".example.com-cert.pem")+":/org-tls-ca.pem:ro",
+		"busybox:latest", "/freezecheck", endpoint, fmt.Sprint(nextBlock))
+}
+
+func databaseAnchor(t *testing.T, devnet, dbService string) uint64 {
+	t.Helper()
+	return decodeAnchor(t, sqlDB(t, devnet, dbService, "SELECT encode(value, 'hex') FROM metadata WHERE convert_from(key, 'UTF8') = 'last committed block number'"))
+}
+
+func waitForDatabaseAnchor(t *testing.T, devnet, dbService string, expected uint64) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		command := exec.Command(
+			"docker", "compose", "-f", filepath.Join(devnet, "compose.yaml"),
+			"exec", "-T", dbService,
+			"psql", "-v", "ON_ERROR_STOP=1", "-U", "sc_user", "-d", "sc_db", "-Atc",
+			"SELECT encode(value, 'hex') FROM metadata WHERE convert_from(key, 'UTF8') = 'last committed block number'",
+		)
+		output, err := command.Output()
+		if err != nil {
+			return false
+		}
+		value, err := hex.DecodeString(strings.TrimSpace(string(output)))
+		return err == nil && len(value) == 8 && binary.BigEndian.Uint64(value) == expected
+	}, time.Minute, time.Second)
+}
+
+func stopOrderers(t *testing.T, devnet string) {
+	t.Helper()
+	compose(t, devnet, append([]string{"stop"}, ordererServices()...)...)
+	require.Eventually(t, func() bool {
+		conn, err := net.DialTimeout("tcp", "localhost:7050", 100*time.Millisecond)
+		if err != nil {
+			return true
+		}
+		_ = conn.Close()
+		return false
+	}, time.Minute, 100*time.Millisecond)
+}
+
+func startOrderers(t *testing.T, devnet string) {
+	t.Helper()
+	compose(t, devnet, append([]string{"start"}, ordererServices()...)...)
+	require.Eventually(t, func() bool {
+		conn, err := net.DialTimeout("tcp", "localhost:7050", 100*time.Millisecond)
+		if err != nil {
+			return false
+		}
+		_ = conn.Close()
+		return true
+	}, time.Minute, 100*time.Millisecond)
+}
+
+func ordererServices() []string {
+	services := make([]string, 0, 16)
+	for party := 1; party <= 4; party++ {
+		for _, component := range []string{"router", "batcher", "consenter", "assembler"} {
+			services = append(services, fmt.Sprintf("orderer-party%d-%s", party, component))
+		}
+	}
+	return services
+}
+
+func writeBootstrapConfig(t *testing.T, dbEndpoint string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "committer-validator.yaml")
+	config := fmt.Sprintf(`server:
+  endpoint: :6001
+  tls:
+    mode: none
+monitoring:
+  endpoint: :2116
+  tls:
+    mode: none
+database:
+  endpoints:
+    - %s
+  username: sc_user
+  password: sc_secret_pwd
+  database: sc_db
+  tls:
+    mode: none
+  max-connections: 10
+  min-connections: 1
+  load-balance: false
+  table-pre-split-tablets: 0
+  retry:
+    initial-interval: 100ms
+    randomization-factor: 0.1
+    multiplier: 1.5
+    max-interval: 1s
+    max-elapsed-time: 30s
+resource-limits:
+  max-workers-for-preparer: 1
+  max-workers-for-validator: 1
+  max-workers-for-committer: 1
+  min-transaction-batch-size: 1
+  timeout-for-min-transaction-batch-size: 1s
+logging:
+  logSpec: error
+`, dbEndpoint)
+	require.NoError(t, os.WriteFile(path, []byte(config), 0o600))
+	return path
+}
+
+func captureBlocks(t *testing.T, devnet string, lastBlock uint64) []string {
+	t.Helper()
+	tlsCredentials, err := connection.NewClientTLSCredentials(connection.TLSConfig{
+		Mode: connection.MutualTLSMode,
+		CertPath: filepath.Join(devnet, "crypto", "peerOrganizations", "org1.example.com", "peers",
+			"fxconfig.org1.example.com", "tls", "server.crt"),
+		KeyPath: filepath.Join(devnet, "crypto", "peerOrganizations", "org1.example.com", "peers",
+			"fxconfig.org1.example.com", "tls", "server.key"),
+		CACertPaths: []string{filepath.Join(devnet, "crypto", "peerOrganizations", "org1.example.com", "msp",
+			"tlscacerts", "tlsca.org1.example.com-cert.pem")},
+	})
+	require.NoError(t, err)
+	transportCredentials, err := connection.NewClientGRPCTransportCredentials(tlsCredentials)
+	require.NoError(t, err)
+	conn, err := grpc.NewClient("localhost:4001", grpc.WithTransportCredentials(transportCredentials))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = conn.Close() })
+
+	directory := t.TempDir()
+	paths := make([]string, lastBlock+1)
+	client := committerpb.NewBlockQueryServiceClient(conn)
+	for blockNumber := uint64(0); blockNumber <= lastBlock; blockNumber++ {
+		block, getErr := client.GetBlockByNumber(t.Context(), &committerpb.BlockNumber{Number: blockNumber})
+		require.NoError(t, getErr)
+		blockBytes, marshalErr := proto.Marshal(block)
+		require.NoError(t, marshalErr)
+		paths[blockNumber] = filepath.Join(directory, fmt.Sprintf("block-%d.pb", blockNumber))
+		require.NoError(t, os.WriteFile(paths[blockNumber], blockBytes, 0o600))
+	}
+	return paths
+}
+
+func replayBlocks(t *testing.T, devnet, binary string, blockPaths []string) {
+	t.Helper()
+	require.NotEmpty(t, blockPaths)
+	blockDirectory := filepath.Dir(blockPaths[0])
+	args := []string{"run", "--rm", "--network", "fabric-x",
+		"-v", binary + ":/replayblocks:ro",
+		"-v", blockDirectory + ":/blocks:ro",
+		"-v", filepath.Join(devnet, "crypto", "peerOrganizations", "org1.example.com", "peers", "committer-sidecar.org1.example.com", "tls") + ":/client-tls:ro",
+		"-v", filepath.Join(devnet, "crypto", "peerOrganizations", "org1.example.com", "msp", "tlscacerts", "tlsca.org1.example.com-cert.pem") + ":/org-tls-ca.pem:ro",
+		"busybox:latest", "/replayblocks", "committer-coordinator:9001"}
+	for _, blockPath := range blockPaths {
+		args = append(args, "/blocks/"+filepath.Base(blockPath))
+	}
+	run(t, devnet, "docker", args...)
+}
+
+func containerRunning(t *testing.T, name string) bool {
+	t.Helper()
+	command := exec.Command("docker", "inspect", "--format", "{{.State.Running}}", name)
+	output, err := command.CombinedOutput()
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(string(output)) == "true"
+}
+
+func run(t *testing.T, dir, name string, args ...string) string {
+	t.Helper()
+	command := exec.Command(name, args...)
+	command.Dir = dir
+	return runCommand(t, command)
+}
+
+func runCommand(t *testing.T, command *exec.Cmd) string {
+	t.Helper()
+	output, err := command.CombinedOutput()
+	require.NoError(t, err, "%s failed\n%s", command.String(), output)
+	return string(output)
+}
+
+func runCommandFailure(t *testing.T, command *exec.Cmd) string {
+	t.Helper()
+	output, err := command.CombinedOutput()
+	require.Error(t, err, "%s unexpectedly succeeded\n%s", command.String(), output)
+	return string(output)
+}

--- a/integration/migration/replayblocks/main.go
+++ b/integration/migration/replayblocks/main.go
@@ -1,0 +1,96 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/hyperledger/fabric-protos-go-apiv2/common"
+	"github.com/hyperledger/fabric-x-common/api/committerpb"
+	"google.golang.org/grpc"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/hyperledger/fabric-x-committer/api/servicepb"
+	"github.com/hyperledger/fabric-x-committer/service/sidecar"
+	"github.com/hyperledger/fabric-x-committer/utils/connection"
+)
+
+func main() {
+	if err := replayBlocks(os.Args[1:]); err != nil {
+		_, _ = fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func replayBlocks(args []string) error {
+	if len(args) < 2 {
+		return fmt.Errorf("usage: replayblocks <coordinator-endpoint> <block> [block...]")
+	}
+
+	tlsCredentials, err := connection.NewClientTLSCredentials(connection.TLSConfig{
+		Mode:        connection.MutualTLSMode,
+		CertPath:    "/client-tls/server.crt",
+		KeyPath:     "/client-tls/server.key",
+		CACertPaths: []string{"/org-tls-ca.pem"},
+	})
+	if err != nil {
+		return err
+	}
+	transportCredentials, err := connection.NewClientGRPCTransportCredentials(tlsCredentials)
+	if err != nil {
+		return err
+	}
+	conn, err := grpc.NewClient(args[0], grpc.WithTransportCredentials(transportCredentials))
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	client := servicepb.NewCoordinatorClient(conn)
+	stream, err := client.BlockProcessing(ctx, grpc.WaitForReady(true))
+	if err != nil {
+		return err
+	}
+	for _, path := range args[1:] {
+		blockBytes, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		block := &common.Block{}
+		if unmarshalErr := proto.Unmarshal(blockBytes, block); unmarshalErr != nil {
+			return unmarshalErr
+		}
+		batch, mapErr := sidecar.MapBlockForTest(block)
+		if mapErr != nil {
+			return mapErr
+		}
+		if sendErr := stream.Send(batch); sendErr != nil {
+			return sendErr
+		}
+		for remaining := len(batch.Txs) + len(batch.Rejected); remaining > 0; {
+			statuses, recvErr := stream.Recv()
+			if recvErr != nil {
+				return recvErr
+			}
+			for _, status := range statuses.Status {
+				if status.Status != committerpb.Status_COMMITTED {
+					return fmt.Errorf("block %d transaction %s: %s", block.Header.Number, status.Ref.TxId, status.Status.String())
+				}
+			}
+			remaining -= len(statuses.Status)
+		}
+		if _, setErr := client.SetLastCommittedBlockNumber(ctx, &servicepb.BlockRef{Number: block.Header.Number}); setErr != nil {
+			return setErr
+		}
+	}
+	return stream.CloseSend()
+}

--- a/integration/migration/testdata/collections.json
+++ b/integration/migration/testdata/collections.json
@@ -1,0 +1,20 @@
+[
+  {
+    "name": "assetCollection",
+    "policy": "OR('Org1MSP.member')",
+    "requiredPeerCount": 0,
+    "maxPeerCount": 1,
+    "blockToLive": 1000000,
+    "memberOnlyRead": true,
+    "memberOnlyWrite": true
+  },
+  {
+    "name": "Org1MSPPrivateCollection",
+    "policy": "OR('Org1MSP.member')",
+    "requiredPeerCount": 0,
+    "maxPeerCount": 1,
+    "blockToLive": 1000000,
+    "memberOnlyRead": true,
+    "memberOnlyWrite": true
+  }
+]

--- a/integration/migration/testdata/compose.yaml
+++ b/integration/migration/testdata/compose.yaml
@@ -1,0 +1,85 @@
+name: fabric-x-migrate-source
+# Copyright IBM Corp. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+services:
+  orderer:
+    image: hyperledger/fabric-orderer:${FABRIC_VERSION}
+    environment:
+      FABRIC_LOGGING_SPEC: INFO
+      ORDERER_GENERAL_LISTENADDRESS: 0.0.0.0
+      ORDERER_GENERAL_LISTENPORT: 7050
+      ORDERER_GENERAL_LOCALMSPID: OrdererMSP
+      ORDERER_GENERAL_LOCALMSPDIR: /var/hyperledger/orderer/msp
+      ORDERER_GENERAL_TLS_ENABLED: "true"
+      ORDERER_GENERAL_TLS_PRIVATEKEY: /var/hyperledger/orderer/tls/server.key
+      ORDERER_GENERAL_TLS_CERTIFICATE: /var/hyperledger/orderer/tls/server.crt
+      ORDERER_GENERAL_TLS_ROOTCAS: "[/var/hyperledger/orderer/tls/ca.crt]"
+      ORDERER_GENERAL_CLUSTER_CLIENTCERTIFICATE: /var/hyperledger/orderer/tls/server.crt
+      ORDERER_GENERAL_CLUSTER_CLIENTPRIVATEKEY: /var/hyperledger/orderer/tls/server.key
+      ORDERER_GENERAL_CLUSTER_ROOTCAS: "[/var/hyperledger/orderer/tls/ca.crt]"
+      ORDERER_GENERAL_BOOTSTRAPMETHOD: none
+      ORDERER_CHANNELPARTICIPATION_ENABLED: "true"
+      ORDERER_ADMIN_TLS_ENABLED: "true"
+      ORDERER_ADMIN_TLS_CERTIFICATE: /var/hyperledger/orderer/tls/server.crt
+      ORDERER_ADMIN_TLS_PRIVATEKEY: /var/hyperledger/orderer/tls/server.key
+      ORDERER_ADMIN_TLS_ROOTCAS: "[/var/hyperledger/orderer/tls/ca.crt]"
+      ORDERER_ADMIN_TLS_CLIENTROOTCAS: "[/var/hyperledger/orderer/tls/ca.crt]"
+      ORDERER_ADMIN_LISTENADDRESS: 0.0.0.0:7053
+    volumes:
+      - ./crypto/ordererOrganizations/example.com/orderers/orderer.example.com/msp:/var/hyperledger/orderer/msp:ro
+      - ./crypto/ordererOrganizations/example.com/orderers/orderer.example.com/tls:/var/hyperledger/orderer/tls:ro
+      - orderer-data:/var/hyperledger/production/orderer
+    ports: ["18050:7050", "18053:7053"]
+    networks: [source]
+  couchdb:
+    image: couchdb:3.4.2
+    environment:
+      COUCHDB_USER: admin
+      COUCHDB_PASSWORD: adminpw
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:5984/_up"]
+      interval: 1s
+      timeout: 1s
+      retries: 30
+    networks: [source]
+  peer:
+    image: hyperledger/fabric-peer:${FABRIC_VERSION}
+    environment:
+      FABRIC_CFG_PATH: /etc/hyperledger/fabric
+      FABRIC_LOGGING_SPEC: INFO
+      CORE_PEER_ID: source-peer
+      CORE_PEER_ADDRESS: peer:7051
+      CORE_PEER_LISTENADDRESS: 0.0.0.0:7051
+      CORE_PEER_CHAINCODEADDRESS: peer:7052
+      CORE_PEER_CHAINCODELISTENADDRESS: 0.0.0.0:7052
+      CORE_PEER_GOSSIP_BOOTSTRAP: peer:7051
+      CORE_PEER_GOSSIP_EXTERNALENDPOINT: peer:7051
+      CORE_PEER_LOCALMSPID: Org1MSP
+      CORE_PEER_MSPCONFIGPATH: /var/hyperledger/peer/msp
+      CORE_PEER_TLS_ENABLED: "true"
+      CORE_PEER_TLS_CERT_FILE: /var/hyperledger/peer/tls/server.crt
+      CORE_PEER_TLS_KEY_FILE: /var/hyperledger/peer/tls/server.key
+      CORE_PEER_TLS_ROOTCERT_FILE: /var/hyperledger/peer/tls/ca.crt
+      CORE_VM_ENDPOINT: unix:///host/var/run/docker.sock
+      CORE_VM_DOCKER_HOSTCONFIG_NETWORKMODE: fabric-x-migrate-source
+      CORE_OPERATIONS_LISTENADDRESS: peer:9444
+      CORE_LEDGER_STATE_STATEDATABASE: ${STATE_DATABASE}
+      CORE_LEDGER_STATE_COUCHDBCONFIG_COUCHDBADDRESS: couchdb:5984
+      CORE_LEDGER_STATE_COUCHDBCONFIG_USERNAME: admin
+      CORE_LEDGER_STATE_COUCHDBCONFIG_PASSWORD: adminpw
+    depends_on:
+      couchdb:
+        condition: service_healthy
+    volumes:
+      - ./crypto/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/msp:/var/hyperledger/peer/msp:ro
+      - ./crypto/peerOrganizations/org1.example.com/peers/peer0.org1.example.com/tls:/var/hyperledger/peer/tls:ro
+      - /var/run/docker.sock:/host/var/run/docker.sock
+      - peer-data:/var/hyperledger/production
+    ports: ["18051:7051", "18444:9444"]
+    networks: [source]
+volumes: {orderer-data: {}, peer-data: {}}
+networks:
+  source: {name: fabric-x-migrate-source}

--- a/integration/migration/testdata/configtx.yaml
+++ b/integration/migration/testdata/configtx.yaml
@@ -1,0 +1,71 @@
+# Copyright IBM Corp. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+Organizations:
+  - &OrdererOrg
+    Name: OrdererMSP
+    ID: OrdererMSP
+    MSPDir: crypto/ordererOrganizations/example.com/msp
+    Policies:
+      Readers: {Type: Signature, Rule: "OR('OrdererMSP.member')"}
+      Writers: {Type: Signature, Rule: "OR('OrdererMSP.member')"}
+      Admins: {Type: Signature, Rule: "OR('OrdererMSP.admin')"}
+    OrdererEndpoints: [orderer:7050]
+  - &Org1
+    Name: Org1MSP
+    ID: Org1MSP
+    MSPDir: crypto/peerOrganizations/org1.example.com/msp
+    Policies:
+      Readers: {Type: Signature, Rule: "OR('Org1MSP.admin', 'Org1MSP.peer', 'Org1MSP.client')"}
+      Writers: {Type: Signature, Rule: "OR('Org1MSP.admin', 'Org1MSP.client')"}
+      Admins: {Type: Signature, Rule: "OR('Org1MSP.admin')"}
+      Endorsement: {Type: Signature, Rule: "OR('Org1MSP.peer')"}
+    AnchorPeers: [{Host: peer, Port: 7051}]
+Capabilities:
+  Channel: &ChannelCapabilities {V2_0: true}
+  Orderer: &OrdererCapabilities {V2_0: true}
+  Application: &ApplicationCapabilities {V2_0: true}
+Application: &ApplicationDefaults
+  Organizations:
+  Policies:
+    Readers: {Type: ImplicitMeta, Rule: "ANY Readers"}
+    Writers: {Type: ImplicitMeta, Rule: "ANY Writers"}
+    Admins: {Type: ImplicitMeta, Rule: "MAJORITY Admins"}
+    LifecycleEndorsement: {Type: ImplicitMeta, Rule: "MAJORITY Endorsement"}
+    Endorsement: {Type: ImplicitMeta, Rule: "MAJORITY Endorsement"}
+  Capabilities: {<<: *ApplicationCapabilities}
+Orderer: &OrdererDefaults
+  OrdererType: etcdraft
+  Addresses: [orderer:7050]
+  EtcdRaft:
+    Consenters:
+      - Host: orderer
+        Port: 7050
+        ClientTLSCert: crypto/ordererOrganizations/example.com/orderers/orderer.example.com/tls/server.crt
+        ServerTLSCert: crypto/ordererOrganizations/example.com/orderers/orderer.example.com/tls/server.crt
+  BatchTimeout: 1s
+  BatchSize: {MaxMessageCount: 10, AbsoluteMaxBytes: 10 MB, PreferredMaxBytes: 2 MB}
+  Organizations:
+  Policies:
+    Readers: {Type: ImplicitMeta, Rule: "ANY Readers"}
+    Writers: {Type: ImplicitMeta, Rule: "ANY Writers"}
+    Admins: {Type: ImplicitMeta, Rule: "MAJORITY Admins"}
+    BlockValidation: {Type: ImplicitMeta, Rule: "ANY Writers"}
+  Capabilities: {<<: *OrdererCapabilities}
+Channel: &ChannelDefaults
+  Policies:
+    Readers: {Type: ImplicitMeta, Rule: "ANY Readers"}
+    Writers: {Type: ImplicitMeta, Rule: "ANY Writers"}
+    Admins: {Type: ImplicitMeta, Rule: "MAJORITY Admins"}
+  Capabilities: {<<: *ChannelCapabilities}
+Profiles:
+  MigrationChannel:
+    <<: *ChannelDefaults
+    Orderer:
+      <<: *OrdererDefaults
+      Organizations: [*OrdererOrg]
+    Application:
+      <<: *ApplicationDefaults
+      Organizations: [*Org1]

--- a/integration/migration/testdata/crypto-config.yaml
+++ b/integration/migration/testdata/crypto-config.yaml
@@ -1,0 +1,20 @@
+# Copyright IBM Corp. All Rights Reserved.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+---
+OrdererOrgs:
+  - Name: Orderer
+    Domain: example.com
+    Specs:
+      - Hostname: orderer
+        SANS: [localhost]
+PeerOrgs:
+  - Name: Org1
+    Domain: org1.example.com
+    EnableNodeOUs: true
+    Template:
+      Count: 1
+      SANS: [localhost]
+    Users:
+      Count: 1

--- a/service/sidecar/test_exports.go
+++ b/service/sidecar/test_exports.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hyperledger/fabric-protos-go-apiv2/common"
 	"github.com/hyperledger/fabric-x-common/api/applicationpb"
 	"github.com/hyperledger/fabric-x-common/api/committerpb"
 	"github.com/hyperledger/fabric-x-common/protoutil"
@@ -19,10 +20,20 @@ import (
 	"github.com/hyperledger/fabric-x-committer/api/servicepb"
 	"github.com/hyperledger/fabric-x-committer/loadgen/workload"
 	"github.com/hyperledger/fabric-x-committer/service/verifier/policy"
+	"github.com/hyperledger/fabric-x-committer/utils"
 	"github.com/hyperledger/fabric-x-committer/utils/signature"
 	"github.com/hyperledger/fabric-x-committer/utils/test"
 	"github.com/hyperledger/fabric-x-committer/utils/testsig"
 )
+
+// MapBlockForTest maps a Fabric-X block to the coordinator representation used by integration tests.
+func MapBlockForTest(block *common.Block) (*servicepb.CoordinatorBatch, error) {
+	mapped, err := mapBlock(block, &utils.SyncMap[string, servicepb.Height]{})
+	if err != nil {
+		return nil, err
+	}
+	return mapped.block, nil
+}
 
 // RequireNotifications verifies that the expected notification were received.
 func RequireNotifications( //nolint:revive // argument-limit.

--- a/service/vc/bootstrap.go
+++ b/service/vc/bootstrap.go
@@ -1,0 +1,647 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package vc
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"fmt"
+	"math"
+	"sort"
+
+	"github.com/cockroachdb/errors"
+	cb "github.com/hyperledger/fabric-protos-go-apiv2/common"
+	"github.com/hyperledger/fabric-x-common/api/applicationpb"
+	"github.com/hyperledger/fabric-x-common/api/committerpb"
+	"github.com/yugabyte/pgx/v5"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/hyperledger/fabric-x-committer/service/verifier/policy"
+	"github.com/hyperledger/fabric-x-committer/utils/signature"
+	"github.com/hyperledger/fabric-x-committer/utils/statedb"
+	"github.com/syndbg/fabric-x-migrate-poc/pkg/genesisdata"
+)
+
+const bootstrapLockID int64 = 0x464142584d494752 // FABXMIGR
+
+// SnapshotInitResult is the verified target state created by InitFromSnapshot.
+type SnapshotInitResult struct {
+	MigrationID       string
+	SourceChannel     string
+	SourceBlockNumber uint64
+	TargetAnchor      uint64
+	PublicStateCount  uint64
+	TransactionIDs    uint64
+	AlreadyImported   bool
+}
+
+// SnapshotActivationResult is the verified migration record activated by
+// ActivateSnapshot.
+type SnapshotActivationResult struct {
+	MigrationID   string
+	TargetAnchor  uint64
+	AlreadyActive bool
+}
+
+// SnapshotVerificationResult describes a successful comparison between a
+// genesis-data file, the migration record, and target state.
+type SnapshotVerificationResult struct {
+	MigrationID         string
+	MigrationStatus     string
+	SourceChannel       string
+	SourceBlockNumber   uint64
+	TargetAnchor        uint64
+	TargetConfigSHA256  string
+	NamespaceMapSHA256  string
+	TargetPolicySHA256  string
+	PublicStateCount    uint64
+	PublicStateSHA256   string
+	TransactionIDCount  uint64
+	TransactionIDSHA256 string
+}
+
+type migrationStatus string
+
+const (
+	migrationAbsent   migrationStatus = ""
+	migrationVerified migrationStatus = "VERIFIED"
+	migrationActive   migrationStatus = "ACTIVE"
+)
+
+type bootstrapDigests struct {
+	config       []byte
+	namespaceMap []byte
+	policy       []byte
+	state        []byte
+	txIDs        []byte
+}
+
+// InitFromSnapshot verifies a genesis-data file and imports it into an idle
+// Validator-Committer database without advancing the Fabric-X block height.
+func InitFromSnapshot(ctx context.Context, config *Config, path string) (*SnapshotInitResult, error) {
+	file, db, err := openSnapshotDatabase(ctx, config, path)
+	if err != nil {
+		return nil, err
+	}
+	defer db.close()
+	if err := statedb.SetupSystemTablesAndNamespaces(ctx, config.Database); err != nil {
+		return nil, err
+	}
+	return db.initFromSnapshot(ctx, file)
+}
+
+func (db *database) initFromSnapshot(ctx context.Context, file *genesisdata.File) (*SnapshotInitResult, error) {
+	tx, err := db.pool.BeginTx(ctx, pgx.TxOptions{IsoLevel: pgx.Serializable})
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to begin snapshot initialization")
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	if _, err := tx.Exec(ctx, "SELECT pg_advisory_xact_lock($1)", bootstrapLockID); err != nil {
+		return nil, errors.Wrap(err, "failed to acquire snapshot initialization lock")
+	}
+
+	anchor, err := readTargetAnchor(ctx, tx)
+	if err != nil {
+		return nil, err
+	}
+	digests, err := inspectTarget(ctx, tx, file)
+	if err != nil {
+		return nil, err
+	}
+	result := snapshotInitResult(file, anchor)
+
+	status, err := verifyExistingMigration(ctx, tx, file, anchor, digests)
+	if err != nil {
+		return nil, err
+	}
+	switch status {
+	case migrationActive:
+		return nil, errors.New("target migration is ACTIVE; snapshot import is disabled")
+	case migrationVerified:
+		result.AlreadyImported = true
+		return result, nil
+	}
+	if err := requireEmptyTarget(ctx, tx, file); err != nil {
+		return nil, err
+	}
+	if err := insertSnapshotState(ctx, tx, file); err != nil {
+		return nil, err
+	}
+	if err := verifyLiveTarget(ctx, tx, file, digests.state, digests.txIDs); err != nil {
+		return nil, err
+	}
+	if err := insertMigrationRecord(ctx, tx, file, anchor, digests); err != nil {
+		return nil, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return nil, errors.Wrap(err, "failed to commit snapshot initialization")
+	}
+	return result, nil
+}
+
+// ActivateSnapshot verifies an existing snapshot import and changes only its
+// migration record from VERIFIED to ACTIVE.
+func ActivateSnapshot(ctx context.Context, config *Config, path string) (*SnapshotActivationResult, error) {
+	file, db, err := openSnapshotDatabase(ctx, config, path)
+	if err != nil {
+		return nil, err
+	}
+	defer db.close()
+	return db.activateSnapshot(ctx, file)
+}
+
+// VerifySnapshot independently compares a genesis-data file with the
+// target database and its migration record without changing either.
+func VerifySnapshot(ctx context.Context, config *Config, path string) (*SnapshotVerificationResult, error) {
+	file, db, err := openSnapshotDatabase(ctx, config, path)
+	if err != nil {
+		return nil, err
+	}
+	defer db.close()
+	return db.verifySnapshot(ctx, file)
+}
+
+func openSnapshotDatabase(ctx context.Context, config *Config, path string) (*genesisdata.File, *database, error) {
+	if config == nil || config.Database == nil {
+		return nil, nil, errors.New("validator-committer database configuration is required")
+	}
+	file, err := genesisdata.Read(path)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "failed to verify genesis-data file")
+	}
+	db, err := newDatabase(ctx, config.Database, newVCServiceMetrics(), config.ResourceLimits)
+	if err != nil {
+		return nil, nil, err
+	}
+	return file, db, nil
+}
+
+func (db *database) verifySnapshot(ctx context.Context, file *genesisdata.File) (*SnapshotVerificationResult, error) {
+	tx, err := db.pool.BeginTx(ctx, pgx.TxOptions{IsoLevel: pgx.RepeatableRead, AccessMode: pgx.ReadOnly})
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to begin snapshot verification")
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	if _, err := tx.Exec(ctx, "SELECT pg_advisory_xact_lock($1)", bootstrapLockID); err != nil {
+		return nil, errors.Wrap(err, "failed to acquire snapshot verification lock")
+	}
+	anchor, err := readTargetAnchor(ctx, tx)
+	if err != nil {
+		return nil, err
+	}
+	digests, err := inspectTarget(ctx, tx, file)
+	if err != nil {
+		return nil, err
+	}
+	status, err := verifyExistingMigration(ctx, tx, file, anchor, digests)
+	if err != nil {
+		return nil, err
+	}
+	if status == migrationAbsent {
+		return nil, errors.New("snapshot has not been imported")
+	}
+	return &SnapshotVerificationResult{
+		MigrationID: file.MigrationID, MigrationStatus: string(status),
+		SourceChannel: file.Manifest.Source.Channel, SourceBlockNumber: file.Manifest.Source.LastBlockNumber,
+		TargetAnchor: anchor, TargetConfigSHA256: hex.EncodeToString(digests.config),
+		NamespaceMapSHA256: hex.EncodeToString(digests.namespaceMap), TargetPolicySHA256: hex.EncodeToString(digests.policy),
+		PublicStateCount: uint64(len(file.PublicState)), PublicStateSHA256: hex.EncodeToString(digests.state),
+		TransactionIDCount: uint64(len(file.TransactionIDs)), TransactionIDSHA256: hex.EncodeToString(digests.txIDs),
+	}, nil
+}
+
+func (db *database) activateSnapshot(ctx context.Context, file *genesisdata.File) (*SnapshotActivationResult, error) {
+	tx, err := db.pool.BeginTx(ctx, pgx.TxOptions{IsoLevel: pgx.Serializable})
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to begin snapshot activation")
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	if _, err := tx.Exec(ctx, "SELECT pg_advisory_xact_lock($1)", bootstrapLockID); err != nil {
+		return nil, errors.Wrap(err, "failed to acquire snapshot activation lock")
+	}
+	anchor, err := readTargetAnchor(ctx, tx)
+	if err != nil {
+		return nil, err
+	}
+	digests, err := inspectTarget(ctx, tx, file)
+	if err != nil {
+		return nil, err
+	}
+	status, err := verifyExistingMigration(ctx, tx, file, anchor, digests)
+	if err != nil {
+		return nil, err
+	}
+	result := &SnapshotActivationResult{MigrationID: file.MigrationID, TargetAnchor: anchor}
+	switch status {
+	case migrationAbsent:
+		return nil, errors.New("snapshot has not been imported and verified")
+	case migrationActive:
+		result.AlreadyActive = true
+		return result, nil
+	}
+	command, err := tx.Exec(ctx, "UPDATE migration_record SET status = 'ACTIVE' WHERE singleton_id = 1 AND status = 'VERIFIED'")
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to activate migration record")
+	}
+	if command.RowsAffected() != 1 {
+		return nil, errors.New("migration record was not VERIFIED during activation")
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return nil, errors.Wrap(err, "failed to commit snapshot activation")
+	}
+	return result, nil
+}
+
+func snapshotInitResult(file *genesisdata.File, anchor uint64) *SnapshotInitResult {
+	return &SnapshotInitResult{
+		MigrationID:       file.MigrationID,
+		SourceChannel:     file.Manifest.Source.Channel,
+		SourceBlockNumber: file.Manifest.Source.LastBlockNumber,
+		TargetAnchor:      anchor,
+		PublicStateCount:  uint64(len(file.PublicState)),
+		TransactionIDs:    uint64(len(file.TransactionIDs)),
+	}
+}
+
+func readTargetAnchor(ctx context.Context, tx pgx.Tx) (uint64, error) {
+	var value []byte
+	if err := tx.QueryRow(ctx, getMetadataPrepSQLStmt, lastCommittedBlockNumberKey).Scan(&value); err != nil {
+		return 0, errors.Wrap(err, "failed to read target anchor")
+	}
+	if len(value) != 8 {
+		return 0, errors.New("target has not committed block 0")
+	}
+	return binary.BigEndian.Uint64(value), nil
+}
+
+func inspectTarget(ctx context.Context, tx pgx.Tx, file *genesisdata.File) (*bootstrapDigests, error) {
+	configHash, err := hashRows(ctx, tx, "SELECT key, value, version FROM ns__config ORDER BY key")
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to hash target configuration")
+	}
+	if configHash.count == 0 {
+		return nil, errors.New("target configuration namespace is empty")
+	}
+
+	mappings := append([]genesisdata.NamespaceMapping(nil), file.Manifest.NamespaceMappings...)
+	sort.Slice(mappings, func(i, j int) bool { return mappings[i].Source < mappings[j].Source })
+	mapHash := sha256.New()
+	policyHash := sha256.New()
+	for _, mapping := range mappings {
+		if err := validateTargetNamespace(mapping.Target); err != nil {
+			return nil, err
+		}
+		appendDigestBytes(mapHash, []byte(mapping.Source))
+		appendDigestBytes(mapHash, []byte(mapping.Target))
+		var policyValue []byte
+		var version int64
+		if err := tx.QueryRow(ctx, "SELECT value, version FROM ns__meta WHERE key = $1", []byte(mapping.Target)).Scan(&policyValue, &version); err != nil {
+			return nil, errors.Wrapf(err, "target namespace %q is not installed", mapping.Target)
+		}
+		if err := validateTargetPolicy(policyValue); err != nil {
+			return nil, errors.Wrapf(err, "target namespace %q has an unsupported policy", mapping.Target)
+		}
+		appendDigestBytes(policyHash, []byte(mapping.Target))
+		appendDigestBytes(policyHash, policyValue)
+		appendDigestUint64(policyHash, uint64(version))
+	}
+
+	expectedState := hashExpectedState(file)
+	expectedTxIDs := hashExpectedTxIDs(file)
+	return &bootstrapDigests{
+		config: configHash.hash, namespaceMap: mapHash.Sum(nil), policy: policyHash.Sum(nil),
+		state: expectedState.hash, txIDs: expectedTxIDs.hash,
+	}, nil
+}
+
+func validateTargetPolicy(policyValue []byte) error {
+	namespacePolicy, err := policy.UnmarshalNamespacePolicy(policyValue)
+	if err != nil {
+		return err
+	}
+	switch rule := namespacePolicy.Rule.(type) {
+	case *applicationpb.NamespacePolicy_ThresholdRule:
+		if rule.ThresholdRule == nil {
+			return errors.New("threshold policy is empty")
+		}
+		_, err := signature.NewNsVerifierFromKey(rule.ThresholdRule.Scheme, rule.ThresholdRule.PublicKey)
+		return err
+	case *applicationpb.NamespacePolicy_MspRule:
+		envelope := &cb.SignaturePolicyEnvelope{}
+		if err := proto.Unmarshal(rule.MspRule, envelope); err != nil {
+			return errors.Wrap(err, "invalid MSP policy")
+		}
+		if envelope.Rule == nil || len(envelope.Identities) == 0 {
+			return errors.New("MSP policy is empty")
+		}
+		return nil
+	default:
+		return errors.New("policy rule is not supported")
+	}
+}
+
+func validateTargetNamespace(namespace string) error {
+	if namespace == committerpb.MetaNamespaceID || namespace == committerpb.ConfigNamespaceID {
+		return errors.Newf("system namespace %q cannot receive imported state", namespace)
+	}
+	if err := policy.ValidateNamespaceID(namespace); err != nil {
+		return errors.Wrapf(err, "invalid target namespace %q", namespace)
+	}
+	return nil
+}
+
+func verifyExistingMigration(
+	ctx context.Context,
+	tx pgx.Tx,
+	file *genesisdata.File,
+	anchor uint64,
+	digests *bootstrapDigests,
+) (migrationStatus, error) {
+	var migrationID, snapshotHash, configHash, namespaceMapHash, policyHash, stateHash, txIDHash []byte
+	var sourceBlock, storedAnchor, stateCount, txIDCount int64
+	var sourceChannel string
+	var status string
+	err := tx.QueryRow(ctx, `
+SELECT migration_id, source_channel, source_block_number, source_snapshot_hash,
+       target_anchor, target_config_hash, namespace_map_hash, target_policy_hash,
+       public_state_count, public_state_hash, transaction_id_count,
+       transaction_id_hash, status
+FROM migration_record WHERE singleton_id = 1`).Scan(
+		&migrationID, &sourceChannel, &sourceBlock, &snapshotHash, &storedAnchor,
+		&configHash, &namespaceMapHash, &policyHash, &stateCount, &stateHash,
+		&txIDCount, &txIDHash, &status,
+	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return migrationAbsent, nil
+	}
+	if err != nil {
+		return migrationAbsent, errors.Wrap(err, "failed to read migration record")
+	}
+	expectedID, err := decodeHash("migration ID", file.MigrationID)
+	if err != nil {
+		return migrationAbsent, err
+	}
+	if !bytes.Equal(migrationID, expectedID) {
+		return migrationAbsent, errors.New("target was initialized from a different genesis-data file")
+	}
+	expectedSnapshotHash, err := decodeHash("source snapshot hash", file.Manifest.Source.SnapshotHash)
+	if err != nil {
+		return migrationAbsent, err
+	}
+	if storedAnchor < 0 || uint64(storedAnchor) != anchor {
+		return migrationAbsent, errors.New("target advanced beyond the recorded migration anchor")
+	}
+	if sourceBlock < 0 || stateCount < 0 || txIDCount < 0 ||
+		sourceChannel != file.Manifest.Source.Channel || uint64(sourceBlock) != file.Manifest.Source.LastBlockNumber ||
+		!bytes.Equal(snapshotHash, expectedSnapshotHash) ||
+		!bytes.Equal(configHash, digests.config) || !bytes.Equal(namespaceMapHash, digests.namespaceMap) ||
+		!bytes.Equal(policyHash, digests.policy) || uint64(stateCount) != uint64(len(file.PublicState)) ||
+		uint64(txIDCount) != uint64(len(file.TransactionIDs)) ||
+		!bytes.Equal(stateHash, digests.state) || !bytes.Equal(txIDHash, digests.txIDs) {
+		return migrationAbsent, errors.New("migration record no longer matches its source or target bindings")
+	}
+	if migrationStatus(status) != migrationVerified && migrationStatus(status) != migrationActive {
+		return migrationAbsent, errors.Newf("unsupported migration status %q", status)
+	}
+	if err := verifyLiveTarget(ctx, tx, file, digests.state, digests.txIDs); err != nil {
+		return migrationAbsent, err
+	}
+	return migrationStatus(status), nil
+}
+
+func requireEmptyTarget(ctx context.Context, tx pgx.Tx, file *genesisdata.File) error {
+	for _, mapping := range file.Manifest.NamespaceMappings {
+		var exists bool
+		query := "SELECT EXISTS (SELECT 1 FROM " + statedb.TableName(mapping.Target) + " LIMIT 1)"
+		if err := tx.QueryRow(ctx, query).Scan(&exists); err != nil {
+			return errors.Wrapf(err, "failed to inspect target namespace %q", mapping.Target)
+		}
+		if exists {
+			return errors.Newf("target namespace %q is not empty", mapping.Target)
+		}
+	}
+	if len(file.TransactionIDs) == 0 {
+		return nil
+	}
+	ids := transactionIDBytes(file)
+	var count int64
+	if err := tx.QueryRow(ctx, `
+SELECT (SELECT count(*) FROM tx_status WHERE tx_id = ANY($1)) +
+       (SELECT count(*) FROM migrated_tx_ids WHERE tx_id = ANY($1))`, ids).Scan(&count); err != nil {
+		return errors.Wrap(err, "failed to inspect target transaction IDs")
+	}
+	if count != 0 {
+		return errors.New("one or more source transaction IDs already exist in the target")
+	}
+	return nil
+}
+
+func insertSnapshotState(ctx context.Context, tx pgx.Tx, file *genesisdata.File) error {
+	type records struct {
+		keys   [][]byte
+		values [][]byte
+	}
+	byNamespace := map[string]*records{}
+	for _, record := range file.PublicState {
+		group := byNamespace[record.TargetNamespace]
+		if group == nil {
+			group = &records{}
+			byNamespace[record.TargetNamespace] = group
+		}
+		group.keys = append(group.keys, record.Key)
+		group.values = append(group.values, record.Value)
+	}
+	for namespace, group := range byNamespace {
+		versions := make([]int64, len(group.keys))
+		query := "INSERT INTO " + statedb.TableName(namespace) + ` (key, value, version)
+SELECT key, value, version
+FROM unnest($1::bytea[], $2::bytea[], $3::bigint[]) AS rows(key, value, version)`
+		if _, err := tx.Exec(ctx, query, group.keys, group.values, versions); err != nil {
+			return errors.Wrapf(err, "failed to import namespace %q", namespace)
+		}
+	}
+	if len(file.TransactionIDs) > 0 {
+		if _, err := tx.Exec(ctx,
+			"INSERT INTO migrated_tx_ids (tx_id) SELECT unnest($1::bytea[])", transactionIDBytes(file)); err != nil {
+			return errors.Wrap(err, "failed to import transaction IDs")
+		}
+	}
+	return nil
+}
+
+func verifyLiveTarget(ctx context.Context, tx pgx.Tx, file *genesisdata.File, stateHash, txIDHash []byte) error {
+	liveState := sha256.New()
+	var stateCount uint64
+	mappings := append([]genesisdata.NamespaceMapping(nil), file.Manifest.NamespaceMappings...)
+	sort.Slice(mappings, func(i, j int) bool { return mappings[i].Target < mappings[j].Target })
+	for _, mapping := range mappings {
+		rows, err := tx.Query(ctx, "SELECT key, value, version FROM "+statedb.TableName(mapping.Target)+" ORDER BY key")
+		if err != nil {
+			return errors.Wrapf(err, "failed to verify namespace %q", mapping.Target)
+		}
+		for rows.Next() {
+			var key, value []byte
+			var version int64
+			if err := rows.Scan(&key, &value, &version); err != nil {
+				rows.Close()
+				return errors.Wrap(err, "failed to read imported state")
+			}
+			if version < 0 {
+				rows.Close()
+				return errors.New("imported state has a negative target version")
+			}
+			appendStateDigest(liveState, mapping.Target, key, value, uint64(version))
+			stateCount++
+		}
+		if err := rows.Err(); err != nil {
+			rows.Close()
+			return errors.Wrap(err, "failed to scan imported state")
+		}
+		rows.Close()
+	}
+	if stateCount != uint64(len(file.PublicState)) || !bytes.Equal(liveState.Sum(nil), stateHash) {
+		return errors.New("target public state does not match genesis-data file")
+	}
+
+	liveTxIDs, err := tx.Query(ctx, "SELECT tx_id FROM migrated_tx_ids ORDER BY tx_id")
+	if err != nil {
+		return errors.Wrap(err, "failed to verify migrated transaction IDs")
+	}
+	txHasher := sha256.New()
+	var txIDCount uint64
+	for liveTxIDs.Next() {
+		var id []byte
+		if err := liveTxIDs.Scan(&id); err != nil {
+			liveTxIDs.Close()
+			return errors.Wrap(err, "failed to read migrated transaction ID")
+		}
+		appendDigestBytes(txHasher, id)
+		txIDCount++
+	}
+	if err := liveTxIDs.Err(); err != nil {
+		liveTxIDs.Close()
+		return errors.Wrap(err, "failed to scan migrated transaction IDs")
+	}
+	liveTxIDs.Close()
+	if txIDCount != uint64(len(file.TransactionIDs)) || !bytes.Equal(txHasher.Sum(nil), txIDHash) {
+		return errors.New("target transaction IDs do not match genesis-data file")
+	}
+	return nil
+}
+
+func insertMigrationRecord(
+	ctx context.Context,
+	tx pgx.Tx,
+	file *genesisdata.File,
+	anchor uint64,
+	digests *bootstrapDigests,
+) error {
+	if file.Manifest.Source.LastBlockNumber > math.MaxInt64 || anchor > math.MaxInt64 {
+		return errors.New("source or target block number exceeds database range")
+	}
+	migrationID, err := decodeHash("migration ID", file.MigrationID)
+	if err != nil {
+		return err
+	}
+	snapshotHash, err := decodeHash("source snapshot hash", file.Manifest.Source.SnapshotHash)
+	if err != nil {
+		return err
+	}
+	_, err = tx.Exec(ctx, `
+INSERT INTO migration_record (
+    singleton_id, migration_id, source_channel, source_block_number,
+    source_snapshot_hash, target_anchor, target_config_hash, namespace_map_hash,
+    target_policy_hash, public_state_count, public_state_hash,
+    transaction_id_count, transaction_id_hash, status
+) VALUES (1, $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, 'VERIFIED')`,
+		migrationID, file.Manifest.Source.Channel, int64(file.Manifest.Source.LastBlockNumber),
+		snapshotHash, int64(anchor), digests.config, digests.namespaceMap, digests.policy,
+		int64(len(file.PublicState)), digests.state, int64(len(file.TransactionIDs)), digests.txIDs)
+	return errors.Wrap(err, "failed to write migration record")
+}
+
+type rowHash struct {
+	count uint64
+	hash  []byte
+}
+
+func hashRows(ctx context.Context, tx pgx.Tx, query string) (*rowHash, error) {
+	rows, err := tx.Query(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	hasher := sha256.New()
+	var count uint64
+	for rows.Next() {
+		var key, value []byte
+		var version int64
+		if err := rows.Scan(&key, &value, &version); err != nil {
+			return nil, err
+		}
+		appendDigestBytes(hasher, key)
+		appendDigestBytes(hasher, value)
+		appendDigestUint64(hasher, uint64(version))
+		count++
+	}
+	return &rowHash{count: count, hash: hasher.Sum(nil)}, rows.Err()
+}
+
+func hashExpectedState(file *genesisdata.File) *rowHash {
+	hasher := sha256.New()
+	for _, record := range file.PublicState {
+		appendStateDigest(hasher, record.TargetNamespace, record.Key, record.Value, 0)
+	}
+	return &rowHash{count: uint64(len(file.PublicState)), hash: hasher.Sum(nil)}
+}
+
+func hashExpectedTxIDs(file *genesisdata.File) *rowHash {
+	hasher := sha256.New()
+	for _, record := range file.TransactionIDs {
+		appendDigestBytes(hasher, []byte(record.TransactionId))
+	}
+	return &rowHash{count: uint64(len(file.TransactionIDs)), hash: hasher.Sum(nil)}
+}
+
+func appendStateDigest(hasher interface{ Write([]byte) (int, error) }, namespace string, key, value []byte, version uint64) {
+	appendDigestBytes(hasher, []byte(namespace))
+	appendDigestBytes(hasher, key)
+	appendDigestBytes(hasher, value)
+	appendDigestUint64(hasher, version)
+}
+
+func appendDigestBytes(hasher interface{ Write([]byte) (int, error) }, value []byte) {
+	var length [binary.MaxVarintLen64]byte
+	n := binary.PutUvarint(length[:], uint64(len(value)))
+	_, _ = hasher.Write(length[:n])
+	_, _ = hasher.Write(value)
+}
+
+func appendDigestUint64(hasher interface{ Write([]byte) (int, error) }, value uint64) {
+	var encoded [8]byte
+	binary.BigEndian.PutUint64(encoded[:], value)
+	_, _ = hasher.Write(encoded[:])
+}
+
+func transactionIDBytes(file *genesisdata.File) [][]byte {
+	result := make([][]byte, len(file.TransactionIDs))
+	for i, record := range file.TransactionIDs {
+		result[i] = []byte(record.TransactionId)
+	}
+	return result
+}
+
+func decodeHash(name, value string) ([]byte, error) {
+	decoded, err := hex.DecodeString(value)
+	if err != nil || len(decoded) != sha256.Size {
+		return nil, fmt.Errorf("invalid %s", name)
+	}
+	return decoded, nil
+}

--- a/service/vc/bootstrap_test.go
+++ b/service/vc/bootstrap_test.go
@@ -1,0 +1,398 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package vc
+
+import (
+	"bytes"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/hyperledger/fabric-x-common/api/applicationpb"
+	"github.com/hyperledger/fabric-x-common/api/committerpb"
+	"github.com/hyperledger/fabric-x-common/common/policydsl"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/hyperledger/fabric-x-committer/api/servicepb"
+	verifierpolicy "github.com/hyperledger/fabric-x-committer/service/verifier/policy"
+	"github.com/hyperledger/fabric-x-committer/utils/signature"
+	"github.com/hyperledger/fabric-x-committer/utils/statedb"
+	"github.com/hyperledger/fabric-x-committer/utils/testsig"
+	"github.com/syndbg/fabric-x-migrate-poc/pkg/genesisdata"
+)
+
+const migrationNamespace = "migration_basic"
+
+func TestInitFromSnapshot(t *testing.T) {
+	t.Run("when the target is empty, it imports and verifies the snapshot", testInitFromSnapshot)
+	testInitFromSnapshotRejectsUnsafeTargets(t)
+	t.Run("when the final migration record fails, it rolls back every imported row", testInitFromSnapshotAtomic)
+	t.Run("when multiple namespaces are mapped, it imports each namespace", testInitFromSnapshotMultipleNamespaces)
+}
+
+func testInitFromSnapshot(t *testing.T) {
+	env := newSnapshotBootstrapEnv(t, true)
+	file := writeSnapshotBundle(t, migrationNamespace, "value-a")
+
+	result, err := env.DB.initFromSnapshot(t.Context(), file)
+	require.NoError(t, err)
+	assert.False(t, result.AlreadyImported)
+	assert.Equal(t, uint64(1), result.TargetAnchor)
+	assert.Equal(t, uint64(2), result.PublicStateCount)
+	assert.Equal(t, uint64(2), result.TransactionIDs)
+
+	var value []byte
+	var version int64
+	require.NoError(t, env.DB.pool.QueryRow(t.Context(),
+		"SELECT value, version FROM ns_migration_basic WHERE key = $1", []byte("asset-a"),
+	).Scan(&value, &version))
+	assert.Equal(t, []byte("value-a"), value)
+	assert.Zero(t, version)
+	assert.Equal(t, 2, env.getRowCount(t, "SELECT count(*) FROM migrated_tx_ids"))
+	assert.Equal(t, 1, env.getRowCount(t, "SELECT count(*) FROM migration_record WHERE status = 'VERIFIED'"))
+
+	anchor, err := env.DB.getNextBlockNumberToCommit(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, uint64(2), anchor.Number, "bootstrap must not advance target block 1")
+
+	runAgain, err := env.DB.initFromSnapshot(t.Context(), file)
+	require.NoError(t, err)
+	assert.True(t, runAgain.AlreadyImported)
+	assert.Equal(t, 2, env.getRowCount(t, "SELECT count(*) FROM ns_migration_basic"))
+
+	row := env.DB.pool.QueryRow(t.Context(), insertTxStatusSQLStmt,
+		[][]byte{[]byte("tx-a")}, []int{int(committerpb.Status_COMMITTED)}, [][]byte{make([]byte, 16)})
+	duplicates, err := readArrayResult[[]byte](row)
+	require.NoError(t, err)
+	assert.Equal(t, [][]byte{[]byte("tx-a")}, duplicates, "migrated transaction IDs must participate in anti-replay")
+	assert.Zero(t, env.getRowCount(t, "SELECT count(*) FROM tx_status"))
+
+	different := writeSnapshotBundle(t, migrationNamespace, "different-value")
+	_, err = env.DB.initFromSnapshot(t.Context(), different)
+	require.ErrorContains(t, err, "different genesis-data file")
+
+	_, err = env.DB.pool.Exec(t.Context(), "UPDATE ns_migration_basic SET value = $1 WHERE key = $2", []byte("tampered"), []byte("asset-a"))
+	require.NoError(t, err)
+	_, err = env.DB.initFromSnapshot(t.Context(), file)
+	require.ErrorContains(t, err, "target public state does not match")
+	_, err = env.DB.pool.Exec(t.Context(), "UPDATE ns_migration_basic SET value = $1 WHERE key = $2", []byte("value-a"), []byte("asset-a"))
+	require.NoError(t, err)
+
+	_, err = env.DB.pool.Exec(t.Context(), "UPDATE ns__meta SET value = $1 WHERE key = $2", mspPolicyBytes(t, "OR('Org1MSP.admin')"), []byte(migrationNamespace))
+	require.NoError(t, err)
+	_, err = env.DB.initFromSnapshot(t.Context(), file)
+	require.ErrorContains(t, err, "target bindings")
+	_, err = env.DB.pool.Exec(t.Context(), "UPDATE ns__meta SET value = $1 WHERE key = $2", mspPolicyBytes(t, "OR('Org1MSP.member')"), []byte(migrationNamespace))
+	require.NoError(t, err)
+
+	require.NoError(t, env.DB.setLastCommittedBlockNumber(t.Context(), &servicepb.BlockRef{Number: 2}))
+	_, err = env.DB.initFromSnapshot(t.Context(), file)
+	require.ErrorContains(t, err, "advanced beyond")
+}
+
+func testInitFromSnapshotRejectsUnsafeTargets(t *testing.T) {
+	t.Run("when the target namespace is missing, it rejects the import", func(t *testing.T) {
+		env := newSnapshotBootstrapEnv(t, false)
+		_, err := env.DB.initFromSnapshot(t.Context(), writeSnapshotBundle(t, migrationNamespace, "value-a"))
+		require.ErrorContains(t, err, "is not installed")
+	})
+
+	t.Run("when the target namespace is not empty, it rejects the import", func(t *testing.T) {
+		env := newSnapshotBootstrapEnv(t, true)
+		_, err := env.DB.pool.Exec(t.Context(),
+			"INSERT INTO ns_migration_basic (key, value, version) VALUES ($1, $2, 0)", []byte("existing"), []byte("value"))
+		require.NoError(t, err)
+		_, err = env.DB.initFromSnapshot(t.Context(), writeSnapshotBundle(t, migrationNamespace, "value-a"))
+		require.ErrorContains(t, err, "is not empty")
+	})
+
+	t.Run("when a transaction ID already exists, it rejects the import", func(t *testing.T) {
+		env := newSnapshotBootstrapEnv(t, true)
+		_, err := env.DB.pool.Exec(t.Context(),
+			"INSERT INTO tx_status (tx_id, status, height) VALUES ($1, $2, $3)",
+			[]byte("tx-a"), int(committerpb.Status_COMMITTED), make([]byte, 16))
+		require.NoError(t, err)
+		_, err = env.DB.initFromSnapshot(t.Context(), writeSnapshotBundle(t, migrationNamespace, "value-a"))
+		require.ErrorContains(t, err, "transaction IDs already exist")
+	})
+
+	t.Run("when target block zero is not committed, it rejects the import", func(t *testing.T) {
+		env := NewDatabaseTestEnv(t)
+		require.NoError(t, statedb.SetupSystemTablesAndNamespaces(t.Context(), env.DB.config))
+		_, err := env.DB.pool.Exec(t.Context(), "INSERT INTO ns__config (key, value, version) VALUES ($1, $2, 0)", []byte("config"), []byte("block-0"))
+		require.NoError(t, err)
+		_, err = env.DB.initFromSnapshot(t.Context(), writeSnapshotBundle(t, migrationNamespace, "value-a"))
+		require.ErrorContains(t, err, "has not committed block 0")
+	})
+
+	t.Run("when the target policy has no supported rule, it rejects the import", func(t *testing.T) {
+		env := newSnapshotBootstrapEnv(t, true)
+		unsupported, err := proto.Marshal(&applicationpb.NamespacePolicy{})
+		require.NoError(t, err)
+		_, err = env.DB.pool.Exec(t.Context(), "UPDATE ns__meta SET value = $1 WHERE key = $2", unsupported, []byte(migrationNamespace))
+		require.NoError(t, err)
+
+		_, err = env.DB.initFromSnapshot(t.Context(), writeSnapshotBundle(t, migrationNamespace, "value-a"))
+		require.ErrorContains(t, err, "unsupported policy")
+	})
+
+	t.Run("when the target uses a threshold policy, it imports the snapshot", func(t *testing.T) {
+		env := newSnapshotBootstrapEnv(t, true)
+		_, err := env.DB.pool.Exec(t.Context(), "UPDATE ns__meta SET value = $1 WHERE key = $2", thresholdPolicyBytes(t), []byte(migrationNamespace))
+		require.NoError(t, err)
+
+		_, err = env.DB.initFromSnapshot(t.Context(), writeSnapshotBundle(t, migrationNamespace, "value-a"))
+		require.NoError(t, err)
+	})
+}
+
+func testInitFromSnapshotAtomic(t *testing.T) {
+	env := newSnapshotBootstrapEnv(t, true)
+	_, err := env.DB.pool.Exec(t.Context(), `
+ALTER TABLE migration_record
+ADD CONSTRAINT fail_verified_insert CHECK (status <> 'VERIFIED')`)
+	require.NoError(t, err)
+
+	_, err = env.DB.initFromSnapshot(t.Context(), writeSnapshotBundle(t, migrationNamespace, "value-a"))
+	require.ErrorContains(t, err, "failed to write migration record")
+	assert.Zero(t, env.getRowCount(t, "SELECT count(*) FROM ns_migration_basic"))
+	assert.Zero(t, env.getRowCount(t, "SELECT count(*) FROM migrated_tx_ids"))
+	assert.Zero(t, env.getRowCount(t, "SELECT count(*) FROM migration_record"))
+
+	anchor, err := env.DB.getNextBlockNumberToCommit(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, uint64(2), anchor.Number)
+}
+
+func TestActivateSnapshot(t *testing.T) {
+	t.Run("when a verified snapshot is activated, it changes only the migration status", testActivateSnapshot)
+}
+
+func testActivateSnapshot(t *testing.T) {
+	env := newSnapshotBootstrapEnv(t, true)
+	file := writeSnapshotBundle(t, migrationNamespace, "value-a")
+
+	_, err := env.DB.activateSnapshot(t.Context(), file)
+	require.ErrorContains(t, err, "has not been imported and verified")
+	_, err = env.DB.initFromSnapshot(t.Context(), file)
+	require.NoError(t, err)
+
+	_, err = env.DB.pool.Exec(t.Context(), "UPDATE ns_migration_basic SET value = $1 WHERE key = $2", []byte("tampered"), []byte("asset-a"))
+	require.NoError(t, err)
+	_, err = env.DB.activateSnapshot(t.Context(), file)
+	require.ErrorContains(t, err, "target public state does not match")
+	assert.Equal(t, 1, env.getRowCount(t, "SELECT count(*) FROM migration_record WHERE status = 'VERIFIED'"))
+	_, err = env.DB.pool.Exec(t.Context(), "UPDATE ns_migration_basic SET value = $1 WHERE key = $2", []byte("value-a"), []byte("asset-a"))
+	require.NoError(t, err)
+
+	activated, err := env.DB.activateSnapshot(t.Context(), file)
+	require.NoError(t, err)
+	assert.False(t, activated.AlreadyActive)
+	assert.Equal(t, uint64(1), activated.TargetAnchor)
+	assert.Equal(t, 1, env.getRowCount(t, "SELECT count(*) FROM migration_record WHERE status = 'ACTIVE'"))
+
+	again, err := env.DB.activateSnapshot(t.Context(), file)
+	require.NoError(t, err)
+	assert.True(t, again.AlreadyActive)
+
+	_, err = env.DB.initFromSnapshot(t.Context(), file)
+	require.ErrorContains(t, err, "ACTIVE; snapshot import is disabled")
+	assert.Equal(t, 2, env.getRowCount(t, "SELECT count(*) FROM ns_migration_basic"))
+	assert.Equal(t, 2, env.getRowCount(t, "SELECT count(*) FROM migrated_tx_ids"))
+
+	_, err = env.DB.activateSnapshot(t.Context(), writeSnapshotBundle(t, migrationNamespace, "different-value"))
+	require.ErrorContains(t, err, "different genesis-data file")
+}
+
+func TestVerifySnapshot(t *testing.T) {
+	env := newSnapshotBootstrapEnv(t, true)
+	file := writeSnapshotBundle(t, migrationNamespace, "value-a")
+
+	t.Run("when the snapshot has not been imported, it rejects verification", func(t *testing.T) {
+		_, err := env.DB.verifySnapshot(t.Context(), file)
+		require.ErrorContains(t, err, "has not been imported")
+	})
+
+	_, err := env.DB.initFromSnapshot(t.Context(), file)
+	require.NoError(t, err)
+
+	t.Run("when target state matches, it reports verified integrity", func(t *testing.T) {
+		verified, err := env.DB.verifySnapshot(t.Context(), file)
+		require.NoError(t, err)
+		assert.Equal(t, file.MigrationID, verified.MigrationID)
+		assert.Equal(t, "VERIFIED", verified.MigrationStatus)
+		assert.Equal(t, uint64(1), verified.TargetAnchor)
+		assert.Len(t, verified.TargetConfigSHA256, 64)
+		assert.Len(t, verified.NamespaceMapSHA256, 64)
+		assert.Len(t, verified.TargetPolicySHA256, 64)
+		assert.Equal(t, uint64(2), verified.PublicStateCount)
+		assert.Len(t, verified.PublicStateSHA256, 64)
+		assert.Equal(t, uint64(2), verified.TransactionIDCount)
+		assert.Len(t, verified.TransactionIDSHA256, 64)
+	})
+
+	t.Run("when public state is changed, it rejects verification", func(t *testing.T) {
+		_, err := env.DB.pool.Exec(t.Context(), "UPDATE ns_migration_basic SET value = $1 WHERE key = $2", []byte("tampered"), []byte("asset-a"))
+		require.NoError(t, err)
+		_, err = env.DB.verifySnapshot(t.Context(), file)
+		require.ErrorContains(t, err, "target public state does not match")
+		_, err = env.DB.pool.Exec(t.Context(), "UPDATE ns_migration_basic SET value = $1 WHERE key = $2", []byte("value-a"), []byte("asset-a"))
+		require.NoError(t, err)
+	})
+
+	t.Run("when the transaction ID baseline changes, it rejects verification", func(t *testing.T) {
+		_, err := env.DB.pool.Exec(t.Context(), "INSERT INTO migrated_tx_ids (tx_id) VALUES ($1)", []byte("tx-extra"))
+		require.NoError(t, err)
+		_, err = env.DB.verifySnapshot(t.Context(), file)
+		require.ErrorContains(t, err, "target transaction IDs do not match")
+		_, err = env.DB.pool.Exec(t.Context(), "DELETE FROM migrated_tx_ids WHERE tx_id = $1", []byte("tx-extra"))
+		require.NoError(t, err)
+	})
+
+	t.Run("when the namespace policy changes, it rejects verification", func(t *testing.T) {
+		_, err := env.DB.pool.Exec(t.Context(), "UPDATE ns__meta SET value = $1 WHERE key = $2", mspPolicyBytes(t, "OR('Org1MSP.admin')"), []byte(migrationNamespace))
+		require.NoError(t, err)
+		_, err = env.DB.verifySnapshot(t.Context(), file)
+		require.ErrorContains(t, err, "target bindings")
+		_, err = env.DB.pool.Exec(t.Context(), "UPDATE ns__meta SET value = $1 WHERE key = $2", mspPolicyBytes(t, "OR('Org1MSP.member')"), []byte(migrationNamespace))
+		require.NoError(t, err)
+	})
+
+	t.Run("when the target anchor advances, it rejects verification", func(t *testing.T) {
+		require.NoError(t, env.DB.setLastCommittedBlockNumber(t.Context(), &servicepb.BlockRef{Number: 2}))
+		_, err := env.DB.verifySnapshot(t.Context(), file)
+		require.ErrorContains(t, err, "advanced beyond")
+		require.NoError(t, env.DB.setLastCommittedBlockNumber(t.Context(), &servicepb.BlockRef{Number: 1}))
+	})
+
+	t.Run("when the migration is active, it still verifies integrity", func(t *testing.T) {
+		_, err := env.DB.activateSnapshot(t.Context(), file)
+		require.NoError(t, err)
+		active, err := env.DB.verifySnapshot(t.Context(), file)
+		require.NoError(t, err)
+		assert.Equal(t, "ACTIVE", active.MigrationStatus)
+	})
+}
+
+func testInitFromSnapshotMultipleNamespaces(t *testing.T) {
+	env := newSnapshotBootstrapEnv(t, false)
+	env.populateData(t, []string{"migration_assets", "migration_payments"}, nil, nil, nil)
+	for _, namespace := range []string{"migration_assets", "migration_payments"} {
+		_, err := env.DB.pool.Exec(t.Context(), "UPDATE ns__meta SET value = $1 WHERE key = $2", mspPolicyBytes(t, "OR('Org1MSP.member')"), []byte(namespace))
+		require.NoError(t, err)
+	}
+	file := writeMultipleNamespaceBundle(t)
+
+	result, err := env.DB.initFromSnapshot(t.Context(), file)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(2), result.PublicStateCount)
+	assert.Equal(t, 1, env.getRowCount(t, "SELECT count(*) FROM ns_migration_assets"))
+	assert.Equal(t, 1, env.getRowCount(t, "SELECT count(*) FROM ns_migration_payments"))
+
+	verified, err := env.DB.verifySnapshot(t.Context(), file)
+	require.NoError(t, err)
+	assert.Equal(t, uint64(2), verified.PublicStateCount)
+	assert.Len(t, verified.PublicStateSHA256, 64)
+}
+
+func newSnapshotBootstrapEnv(t *testing.T, createNamespace bool) *DatabaseTestEnv {
+	t.Helper()
+	env := NewDatabaseTestEnv(t)
+	require.NoError(t, statedb.SetupSystemTablesAndNamespaces(t.Context(), env.DB.config))
+	_, err := env.DB.pool.Exec(t.Context(),
+		"INSERT INTO ns__config (key, value, version) VALUES ($1, $2, 0)", []byte("config"), []byte("block-0"))
+	require.NoError(t, err)
+	if createNamespace {
+		env.populateData(t, []string{migrationNamespace}, nil, nil, nil)
+		_, err = env.DB.pool.Exec(t.Context(), "UPDATE ns__meta SET value = $1 WHERE key = $2", mspPolicyBytes(t, "OR('Org1MSP.member')"), []byte(migrationNamespace))
+		require.NoError(t, err)
+	}
+	require.NoError(t, env.DB.setLastCommittedBlockNumber(t.Context(), &servicepb.BlockRef{Number: 1}))
+	return env
+}
+
+func mspPolicyBytes(t *testing.T, expression string) []byte {
+	t.Helper()
+	envelope, err := policydsl.FromString(expression)
+	require.NoError(t, err)
+	envelopeBytes, err := proto.Marshal(envelope)
+	require.NoError(t, err)
+	policyBytes, err := proto.Marshal(&applicationpb.NamespacePolicy{
+		Rule: &applicationpb.NamespacePolicy_MspRule{MspRule: envelopeBytes},
+	})
+	require.NoError(t, err)
+	return policyBytes
+}
+
+func thresholdPolicyBytes(t *testing.T) []byte {
+	t.Helper()
+	_, verificationKey := testsig.NewKeyPair(signature.Ecdsa)
+	policyBytes, err := proto.Marshal(verifierpolicy.MakeECDSAThresholdRuleNsPolicy(verificationKey))
+	require.NoError(t, err)
+	return policyBytes
+}
+
+func writeSnapshotBundle(t *testing.T, targetNamespace, firstValue string) *genesisdata.File {
+	t.Helper()
+	input := genesisdata.Input{
+		ExporterVersion: "integration-test",
+		Source: genesisdata.Source{
+			FabricVersion: "2.5.16", Channel: "migration", LastBlockNumber: 3,
+			LastBlockHash: strings.Repeat("a", 64), PreviousBlockHash: strings.Repeat("b", 64),
+			SnapshotHash: strings.Repeat("c", 64), StateDBType: "SimpleKeyValueDB",
+		},
+		NamespaceMappings: []genesisdata.NamespaceMapping{{Source: "basic", Target: targetNamespace}},
+		PublicState: []*genesisdata.StateRecord{
+			{SourceNamespace: "basic", TargetNamespace: targetNamespace, Key: []byte("asset-a"), Value: []byte(firstValue)},
+			{SourceNamespace: "basic", TargetNamespace: targetNamespace, Key: []byte("asset-b"), Value: []byte("value-b")},
+		},
+		TransactionIDs: []*genesisdata.TransactionIDRecord{{TransactionId: "tx-a"}, {TransactionId: "tx-b"}},
+	}
+	path := filepath.Join(t.TempDir(), "snapshot.fxgenesis")
+	file, err := genesisdata.Write(path, input)
+	require.NoError(t, err)
+	return file
+}
+
+func writeMultipleNamespaceBundle(t *testing.T) *genesisdata.File {
+	t.Helper()
+	input := genesisdata.Input{
+		ExporterVersion: "integration-test",
+		Source: genesisdata.Source{
+			FabricVersion: "3.1.5", Channel: "channel-a", LastBlockNumber: 3,
+			LastBlockHash: strings.Repeat("a", 64), PreviousBlockHash: strings.Repeat("b", 64),
+			SnapshotHash: strings.Repeat("c", 64), StateDBType: "SimpleKeyValueDB",
+		},
+		NamespaceMappings: []genesisdata.NamespaceMapping{
+			{Source: "assets", Target: "migration_assets"},
+			{Source: "payments", Target: "migration_payments"},
+		},
+		PublicState: []*genesisdata.StateRecord{
+			{SourceNamespace: "assets", TargetNamespace: "migration_assets", Key: []byte("asset-a"), Value: []byte("value-a")},
+			{SourceNamespace: "payments", TargetNamespace: "migration_payments", Key: []byte("payment-a"), Value: []byte("value-b")},
+		},
+		TransactionIDs: []*genesisdata.TransactionIDRecord{{TransactionId: "tx-a"}, {TransactionId: "tx-b"}},
+	}
+	path := filepath.Join(t.TempDir(), "multiple-namespaces.fxgenesis")
+	file, err := genesisdata.Write(path, input)
+	require.NoError(t, err)
+	return file
+}
+
+func TestAppendDigestBytes(t *testing.T) {
+	t.Run("when byte partitions differ, it produces distinct framed digests", func(t *testing.T) {
+		left := bytes.NewBuffer(nil)
+		appendDigestBytes(left, []byte("ab"))
+		appendDigestBytes(left, []byte("c"))
+		right := bytes.NewBuffer(nil)
+		appendDigestBytes(right, []byte("a"))
+		appendDigestBytes(right, []byte("bc"))
+		assert.NotEqual(t, left.Bytes(), right.Bytes())
+	})
+}

--- a/service/vc/database_test.go
+++ b/service/vc/database_test.go
@@ -29,7 +29,7 @@ func TestTablesAndMethods(t *testing.T) {
 	env.populateData(t, []string{"a", "b"}, namespaceToWrites{}, nil, nil)
 
 	expectedTables := []string{
-		"metadata", "tx_status",
+		"metadata", "tx_status", "migrated_tx_ids", "migration_record",
 		"ns__meta", "ns__config", "ns__snapshot", "ns__checkpoint",
 		"ns_a", "ns_b",
 	}

--- a/utils/statedb/init_database_tmpl.sql
+++ b/utils/statedb/init_database_tmpl.sql
@@ -27,6 +27,29 @@ CREATE TABLE IF NOT EXISTS tx_status
     height BYTEA NOT NULL
 )${SPLIT_INTO_TABLETS};
 
+CREATE TABLE IF NOT EXISTS migrated_tx_ids
+(
+    tx_id BYTEA NOT NULL PRIMARY KEY
+)${SPLIT_INTO_TABLETS};
+
+CREATE TABLE IF NOT EXISTS migration_record
+(
+    singleton_id            SMALLINT NOT NULL PRIMARY KEY DEFAULT 1 CHECK (singleton_id = 1),
+    migration_id            BYTEA NOT NULL UNIQUE,
+    source_channel          TEXT NOT NULL,
+    source_block_number     BIGINT NOT NULL CHECK (source_block_number >= 0),
+    source_snapshot_hash    BYTEA NOT NULL,
+    target_anchor           BIGINT NOT NULL CHECK (target_anchor >= 0),
+    target_config_hash      BYTEA NOT NULL,
+    namespace_map_hash      BYTEA NOT NULL,
+    target_policy_hash      BYTEA NOT NULL,
+    public_state_count      BIGINT NOT NULL CHECK (public_state_count >= 0),
+    public_state_hash       BYTEA NOT NULL,
+    transaction_id_count   BIGINT NOT NULL CHECK (transaction_id_count >= 0),
+    transaction_id_hash    BYTEA NOT NULL,
+    status                  TEXT NOT NULL CHECK (status IN ('VERIFIED', 'ACTIVE'))
+)${SPLIT_INTO_TABLETS};
+
 CREATE OR REPLACE FUNCTION insert_tx_status(
     IN _tx_ids BYTEA[],
     IN _statuses INTEGER[],
@@ -37,6 +60,23 @@ $$
 DECLARE
     violating BYTEA[];
 BEGIN
+    SELECT array_agg(v.tx_id ORDER BY v.tx_id)
+    INTO violating
+    FROM (
+        SELECT i.tx_id
+        FROM unnest(_tx_ids) AS i(tx_id)
+        GROUP BY i.tx_id
+        HAVING count(*) > 1
+        UNION
+        SELECT t.tx_id FROM tx_status t WHERE t.tx_id = ANY (_tx_ids)
+        UNION
+        SELECT m.tx_id FROM migrated_tx_ids m WHERE m.tx_id = ANY (_tx_ids)
+    ) AS v;
+
+    IF cardinality(violating) > 0 THEN
+        RETURN violating;
+    END IF;
+
     INSERT INTO tx_status (tx_id, status, height)
     VALUES (unnest(_tx_ids),
             unnest(_statuses),
@@ -46,8 +86,11 @@ EXCEPTION
     WHEN unique_violation THEN
         SELECT array_agg(t.tx_id)
         INTO violating
-        FROM tx_status t
-        WHERE t.tx_id = ANY (_tx_ids);
+        FROM (
+            SELECT t.tx_id FROM tx_status t WHERE t.tx_id = ANY (_tx_ids)
+            UNION
+            SELECT m.tx_id FROM migrated_tx_ids m WHERE m.tx_id = ANY (_tx_ids)
+        ) AS t;
         RETURN COALESCE(violating, '{}');
 END;
 $$ LANGUAGE plpgsql;

--- a/utils/testdb/container.go
+++ b/utils/testdb/container.go
@@ -317,12 +317,10 @@ func (dc *DatabaseContainer) GetConnectionOptions(ctx context.Context, t *testin
 	require.NoError(t, err)
 
 	portBindings := container.NetworkSettings.Ports[dc.DbPort]
-	endpoints := make([]*connection.Endpoint, 0, len(portBindings)+1)
-	endpoints = append(endpoints, dc.GetContainerConnectionDetails(t))
-	for _, p := range portBindings {
-		endpoints = append(endpoints, test.NewEndpoint(t, p.HostIP, p.HostPort))
+	if len(portBindings) > 0 {
+		return NewConnection(dc.DatabaseType, dc.GetHostMappedEndpoint(t))
 	}
-	return NewConnection(dc.DatabaseType, endpoints...)
+	return NewConnection(dc.DatabaseType, dc.GetContainerConnectionDetails(t))
 }
 
 // GetContainerConnectionDetails inspect the container and fetches its connection to an endpoint.


### PR DESCRIPTION
WIP and proof of https://github.com/hyperledger/fabric-rfcs/pull/68

#### Type of change

- New feature
- Test update

#### Description

- Add `--init-from-snapshot`, `--verify-migration`, and
  `--activate-migration` committer operations.
- Import mapped public state and Fabric transaction IDs into pre-created,
  empty namespaces in one serializable database transaction.
- Require a supported installed target-policy encoding and bind its exact
  bytes and version, together with the target anchor, effective configuration,
  and namespace map, to the migration record.
- Store migrated transaction IDs for duplicate detection without assigning
  fabricated Fabric-X transaction statuses.
- Create a `VERIFIED` migration record atomically with imported state, make
  repeated imports idempotent, and reject imports after activation.
- Verify target counts and binding digests before changing the migration
  record to `ACTIVE`.

#### Additional details (Optional)

The public
[fabric-x-migrate-poc](https://github.com/syndbg/fabric-x-migrate-poc)
repository currently contains the genesis-data schema and reader while the RFC
is reviewed. The RFC proposes
[fabric-x-common](https://github.com/hyperledger/fabric-x-common) as their
production owner.

#### Related issues

- [Fabric to Fabric-X ledger migration mentorship project](https://github.com/LF-Decentralized-Trust-Mentorships/mentorship-program/issues/65)
- [Migration RFC branch](https://github.com/syndbg/fabric-rfcs/tree/feat-add-fabric-to-fabric-x-migration)

cc @liran-funaro @cendhu @tock-ibm