### PR TITLE
[test] Never assert on the outer testing.T inside a polling condition

### DIFF
--- a/.bob/skills/tests/SKILL.md
+++ b/.bob/skills/tests/SKILL.md
@@ -44,7 +44,8 @@ This document provides specific guidelines for writing and running tests in the 
 Don't hand-roll crypto, TLS, config-block, or service/DB setup — reuse existing helpers:
 
 - **In-process harnesses (this repo):** `test.RunServiceForTest` / `test.ServeForTest` ([`utils/test/serve.go`](../../utils/test/serve.go)), `testdb.PrepareTestEnv` + `testdb.RunTestMain` (`utils/testdb`), and the hand-written mocks in `mock/`.
-- **Proto assertions (this repo):** `test.RequireProtoEqual` / `test.RequireProtoElementsMatch` (`utils/test/require_proto.go`) — never compare protos with `require.Equal`. Both accept `require.TestingT`, so they also work inside `require.EventuallyWithT`.
+- **Proto assertions (this repo):** `test.RequireProtoEqual` / `test.RequireProtoElementsMatch` (`utils/test/require_proto.go`) — never compare protos with `require.Equal`. Both accept `test.TestingT`, so they also work inside `require.EventuallyWithT`.
+- **Inside an `Eventually` condition, never touch the outer `t`** — not `require`, not `t.Fatalf`, not `t.Logf`. The condition runs on its own goroutine and may outlive the test, where asserting on the test's own `T` panics the *whole test binary* instead of failing one test; it also fails the test on the first transient error instead of retrying. Assert on the `ct`, and give any helper the condition calls a `test.TestingT` parameter (`require.TestingT` plus `Helper()`) so the `ct` can be passed down — see `test.GetIntMetricValue`, `testdb.DatabaseContainer.ExecuteCommand`. `testing.TB` cannot serve here: it is sealed, so an `assert.CollectT` can never satisfy it; reserve it for helpers needing `Cleanup`/`TempDir`/`Context` that no condition calls.
 - **MSP / identity / Fabric config blocks:** `github.com/hyperledger/fabric-x-common/utils/testcrypto` — `CreateOrExtendConfigBlockWithCrypto`, `ConfigBlock`, `PrepareBlockHeaderAndMetadata`, `GetPeersIdentities` / `GetConsenterIdentities` / `GetSigningIdentities` / `GetPeersMspDirs` / `GetConsenterMspDirs`.
 - **TLS test material:** `github.com/hyperledger/fabric-x-common/common/crypto/tlsgen` — `tlsgen.NewCA()`, `CA`, `CertKeyPair`.
 - **Generate crypto material:** `github.com/hyperledger/fabric-x-common/tools/cryptogen`.
@@ -395,8 +396,8 @@ require.Greater(t, latency, float64(0))
 
 // Use with require.EventuallyWithT for complex conditions
 require.EventuallyWithT(t, func(ct *assert.CollectT) {
-    require.Equal(ct, 0, test.GetIntMetricValue(t, metrics.queueSize))
-    require.Equal(ct, 5, test.GetIntMetricValue(t, metrics.activeWorkers))
+    require.Equal(ct, 0, test.GetIntMetricValue(ct, metrics.queueSize))
+    require.Equal(ct, 5, test.GetIntMetricValue(ct, metrics.activeWorkers))
 }, 3*time.Second, 500*time.Millisecond)
 ```
 
@@ -503,9 +504,9 @@ require.Greater(t, count, 500)
    ```go
    // ✅ CORRECT - Shows which metric failed
    require.EventuallyWithT(t, func(ct *assert.CollectT) {
-       require.Equal(ct, 1, test.GetIntMetricValue(t, metrics.inputQueue))
-       require.Equal(ct, 1, test.GetIntMetricValue(t, metrics.outputQueue))
-       require.Equal(ct, 0, test.GetIntMetricValue(t, metrics.processingQueue))
+       require.Equal(ct, 1, test.GetIntMetricValue(ct, metrics.inputQueue))
+       require.Equal(ct, 1, test.GetIntMetricValue(ct, metrics.outputQueue))
+       require.Equal(ct, 0, test.GetIntMetricValue(ct, metrics.processingQueue))
    }, 3*time.Second, 500*time.Millisecond)
 
    // ❌ INCORRECT - Doesn't show which condition failed
