### PR TITLE
[test] Make container teardown tolerate an already-exited container

### DIFF
--- a/utils/testdb/container.go
+++ b/utils/testdb/container.go
@@ -427,8 +427,11 @@ func (dc *DatabaseContainer) GetContainerLogs(t test.TestingT) string {
 }
 
 // StopAndRemoveContainer stops and removes the db container from the docker engine.
-// It is a no-op for a container that was never created, so a cluster teardown registered before
-// startup can run after a partial start.
+//
+// It is idempotent: a container that was never created, has already exited, or is already gone is not
+// an error, since the postcondition — the container is not running — already holds. A cluster teardown
+// therefore survives both a partial start and a node that exited on its own, as a yugabyte tserver does
+// once the masters it depends on are stopped.
 func (dc *DatabaseContainer) StopAndRemoveContainer(t *testing.T) {
 	t.Helper()
 	if dc.containerID == "" {
@@ -436,17 +439,31 @@ func (dc *DatabaseContainer) StopAndRemoveContainer(t *testing.T) {
 	}
 
 	dc.StopContainer(t)
-	require.NoError(t, dc.client.RemoveContainer(docker.RemoveContainerOptions{
+	err := dc.client.RemoveContainer(docker.RemoveContainerOptions{
 		ID:    dc.ContainerID(),
 		Force: true,
-	}))
+	})
+	var noSuchContainer *docker.NoSuchContainer
+	if errors.As(err, &noSuchContainer) {
+		return
+	}
+	require.NoError(t, err)
 	t.Logf("Container %s stopped and removed successfully", dc.ContainerID())
 }
 
-// StopContainer stops db container.
+// StopContainer stops db container. A container that has already exited, or that no longer exists, is
+// not an error — see [DatabaseContainer.StopAndRemoveContainer].
 func (dc *DatabaseContainer) StopContainer(t *testing.T) {
 	t.Helper()
-	require.NoError(t, dc.client.StopContainer(dc.ContainerID(), 10))
+	err := dc.client.StopContainer(dc.ContainerID(), 10)
+	var (
+		notRunning      *docker.ContainerNotRunning
+		noSuchContainer *docker.NoSuchContainer
+	)
+	if errors.As(err, &notRunning) || errors.As(err, &noSuchContainer) {
+		return
+	}
+	require.NoError(t, err)
 }
 
 // ContainerID returns the container ID.

--- a/utils/testdb/container_test.go
+++ b/utils/testdb/container_test.go
@@ -7,13 +7,18 @@ SPDX-License-Identifier: Apache-2.0
 package testdb
 
 import (
+	"context"
+	"fmt"
 	"sync"
 	"testing"
 	"time"
 
 	docker "github.com/fsouza/go-dockerclient"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger/fabric-x-committer/utils/test"
 )
 
 // GetContainerLogs and ExecuteCommand accept a [test.TestingT] so that a polling condition can
@@ -51,6 +56,34 @@ func TestStopAndRemoveContainerWithoutContainerIsNoOp(t *testing.T) {
 	t.Parallel()
 	dc := &DatabaseContainer{Name: "sc_test_never_started"}
 
+	dc.StopAndRemoveContainer(t)
+}
+
+// A cluster node can exit on its own before teardown reaches it — a yugabyte tserver does once the
+// masters it depends on are stopped — so teardown must not fail on a container that is already gone.
+// Both halves of "already gone" are covered: exited but still present, and removed outright.
+func TestStopAndRemoveContainerIsIdempotent(t *testing.T) {
+	t.Parallel()
+	dc := &DatabaseContainer{
+		Name:         fmt.Sprintf("%s_teardown_%s", test.DockerNamesPrefix, uuid.NewString()[:8]),
+		Image:        DefaultPostgresImage,
+		DatabaseType: PostgresDBType,
+	}
+	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Minute)
+	t.Cleanup(cancel)
+	dc.StartContainer(ctx, t)
+	// Reap directly rather than through the method under test, so a failure here cannot leak the
+	// container. Force removal of an already-removed container is the expected path once the test
+	// body has run.
+	t.Cleanup(func() {
+		_ = dc.client.RemoveContainer(docker.RemoveContainerOptions{ID: dc.ContainerID(), Force: true})
+	})
+
+	// Stop it behind teardown's back, as a node that exits by itself would.
+	require.NoError(t, dc.client.StopContainer(dc.ContainerID(), 10))
+	dc.StopAndRemoveContainer(t)
+
+	// And again, now that the container no longer exists at all.
 	dc.StopAndRemoveContainer(t)
 }
 


### PR DESCRIPTION
#### Type of change

- Bug fix
- Test update

#### Description

- `utils/testdb`: `StopContainer` no longer fails when the container has already exited or no longer
  exists, and `StopAndRemoveContainer` tolerates one that is already gone — making the pair idempotent
  for a container in any state, alongside the guard it already had for one that was never created. The
  typed `errors.As` checks mirror the `*docker.ContainerAlreadyRunning` handling in `start`.
- Add `TestStopAndRemoveContainerIsIdempotent`: it starts a real container, stops it out of band the way
  a self-exiting node would, then tears it down twice.

#### Additional details (Optional)

The graceful stop is kept rather than relying on `RemoveContainer`'s `Force: true`, because
`StopAndRemoveContainer` is also the mid-test action that kills a node
(`DBClusterController.StopAndRemoveSingleNodeByIndex`): force removal would replace SIGTERM-with-grace by
an immediate SIGKILL and change what the resiliency scenarios exercise.

To see the effect, revert `utils/testdb/container.go` and keep the test: it fails at `container.go:449`,
the line that failed in CI. The test reaps its container directly through the docker client in
`t.Cleanup`, not through the method under test, so a regression cannot leak it.

#### Related issues

- resolves #760