@@ -520,7 +521,7 @@ require.Greater(t, count, 500)
 
    ```go
    require.EventuallyWithT(t, func(ct *assert.CollectT) {
-       actual := test.GetIntMetricValue(t, metrics.counter)
+       actual := test.GetIntMetricValue(ct, metrics.counter)
        require.Equal(ct, expected, actual, "counter should reach expected value")
    }, 5*time.Second, 100*time.Millisecond)
    ```
@@ -578,8 +579,8 @@ test.EventuallyIntMetric(t, 0, metrics.waitingTransactionsQueueSize,
 ```go
 // Use EventuallyWithT for clear failure messages
 require.EventuallyWithT(t, func(ct *assert.CollectT) {
-    require.Equal(ct, 10, test.GetIntMetricValue(t, metrics.gdgTxProcessedTotal))
-    require.Equal(ct, 8, test.GetIntMetricValue(t, metrics.gdgValidatedTxProcessedTotal))
+    require.Equal(ct, 10, test.GetIntMetricValue(ct, metrics.gdgTxProcessedTotal))
+    require.Equal(ct, 8, test.GetIntMetricValue(ct, metrics.gdgValidatedTxProcessedTotal))
 }, 2*time.Second, 200*time.Millisecond)
 ```
 

--- a/docker/test/common.go
+++ b/docker/test/common.go
@@ -152,7 +152,7 @@ func monitorMetric(t *testing.T, metricsPort string, metricsTLS *connection.TLSC
 	currentNumberOfTxs := test.GetMetricValueFromURL(t, metricsURL, monitoredMetric, tlsConf)
 	t.Logf("Check the load generator metrics from: %s", metricsURL)
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
-		committedTxs := test.GetMetricValueFromURL(t, metricsURL, monitoredMetric, tlsConf)
+		committedTxs := test.GetMetricValueFromURL(ct, metricsURL, monitoredMetric, tlsConf)
 		require.Greater(ct, committedTxs, currentNumberOfTxs+waitForCount)
 	}, 15*time.Minute, 100*time.Millisecond)
 }

--- a/integration/runner/postgres.go
+++ b/integration/runner/postgres.go
@@ -80,12 +80,13 @@ func StartPostgresCluster(ctx context.Context, t *testing.T) (*PostgresClusterCo
 	}
 
 	t.Log("starting postgres cluster")
-	cluster.addPrimaryNode(ctx, t)
-	cluster.addSecondaryNode(ctx, t)
-
+	// Registered before startup: adding a node starts its container and can then fail (for example
+	// its readiness wait times out), and without this the containers would leak.
 	t.Cleanup(func() {
 		cluster.stopAndRemoveCluster(t)
 	})
+	cluster.addPrimaryNode(ctx, t)
+	cluster.addSecondaryNode(ctx, t)
 
 	clusterConnections := cluster.getNodesConnections(t)
 	// After the initial connection, we create a testing-db that will be used by the vc-service.
@@ -156,7 +157,7 @@ func (cc *PostgresClusterController) addSecondaryNode(ctx context.Context, t *te
 func ensurePostgresFullyReady(t *testing.T, node *testdb.DatabaseContainer) {
 	t.Helper()
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
-		output := node.GetContainerLogs(t)
+		output := node.GetContainerLogs(ct)
 		count := strings.Count(output, testdb.PostgresReadinesssOutput)
 		require.GreaterOrEqual(ct, count, 2)
 	}, 45*time.Second, 250*time.Millisecond)

--- a/integration/runner/process.go
+++ b/integration/runner/process.go
@@ -185,8 +185,9 @@ func (p *ProcessWithConfig) writeConfig(t *testing.T, conf *config.SystemConfig)
 	p.configFilePath = config.CreateTempConfigFromTemplate(t, p.params.Template, &s)
 }
 
-// requireRunning fails the test immediately if the process has already exited.
-func (p *ProcessWithConfig) requireRunning(t *testing.T) {
+// requireRunning fails immediately if the process has already exited. It takes a [test.TestingT] so
+// a polling condition can pass its [assert.CollectT] and fail only that tick.
+func (p *ProcessWithConfig) requireRunning(t test.TestingT) {
 	t.Helper()
 	if p == nil || p.process == nil {
 		return
@@ -194,7 +195,7 @@ func (p *ProcessWithConfig) requireRunning(t *testing.T) {
 
 	select {
 	case err := <-p.process.Wait():
-		t.Fatalf("Process [%s] exited unexpectedly: %v", p.params.Name, err)
+		require.Failf(t, "process exited unexpectedly", "[%s]: %v", p.params.Name, err)
 	default:
 	}
 }

--- a/integration/runner/runtime.go
+++ b/integration/runner/runtime.go
@@ -672,7 +672,7 @@ func (c *CommitterRuntime) ensureAtLeastLastCommittedBlockNumber(t *testing.T, b
 	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Minute)
 	defer cancel()
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
-		c.requireAllServicesAreRunning(t)
+		c.requireAllServicesAreRunning(ct)
 		nextBlock, err := c.CoordinatorClient.GetNextBlockNumberToCommit(ctx, nil)
 		require.NoError(ct, err)
 		require.NotNil(ct, nextBlock)
@@ -680,8 +680,9 @@ func (c *CommitterRuntime) ensureAtLeastLastCommittedBlockNumber(t *testing.T, b
 	}, 2*time.Minute, 250*time.Millisecond)
 }
 
-// requireAllServicesAreRunning fails the test if any managed process has exited unexpectedly.
-func (c *CommitterRuntime) requireAllServicesAreRunning(t *testing.T) {
+// requireAllServicesAreRunning fails if any managed process has exited unexpectedly. It takes a
+// [test.TestingT] so a polling condition can pass its [assert.CollectT] and fail only that tick.
+func (c *CommitterRuntime) requireAllServicesAreRunning(t test.TestingT) {
 	t.Helper()
 	for _, p := range c.serverProcesses() {
 		p.requireRunning(t)

--- a/integration/runner/yugabyte.go
+++ b/integration/runner/yugabyte.go
@@ -13,6 +13,7 @@ import (
 	"net"
 	"path"
 	"regexp"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -54,6 +55,12 @@ const (
 	networkPrefix = "sc_yuga_net_"
 	masterPort    = "7100"
 	tabletPort    = "9100"
+
+	// ybAdminTimeout bounds a single yb-admin invocation. Its own default is 60s, which is the
+	// entire budget of the waits in startNodes: an attempt that cannot reach the leader master
+	// would consume the whole retry window, leaving the wait with one sample instead of hundreds,
+	// and would still be running when the wait gives up. Keep this well below those waits.
+	ybAdminTimeout = 5 * time.Second
 
 	// MasterNode represents yugabyte master db node.
 	MasterNode = "master"
@@ -109,11 +116,12 @@ func StartYugaCluster(ctx context.Context, t *testing.T, numberOfMasters, number
 	for range numberOfTablets {
 		cluster.createNode(TabletNode)
 	}
-	cluster.startNodes(ctx, t)
-
+	// Registered before startup: startNodes starts the containers and can then fail (for example
+	// its wait for a master quorum times out), and without this the containers would leak.
 	t.Cleanup(func() {
 		cluster.stopAndRemoveCluster(t)
 	})
+	cluster.startNodes(ctx, t)
 
 	// In YugabyteDB, masters manage cluster metadata (tablet locations, schema,
 	// Raft leadership) while tservers handle all SQL read/write operations.
@@ -208,7 +216,7 @@ func (cc *YugaClusterController) startNodes(ctx context.Context, t *testing.T) {
 	// registrations, create system tables, or serve any metadata requests.
 	expectedMasters := len(maps.Collect(cc.IterNodesByRole(MasterNode)))
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
-		require.Equal(ct, expectedMasters, strings.Count(cc.listAllMasters(t), "ALIVE"))
+		require.Equal(ct, expectedMasters, strings.Count(cc.listAllMasters(ct), "ALIVE"))
 	}, time.Minute, time.Millisecond*100)
 
 	// Wait for each tserver to finish bootstrapping (syncing data to disk).
@@ -222,7 +230,7 @@ func (cc *YugaClusterController) startNodes(ctx context.Context, t *testing.T) {
 	// to serve queries reliably.
 	expectedTablets := len(maps.Collect(cc.IterNodesByRole(TabletNode)))
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
-		require.Equal(ct, expectedTablets, strings.Count(cc.runYBAdmin(t, "list_all_tablet_servers"), "ALIVE"))
+		require.Equal(ct, expectedTablets, strings.Count(cc.runYBAdmin(ct, "list_all_tablet_servers"), "ALIVE"))
 	}, time.Minute, time.Millisecond*500)
 
 	// Set the cluster-level placement policy to ensure the load balancer
@@ -275,25 +283,26 @@ func (cc *YugaClusterController) verifyTransactionTableRF(t *testing.T) {
 		return
 	}
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
-		output := cc.runYBAdmin(t, "list_tablets", "system", "transactions", "0", "include_followers")
+		output := cc.runYBAdmin(ct, "list_tablets", "system", "transactions", "0", "include_followers")
 		for _, n := range cc.IterNodesByRole(TabletNode) {
 			assert.Contains(ct, output, n.Name)
 		}
 	}, 2*time.Minute, 500*time.Millisecond)
 }
 
-func (cc *YugaClusterController) listAllMasters(t *testing.T) string {
+func (cc *YugaClusterController) listAllMasters(t test.TestingT) string {
 	t.Helper()
 	output := cc.runYBAdmin(t, "list_all_masters")
 	require.NotEmpty(t, output, "Could not get yb-admin output from any node")
 	return output
 }
 
-func (cc *YugaClusterController) runYBAdmin(t *testing.T, args ...string) string {
+func (cc *YugaClusterController) runYBAdmin(t test.TestingT, args ...string) string {
 	t.Helper()
 	cmd := append([]string{
 		"/home/yugabyte/bin/yb-admin",
 		"-master_addresses", cc.getMasterAddresses(),
+		"-timeout_ms", strconv.Itoa(int(ybAdminTimeout.Milliseconds())),
 	}, args...)
 	var output string
 	for _, n := range cc.nodes {

--- a/integration/test/keep_alive_test.go
+++ b/integration/test/keep_alive_test.go
@@ -66,8 +66,9 @@ type (
 	}
 )
 
-// value returns the gauge's current value.
-func (g metricsGetter) value(t *testing.T) int {
+// value returns the gauge's current value. It takes a [test.TestingT] so a polling condition can
+// pass its [assert.CollectT] instead of the test's own T.
+func (g metricsGetter) value(t test.TestingT) int {
 	t.Helper()
 	return test.GetMetricValueFromURL(t, g.url, g.name, g.tlsConfig)
 }
@@ -171,7 +172,7 @@ func TestKeepAliveSidecarStreamSlotRelease(t *testing.T) {
 
 	// Both the intercepted connection and conn2 are now open on the server.
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
-		require.Equal(ct, prevActiveConnections+2, gauge.value(t))
+		require.Equal(ct, prevActiveConnections+2, gauge.value(ct))
 	}, 30*time.Second, 200*time.Millisecond)
 
 	blockMessages(t, proxy)
@@ -179,7 +180,7 @@ func TestKeepAliveSidecarStreamSlotRelease(t *testing.T) {
 	// Keep-alive closes the dead connection: the server reports one fewer active
 	// connection (conn2 stays open).
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
-		require.Equal(ct, prevActiveConnections+1, gauge.value(t))
+		require.Equal(ct, prevActiveConnections+1, gauge.value(ct))
 	}, maxConnectionClosingTime, 500*time.Millisecond)
 
 	// And the stream slot it held is released for new clients.
@@ -249,7 +250,7 @@ func blockAndWaitForServerClose(t *testing.T, proxy *toxiclient.Proxy, gauge met
 
 	// The server counts the new connection.
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
-		require.Equal(ct, prevActiveConnections+1, gauge.value(t))
+		require.Equal(ct, prevActiveConnections+1, gauge.value(ct))
 	}, 30*time.Second, 200*time.Millisecond)
 
 	blockMessages(t, proxy)
@@ -257,7 +258,7 @@ func blockAndWaitForServerClose(t *testing.T, proxy *toxiclient.Proxy, gauge met
 	// The server's keep-alive detects the silent connection and closes it itself,
 	// so the active-connection count returns to the baseline.
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
-		require.Equal(ct, prevActiveConnections, gauge.value(t))
+		require.Equal(ct, prevActiveConnections, gauge.value(ct))
 	}, maxConnectionClosingTime, 500*time.Millisecond)
 }
 

--- a/integration/test/loadgen_test.go
+++ b/integration/test/loadgen_test.go
@@ -82,7 +82,7 @@ func TestLoadGenWithTLSModes(t *testing.T) {
 					require.NoError(t, err)
 					require.EventuallyWithT(t, func(ct *assert.CollectT) {
 						count := test.GetMetricValueFromURL(
-							t, metricsURL, "loadgen_transaction_committed_total", metricsClientTLSConfig,
+							ct, metricsURL, "loadgen_transaction_committed_total", metricsClientTLSConfig,
 						)
 						t.Logf("loadgen_transaction_committed_total: %d", count)
 						require.Greater(ct, count, 500)

--- a/utils/test/metrics.go
+++ b/utils/test/metrics.go
@@ -35,18 +35,21 @@ func CheckMetrics(t *testing.T, url string, tlsConfig *tls.Config, expectedMetri
 }
 
 // GetMetricValueFromURL reads the metrics endpoint and fetch the value of a specific metric.
-func GetMetricValueFromURL(t *testing.T, url, metricName string, tlsConfig *tls.Config) int {
+func GetMetricValueFromURL(t TestingT, url, metricName string, tlsConfig *tls.Config) int {
 	t.Helper()
 	metricsOutput := getMetricsFromURL(t, url, tlsConfig)
 	r, err := regexp.Compile(`(?m)^` + metricName + `\s+([\d.]+)`)
 	require.NoError(t, err)
 	m := r.FindStringSubmatch(metricsOutput)
+	// Without this, a metric that is not exported yet indexes an empty match and panics -- which,
+	// from a polling goroutine, takes the whole test binary down.
+	require.Lenf(t, m, 2, "metric [%s] not found", metricName)
 	val, err := strconv.ParseFloat(m[1], 64)
 	require.NoError(t, err)
 	return int(math.Round(val))
 }
 
-func getMetricsFromURL(t *testing.T, url string, tlsConfig *tls.Config) string {
+func getMetricsFromURL(t TestingT, url string, tlsConfig *tls.Config) string {
 	t.Helper()
 	client := &http.Client{
 		Transport: &http.Transport{
@@ -61,7 +64,7 @@ func getMetricsFromURL(t *testing.T, url string, tlsConfig *tls.Config) string {
 		require.NotNil(ct, resp)
 		require.Equal(ct, http.StatusOK, resp.StatusCode)
 		b, err := io.ReadAll(resp.Body)
-		require.NoError(t, err)
+		require.NoError(ct, err)
 		require.NoError(ct, resp.Body.Close())
 		val = string(b)
 	}, time.Minute, 100*time.Millisecond)
@@ -69,7 +72,7 @@ func getMetricsFromURL(t *testing.T, url string, tlsConfig *tls.Config) string {
 }
 
 // GetMetricValue returns the value of a prometheus metric.
-func GetMetricValue(t *testing.T, m prometheus.Metric) float64 {
+func GetMetricValue(t TestingT, m prometheus.Metric) float64 {
 	t.Helper()
 	gm := promgo.Metric{}
 	require.NoError(t, m.Write(&gm))
@@ -92,7 +95,7 @@ func GetMetricValue(t *testing.T, m prometheus.Metric) float64 {
 }
 
 // GetIntMetricValue returns the value of a prometheus metric, rounded to the nearest integer.
-func GetIntMetricValue(t *testing.T, m prometheus.Metric) int {
+func GetIntMetricValue(t TestingT, m prometheus.Metric) int {
 	t.Helper()
 	val := GetMetricValue(t, m)
 	return int(math.Round(val))
@@ -110,7 +113,7 @@ func EventuallyIntMetric( //nolint:revive // number of arguments is derived from
 ) {
 	t.Helper()
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
-		v := GetIntMetricValue(t, m)
+		v := GetIntMetricValue(ct, m)
 		require.Equal(ct, expected, v)
 	}, waitFor, tick, msgAndArgs...)
 }

--- a/utils/test/require_proto.go
+++ b/utils/test/require_proto.go
@@ -15,15 +15,9 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-type tHelper = interface {
-	Helper()
-}
-
 // RequireProtoEqual verifies that two proto are equal.
-func RequireProtoEqual(t require.TestingT, expected, actual proto.Message) {
-	if h, ok := t.(tHelper); ok {
-		h.Helper()
-	}
+func RequireProtoEqual(t TestingT, expected, actual proto.Message) {
+	t.Helper()
 	require.Truef(
 		t,
 		proto.Equal(expected, actual),
@@ -35,11 +29,9 @@ func RequireProtoEqual(t require.TestingT, expected, actual proto.Message) {
 
 // RequireProtoElementsMatch verifies that two arrays of proto have the same elements.
 func RequireProtoElementsMatch[T proto.Message](
-	t require.TestingT, expected, actual []T, msgAndArgs ...any,
+	t TestingT, expected, actual []T, msgAndArgs ...any,
 ) {
-	if h, ok := t.(tHelper); ok {
-		h.Helper()
-	}
+	t.Helper()
 	if expected == nil {
 		require.Nil(t, actual, msgAndArgs...)
 		return

--- a/utils/test/testing_t.go
+++ b/utils/test/testing_t.go
@@ -1,0 +1,25 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package test
+
+import "github.com/stretchr/testify/require"
+
+// TestingT is the assertion surface shared by [testing.T] and [assert.CollectT]: what
+// [require.TestingT] carries, plus Helper. A helper that takes it can be called both from a test and
+// from inside an [require.Eventually] condition — which runs on its own goroutine and may still be
+// running after the test completed, where asserting on the test's own T panics the whole test binary
+// rather than failing one test.
+//
+// Prefer this over a bare [require.TestingT], which cannot call Helper and so reports failures against
+// the helper's own line instead of the caller's. [testing.TB] cannot serve either: it is sealed by an
+// unexported method, so an [assert.CollectT] can never implement it. Use [testing.TB] only for a
+// helper that needs the rest of it (Cleanup, TempDir, Context, ...) and is never called from a
+// condition.
+type TestingT interface {
+	require.TestingT
+	Helper()
+}

--- a/utils/testapp/apptest.go
+++ b/utils/testapp/apptest.go
@@ -44,7 +44,8 @@ func EnsurePersistedTxStatus(
 }
 
 // RequireStatus fails if the expected status does not appear in the statuses list.
-func RequireStatus(t require.TestingT, expected *committerpb.TxStatus, statuses []*committerpb.TxStatus) {
+func RequireStatus(t test.TestingT, expected *committerpb.TxStatus, statuses []*committerpb.TxStatus) {
+	t.Helper()
 	var actualStatus *committerpb.TxStatus
 	for _, status := range statuses {
 		if status.Ref.TxId == expected.Ref.TxId {

--- a/utils/testdb/container.go
+++ b/utils/testdb/container.go
@@ -84,6 +84,12 @@ var (
 	passwordRegex = regexp.MustCompile(`(?i)(?m)^password:\s*(.+)$`)
 )
 
+// tLogger recovers Logf, which [test.TestingT] does not carry because an [assert.CollectT] has no
+// equivalent for it.
+type tLogger = interface {
+	Logf(format string, args ...any)
+}
+
 // DatabaseContainer manages the execution of an instance of a dockerized DB for tests.
 type DatabaseContainer struct {
 	Name         string
@@ -406,7 +412,7 @@ func (dc *DatabaseContainer) streamLogs() {
 }
 
 // GetContainerLogs return the output of the DatabaseContainer.
-func (dc *DatabaseContainer) GetContainerLogs(t *testing.T) string {
+func (dc *DatabaseContainer) GetContainerLogs(t test.TestingT) string {
 	t.Helper()
 	var outputBuffer bytes.Buffer
 	require.NoError(t, dc.client.Logs(docker.LogsOptions{
@@ -421,8 +427,14 @@ func (dc *DatabaseContainer) GetContainerLogs(t *testing.T) string {
 }
 
 // StopAndRemoveContainer stops and removes the db container from the docker engine.
+// It is a no-op for a container that was never created, so a cluster teardown registered before
+// startup can run after a partial start.
 func (dc *DatabaseContainer) StopAndRemoveContainer(t *testing.T) {
 	t.Helper()
+	if dc.containerID == "" {
+		return
+	}
+
 	dc.StopContainer(t)
 	require.NoError(t, dc.client.RemoveContainer(docker.RemoveContainerOptions{
 		ID:    dc.ContainerID(),
@@ -456,10 +468,12 @@ func (dc *DatabaseContainer) ReadPasswordFromContainer(t *testing.T, filePath st
 }
 
 // ExecuteCommand executes a command and returns the container output.
-func (dc *DatabaseContainer) ExecuteCommand(t *testing.T, cmd []string) string {
+func (dc *DatabaseContainer) ExecuteCommand(t test.TestingT, cmd []string) string {
 	t.Helper()
 	require.NotNil(t, dc.client)
-	t.Logf("executing %s", strings.Join(cmd, " "))
+	if l, ok := t.(tLogger); ok {
+		l.Logf("executing %s", strings.Join(cmd, " "))
+	}
 
 	var stdout strings.Builder
 	var stderr strings.Builder
@@ -487,7 +501,7 @@ func (dc *DatabaseContainer) ExecuteCommand(t *testing.T, cmd []string) string {
 func (dc *DatabaseContainer) EnsureNodeReadinessByLogs(t *testing.T, requiredOutput string) {
 	t.Helper()
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
-		output := dc.GetContainerLogs(t)
+		output := dc.GetContainerLogs(ct)
 		require.Contains(ct, output, requiredOutput)
 	}, 45*time.Second, 250*time.Millisecond)
 }

--- a/utils/testdb/container_test.go
+++ b/utils/testdb/container_test.go
@@ -1,0 +1,86 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package testdb
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	docker "github.com/fsouza/go-dockerclient"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// GetContainerLogs and ExecuteCommand accept a [test.TestingT] so that a polling condition can
+// pass its [assert.CollectT]. That is what stops a probe which is still running after its test
+// completed from panicking the whole test binary instead of failing one test. These tests pin the
+// runtime half of that contract: a failing probe fails only the tick, the wait keeps retrying, and
+// the test's own T is never touched.
+func TestContainerProbeFailsTheTickNotTheTest(t *testing.T) {
+	t.Parallel()
+	dc := newContainerWithBogusID(t)
+
+	for _, tc := range []struct {
+		name  string
+		probe func(ct *assert.CollectT)
+	}{
+		{name: "GetContainerLogs", probe: func(ct *assert.CollectT) { dc.GetContainerLogs(ct) }},
+		{name: "ExecuteCommand", probe: func(ct *assert.CollectT) { dc.ExecuteCommand(ct, []string{"true"}) }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			// A stand-in for the outer T, so the wait's own verdict is observable without this
+			// test failing on it.
+			var outer errorRecorder
+			satisfied := assert.EventuallyWithT(&outer, tc.probe, 300*time.Millisecond, 50*time.Millisecond)
+
+			require.False(t, satisfied, "a failing probe must not satisfy the condition")
+			require.NotZero(t, outer.count(), "the wait must report the failure")
+		})
+	}
+}
+
+// StopAndRemoveContainer must tolerate a node whose container was never created, so that a cluster
+// teardown registered before startup can still run after a partial start.
+func TestStopAndRemoveContainerWithoutContainerIsNoOp(t *testing.T) {
+	t.Parallel()
+	dc := &DatabaseContainer{Name: "sc_test_never_started"}
+
+	dc.StopAndRemoveContainer(t)
+}
+
+func newContainerWithBogusID(t *testing.T) *DatabaseContainer {
+	t.Helper()
+	client, err := docker.NewClientFromEnv()
+	if err != nil {
+		t.Skipf("no docker environment available: %v", err)
+	}
+	return &DatabaseContainer{
+		Name:        "sc_test_no_such_container",
+		client:      client,
+		containerID: "sc_test_no_such_container",
+	}
+}
+
+// errorRecorder implements [assert.TestingT] by counting reported failures.
+type errorRecorder struct {
+	mu       sync.Mutex
+	failures int
+}
+
+func (r *errorRecorder) Errorf(string, ...any) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.failures++
+}
+
+func (r *errorRecorder) count() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.failures
+}


### PR DESCRIPTION
#### Type of change

- Bug fix
- Test update

#### Description

- Add `test.TestingT`: `require.TestingT` plus `Helper()`, the assertion surface both a `testing.T` and
  an `assert.CollectT` provide. A bare `require.TestingT` cannot call `Helper`, so helpers taking it
  either skipped it (`testapp.RequireStatus`) or open-coded a type assertion for it
  (`test.RequireProtoEqual`); `testing.TB` cannot serve at all, being sealed by an unexported method
  that no `CollectT` can satisfy.
- Adopt it for every existing `require.TestingT` holder, calling `Helper` directly and dropping the
  open-coded assertions: `test.RequireProtoEqual`, `RequireProtoElementsMatch`, `testapp.RequireStatus`.
- Widen every helper a polling condition reaches from `*testing.T` to `test.TestingT`, and pass the
  condition's `assert.CollectT` at those call sites, so a failing probe fails the tick rather than the
  test: `DatabaseContainer.GetContainerLogs` and `ExecuteCommand`, `ProcessWithConfig.requireRunning`,
  `CommitterRuntime.requireAllServicesAreRunning`, `YugaClusterController.runYBAdmin` and
  `listAllMasters`, `test.GetMetricValueFromURL`, `GetMetricValue` and `GetIntMetricValue`, and
  `metricsGetter.value`.
- `requireRunning` reports through `require.Failf` rather than `t.Fatalf`, which a `CollectT` cannot
  offer; `ExecuteCommand` keeps its "executing" log only when a `*testing.T` was passed.
- `integration/runner`: bound `yb-admin` with `-timeout_ms` (`ybAdminTimeout`, 5s). Its own default is
  60s, which is the entire budget of the waits in `startNodes`.
- `integration/runner`: register the cluster teardown before the nodes start, in both
  `StartYugaCluster` and `StartPostgresCluster`; `StopAndRemoveContainer` is a no-op for a container
  that was never created, so the earlier registration is safe after a partial start.
- `utils/test`: fix two single-line faults in the metrics helpers — `getMetricsFromURL` asserted one of
  its reads on the outer `t` while every sibling used `ct`, and `GetMetricValueFromURL` indexed an
  empty regexp match when the metric is absent, panicking instead of failing.
- Add `utils/testdb/container_test.go`, pinning that a failing container probe fails only the tick and
  that teardown tolerates a container that was never created.
- `tests` skill: every metrics example read its value with the outer `t` from inside a `CollectT`
  closure, teaching the defect this change fixes; they now pass `ct`, and the rule is stated along with
  when to reach for `test.TestingT` over `require.TestingT` or `testing.TB`.

#### Additional details (Optional)

`ybAdminTimeout` is 5s because a healthy `list_all_masters` on a 3-master/3-tserver cluster measures
p50 97ms / p95 105ms / max 105ms over 20 samples, three orders of magnitude under `yb-admin`'s 60s
default.

The 15 `testing.TB` helpers are left as they are: all already call `tb.Helper()`, and most need parts
of `TB` that `test.TestingT` does not carry (`Cleanup`, `Context`, `TempDir`). `utils/testdb` keeps one
`tLogger` assertion so `ExecuteCommand` can still log for a `*testing.T`; dropping that log instead
would remove the need for it.

Three things are deliberately left out. `DatabaseTestEnv.CountStatus` cannot be widened the same way
because it draws its context from `t.Context()`, which a `CollectT` has no equivalent for, so the
`CountStatus` calls inside polling conditions are untouched. About twenty polling conditions in unit
tests still pass `t` to helpers that only read in-memory state, where no probe can outlive its wait.
And #739's request to *abort promptly* on a crashed service is unaddressed: the crash is now reported
through the `CollectT` rather than swallowed, but the wait still runs to its deadline.

To reproduce the original failure, point `runYBAdmin` at a host that does not resolve, bound it to 15s,
and shorten the `startNodes` master wait to 10s, so a probe is guaranteed to return after the subtest
has completed. On `main` that panics the test binary and every parallel test fails with it; with this
change only the faulted subtests fail.

#### Related issues

- resolves #755
- resolves partly #739
