### PR TITLE
[metrics] Extract duplicated namespace, subsystem and name literals in service metrics to consts

### DIFF
--- a/loadgen/metrics/metrics.go
+++ b/loadgen/metrics/metrics.go
@@ -18,6 +18,8 @@ import (
 	"github.com/hyperledger/fabric-x-committer/utils/monitoring/promutil"
 )
 
+const namespace = "loadgen"
+
 type (
 	// PerfMetrics is a struct that contains the metrics for the block generator.
 	PerfMetrics struct {
@@ -69,62 +71,62 @@ func NewLoadgenServiceMetrics(c *Config, counter *workload.TxCounter) *PerfMetri
 		Provider:       p,
 		latencyTracker: latencyTracker,
 		blockSentTotal: p.NewCounter(prometheus.CounterOpts{
-			Namespace: "loadgen",
+			Namespace: namespace,
 			Name:      "block_sent_total",
 			Help:      "Total number of blocks sent by the block generator",
 		}),
 		blockReceivedTotal: p.NewCounter(prometheus.CounterOpts{
-			Namespace: "loadgen",
+			Namespace: namespace,
 			Name:      "block_received_total",
 			Help:      "Total number of blocks received by the block generator",
 		}),
 		transactionSentTotal: p.NewCounter(prometheus.CounterOpts{
-			Namespace: "loadgen",
+			Namespace: namespace,
 			Name:      "transaction_sent_total",
 			Help:      "Total number of transactions sent by the block generator",
 		}),
 		transactionReceivedTotal: p.NewCounter(prometheus.CounterOpts{
-			Namespace: "loadgen",
+			Namespace: namespace,
 			Name:      "transaction_received_total",
 			Help:      "Total number of transactions received by the block generator",
 		}),
 		transactionCommittedTotal: p.NewCounter(prometheus.CounterOpts{
-			Namespace: "loadgen",
+			Namespace: namespace,
 			Name:      "transaction_committed_total",
 			Help:      "Total number of transaction commit statuses received by the block generator",
 		}),
 		transactionAbortedTotal: p.NewCounter(prometheus.CounterOpts{
-			Namespace: "loadgen",
+			Namespace: namespace,
 			Name:      "transaction_aborted_total",
 			Help:      "Total number of transaction abort statuses received by the block generator",
 		}),
 		validLatency: p.NewHistogram(prometheus.HistogramOpts{
-			Namespace: "loadgen",
+			Namespace: namespace,
 			Name:      "valid_transaction_latency_seconds",
 			Help:      "Latency of valid transactions in seconds",
 			Buckets:   latencyTracker.buckets,
 		}),
 		invalidLatency: p.NewHistogram(prometheus.HistogramOpts{
-			Namespace: "loadgen",
+			Namespace: namespace,
 			Name:      "invalid_transaction_latency_seconds",
 			Help:      "Latency of invalid transactions in seconds",
 			Buckets:   latencyTracker.buckets,
 		}),
 		createdKeysTotal: p.NewCounterFunc(prometheus.CounterOpts{
-			Namespace: "loadgen",
+			Namespace: namespace,
 			Name:      "created_keys_total",
 			Help: "Total number of new keys the workload has introduced, each counted once when it is " +
 				"first created; some may never be committed (for example, when the transaction that " +
 				"creates the key aborts)",
 		}, func() float64 { return float64(counter.KeyStats().KeyFrontier) }),
 		referencedReadKeysTotal: p.NewCounterFunc(prometheus.CounterOpts{
-			Namespace: "loadgen",
+			Namespace: namespace,
 			Name:      "referenced_read_keys_total",
 			Help: "Total number of read-only accesses that reused an already-created key instead of " +
 				"introducing a new one",
 		}, func() float64 { return float64(counter.KeyStats().ReferencedReadKeys) }),
 		referencedWriteKeysTotal: p.NewCounterFunc(prometheus.CounterOpts{
-			Namespace: "loadgen",
+			Namespace: namespace,
 			Name:      "referenced_write_keys_total",
 			Help: "Total number of write accesses (read-write and blind-write) that reused an " +
 				"already-created key instead of introducing a new one",

--- a/scripts/metrics_doc_extract.py
+++ b/scripts/metrics_doc_extract.py
@@ -25,9 +25,18 @@ while repo_root_dir.parent != repo_root_dir:
         break
     repo_root_dir = repo_root_dir.parent
 
-# Pattern: New(Counter|Gauge|Histogram)(Vec|Func)?(prometheus.(Counter|Gauge|Histogram)Opts
+# Pattern: New[<Qualifier>](Counter|Gauge|Histogram)(Vec|Func)?[<type args>]([<provider>,]
+#          prometheus.(...)Opts
+# Matches the Provider methods (NewGauge(prometheus.GaugeOpts{...})), the free helpers that take
+# the provider first (NewChannelLenGauge(p, prometheus.GaugeOpts{...}, ch)), and generic helpers
+# instantiated explicitly (NewChannelLenGaugeVec[*pkg.Type](p, prometheus.GaugeOpts{...}, labels)).
+# The qualifier before the metric type is non-greedy so group(1) is always the type itself.
 # Captures: group(1)=metric type, group(2)=Vec, Func or None, group(3)=opts type
-metric_pattern = re.compile(r'New([A-Z][a-z]+)(Vec|Func)?\(prometheus\.([A-Z][a-z]+)Opts')
+metric_pattern = re.compile(
+    # The type-argument list allows one level of nesting, for a slice element like [[]*pkg.Type].
+    r'New[A-Za-z]*?([A-Z][a-z]+)(Vec|Func)?(?:\[(?:[^\[\]]|\[[^\]]*])*])?'
+    r'\((?:\s*[\w.]+\s*,)?\s*prometheus\.([A-Z][a-z]+)Opts'
+)
 
 # Pattern: package.FunctionName(..., monitoring.MetricsParameters
 # Captures: group(1)=package, group(2)=method name
@@ -36,6 +45,18 @@ params_usage_pattern = re.compile(r'(\w+)\.(\w+)\([^)]+,\s*(?:monitoring\.)?Metr
 # Pattern: FunctionName(..., monitoring.MetricsParameters — a helper in the file being parsed.
 # Captures: group(1)=function name
 local_params_usage_pattern = re.compile(r'(?<![\w.])(\w+)\([^)]+,\s*(?:monitoring\.)?MetricsParameters')
+
+# Pattern: identifier = "value" — a string constant declaration.
+# Captures: group(1)=identifier, group(2)=value
+string_const_pattern = re.compile(r'(?<![\w.])(\w+)\s*(?:string\s*)?=\s*"([^"]*)"')
+
+# Pattern: Namespace|Subsystem|Name|Help: identifier — an opts field given as a bare identifier.
+# Captures: group(1)=field, group(2)=identifier
+opts_field_ident_pattern = re.compile(r'\b(Namespace|Subsystem|Name|Help)\s*:\s*([A-Za-z_]\w*)\s*,')
+
+# Pattern: identifier := []string{...} — a label-name slice, usually shared by several metrics.
+# Captures: group(1)=identifier, group(2)=the slice literal
+string_slice_pattern = re.compile(r'(?<![\w.])(\w+)\s*:?=\s*(\[]string\{[^}]*})')
 
 
 def main():
@@ -56,6 +77,12 @@ def print_all_metrics_from_content(content: str):
     """Extract all metrics from Go source content in order of appearance."""
     # Join concatenated strings
     content = re.sub(r'"\s*\+\s*"', '', content)
+
+    # Inline string constants, so a metric that names its namespace, subsystem or name through a
+    # constant is still resolved. Without this the field reads as empty and the metric is dropped
+    # from the doc silently, which makes hoisting a repeated literal (as goconst asks) look safe
+    # when it is not.
+    content = inline_string_constants(content)
 
     # Collect all matches with their positions, sorted by position to maintain order.
     for pos, match_type, *rest in sorted(iter_all_matches(content)):
@@ -102,6 +129,24 @@ def print_all_metrics_from_content(content: str):
 
         # Extract metrics from the substituted function body
         print_all_metrics_from_content(func_body)
+
+
+def inline_string_constants(content: str) -> str:
+    """Replace identifiers declared as `name = "value"` or `name := []string{...}` with the value."""
+    constants = dict(string_const_pattern.findall(content))
+    if constants:
+        def substitute(match: re.Match) -> str:
+            field, identifier = match.group(1), match.group(2)
+            value = constants.get(identifier)
+            return f'{field}: "{value}"' if value is not None else match.group(0)
+
+        content = opts_field_ident_pattern.sub(substitute, content)
+
+    # Label slices are shared between metrics, so inline them too — extract_labels reads the
+    # literal. The declaration itself is left alone, hence the lookahead.
+    for name, literal in string_slice_pattern.findall(content):
+        content = re.sub(rf'(?<![\w.])({name})\b(?!\s*:?=)', literal.replace('\\', '\\\\'), content)
+    return content
 
 
 def iter_all_matches(content: str):

--- a/service/coordinator/dependencygraph/metrics.go
+++ b/service/coordinator/dependencygraph/metrics.go
@@ -12,6 +12,16 @@ import (
 	"github.com/hyperledger/fabric-x-committer/utils/monitoring"
 )
 
+const (
+	namespace = "coordinator"
+
+	subsystemGlobalDependencyGraph = "global_dependency_graph"
+	subsystemLocalDependencyGraph  = "local_dependency_graph"
+
+	nameInputTxBatchQueueSize = "input_tx_batch_queue_size"
+	nameTxProcessedTotal      = "tx_processed_total"
+)
+
 var bucket = []float64{.0001, .001, .002, .003, .004, .005, .01, .03, .05, .1, .3, .5, 1}
 
 type perfMetrics struct {
@@ -49,113 +59,113 @@ func newPerformanceMetrics(p *monitoring.Provider) *perfMetrics {
 	return &perfMetrics{
 		provider: p,
 		ldgInputTxBatchQueueSize: p.NewGauge(prometheus.GaugeOpts{
-			Namespace: "coordinator",
-			Subsystem: "local_dependency_graph",
-			Name:      "input_tx_batch_queue_size",
+			Namespace: namespace,
+			Subsystem: subsystemLocalDependencyGraph,
+			Name:      nameInputTxBatchQueueSize,
 			Help:      "Size of the input transaction batch queue of the local dependency graph manager",
 		}),
 		gdgInputTxBatchQueueSize: p.NewGauge(prometheus.GaugeOpts{
-			Namespace: "coordinator",
-			Subsystem: "global_dependency_graph",
-			Name:      "input_tx_batch_queue_size",
+			Namespace: namespace,
+			Subsystem: subsystemGlobalDependencyGraph,
+			Name:      nameInputTxBatchQueueSize,
 			Help:      "Size of the input transaction batch queue of the global dependency graph manager",
 		}),
 		gdgWaitingTxQueueSize: p.NewGauge(prometheus.GaugeOpts{
-			Namespace: "coordinator",
-			Subsystem: "global_dependency_graph",
+			Namespace: namespace,
+			Subsystem: subsystemGlobalDependencyGraph,
 			Name:      "size",
 			Help: "Size of the global dependency graph manager in terms " +
 				"of the number of transactions waiting to be processed",
 		}),
 		ldgTxProcessedTotal: p.NewCounter(prometheus.CounterOpts{
-			Namespace: "coordinator",
-			Subsystem: "local_dependency_graph",
-			Name:      "tx_processed_total",
+			Namespace: namespace,
+			Subsystem: subsystemLocalDependencyGraph,
+			Name:      nameTxProcessedTotal,
 			Help:      "Total number of new transactions processed by the local dependency graph manager",
 		}),
 		gdgTxProcessedTotal: p.NewCounter(prometheus.CounterOpts{
-			Namespace: "coordinator",
-			Subsystem: "global_dependency_graph",
-			Name:      "tx_processed_total",
+			Namespace: namespace,
+			Subsystem: subsystemGlobalDependencyGraph,
+			Name:      nameTxProcessedTotal,
 			Help:      "Total number of new transactions processed by the global dependency graph manager",
 		}),
 		gdgValidatedTxProcessedTotal: p.NewCounter(prometheus.CounterOpts{
-			Namespace: "coordinator",
-			Subsystem: "global_dependency_graph",
+			Namespace: namespace,
+			Subsystem: subsystemGlobalDependencyGraph,
 			Name:      "validated_tx_processed_total",
 			Help:      "Total number of validated transactions processed by the global dependency graph manager",
 		}),
 		gdgConstructionSeconds: p.NewHistogram(prometheus.HistogramOpts{
-			Namespace: "coordinator",
-			Subsystem: "global_dependency_graph",
+			Namespace: namespace,
+			Subsystem: subsystemGlobalDependencyGraph,
 			Name:      "construction_seconds",
 			Help: "Time spent adding a transaction batch to the global dependency graph " +
 				"in the global dependency graph manager",
 			Buckets: bucket,
 		}),
 		gdgConstructorWaitForLockSeconds: p.NewHistogram(prometheus.HistogramOpts{
-			Namespace:   "coordinator",
-			Subsystem:   "global_dependency_graph",
+			Namespace:   namespace,
+			Subsystem:   subsystemGlobalDependencyGraph,
 			Name:        "constructor_wait_for_lock_seconds",
 			Help:        "Time spent waiting for the lock in the constructor of the global dependency graph manager",
 			ConstLabels: map[string]string{},
 			Buckets:     bucket,
 		}),
 		gdgAddTxToGraphSeconds: p.NewHistogram(prometheus.HistogramOpts{
-			Namespace: "coordinator",
-			Subsystem: "global_dependency_graph",
+			Namespace: namespace,
+			Subsystem: subsystemGlobalDependencyGraph,
 			Name:      "add_tx_batch_to_graph_seconds",
 			Help:      "Time spent adding a transaction batch to the graph in the global dependency graph manager",
 			Buckets:   bucket,
 		}),
 		gdgUpdateDependencyDetectorSeconds: p.NewHistogram(prometheus.HistogramOpts{
-			Namespace: "coordinator",
-			Subsystem: "global_dependency_graph",
+			Namespace: namespace,
+			Subsystem: subsystemGlobalDependencyGraph,
 			Name:      "update_dependency_detector_seconds",
 			Help: "Time spent updating the dependency detector with a transaction batch " +
 				"in the global dependency graph manager",
 			Buckets: bucket,
 		}),
 		gdgValidatedTxProcessingSeconds: p.NewHistogram(prometheus.HistogramOpts{
-			Namespace: "coordinator",
-			Subsystem: "global_dependency_graph",
+			Namespace: namespace,
+			Subsystem: subsystemGlobalDependencyGraph,
 			Name:      "validated_tx_batch_processing_seconds",
 			Help: "Time spent processing a validated transaction batch in the global " +
 				"dependency graph manager",
 			Buckets: bucket,
 		}),
 		gdgValidatedTxProcessorWaitForLockSeconds: p.NewHistogram(prometheus.HistogramOpts{
-			Namespace: "coordinator",
-			Subsystem: "global_dependency_graph",
+			Namespace: namespace,
+			Subsystem: subsystemGlobalDependencyGraph,
 			Name:      "validated_tx_batch_processor_wait_for_lock_seconds",
 			Help: "Time spent waiting for the lock in the validated transaction " +
 				"processor of the global dependency graph manager",
 			Buckets: bucket,
 		}),
 		gdgRemoveDependentsOfValidatedTxSeconds: p.NewHistogram(prometheus.HistogramOpts{
-			Namespace: "coordinator",
-			Subsystem: "global_dependency_graph",
+			Namespace: namespace,
+			Subsystem: subsystemGlobalDependencyGraph,
 			Name:      "remove_dependents_of_validated_tx_batch_seconds",
 			Help: "Time spent removing the dependents of a validated transaction batch " +
 				"in the global dependency graph manager",
 			Buckets: bucket,
 		}),
 		gdgAddFreedTxSeconds: p.NewHistogram(prometheus.HistogramOpts{
-			Namespace: "coordinator",
-			Subsystem: "global_dependency_graph",
+			Namespace: namespace,
+			Subsystem: subsystemGlobalDependencyGraph,
 			Name:      "add_freed_tx_batch_seconds",
 			Help:      "Time spent adding a freed transaction batch to a queue in the global dependency graph manager",
 			Buckets:   bucket,
 		}),
 		gdgOutputFreedTxSeconds: p.NewHistogram(prometheus.HistogramOpts{
-			Namespace: "coordinator",
-			Subsystem: "global_dependency_graph",
+			Namespace: namespace,
+			Subsystem: subsystemGlobalDependencyGraph,
 			Name:      "output_freed_tx_batch_seconds",
 			Help:      "Time spent outputting a freed transaction batch in the global dependency graph manager",
 			Buckets:   bucket,
 		}),
 		dependentTransactionsQueueSize: p.NewGauge(prometheus.GaugeOpts{
-			Namespace: "coordinator",
+			Namespace: namespace,
 			Subsystem: "dependency_graph",
 			Name:      "dependent_transactions_queue_size",
 			Help:      "The number of transactions currently waiting on dependencies.",

--- a/service/coordinator/metrics.go
+++ b/service/coordinator/metrics.go
@@ -13,6 +13,13 @@ import (
 	"github.com/hyperledger/fabric-x-committer/utils/monitoring"
 )
 
+const (
+	namespace = "coordinator"
+
+	subsystemGRPC      = "grpc"
+	subsystemVCService = "vcservice"
+)
+
 type (
 	perfMetrics struct {
 		*monitoring.Provider
@@ -52,28 +59,28 @@ func newPerformanceMetrics(q *channels) *perfMetrics {
 	return &perfMetrics{
 		Provider: p,
 		transactionReceivedTotal: p.NewCounter(prometheus.CounterOpts{
-			Namespace: "coordinator",
-			Subsystem: "grpc",
+			Namespace: namespace,
+			Subsystem: subsystemGRPC,
 			Name:      "received_transaction_total",
 			Help:      "Total number of transactions received by the coordinator service from the client.",
 		}),
 		transactionCommittedTotal: p.NewCounterVec(prometheus.CounterOpts{
-			Namespace: "coordinator",
-			Subsystem: "grpc",
+			Namespace: namespace,
+			Subsystem: subsystemGRPC,
 			Name:      "committed_transaction_total",
 			Help:      "Total number of transactions committed status sent by the coordinator service to the client.",
 		}, []string{"status"}),
 		verifiers: newManagerMetrics(p, monitoring.MetricsParameters{
-			Namespace: "coordinator",
+			Namespace: namespace,
 			Subsystem: "verifier",
 		}, q.depGraphToSigVerifierFreeTxs, q.sigVerifierToVCServiceValidatedTxs),
 		vcs: newManagerMetrics(p, monitoring.MetricsParameters{
-			Namespace: "coordinator",
-			Subsystem: "vcservice",
+			Namespace: namespace,
+			Subsystem: subsystemVCService,
 		}, q.sigVerifierToVCServiceValidatedTxs, q.vcServiceToDepGraphValidatedTxs),
 		vcserviceOutputTxStatusBatchQueueSize: p.NewGaugeFunc(prometheus.GaugeOpts{
-			Namespace: "coordinator",
-			Subsystem: "vcservice",
+			Namespace: namespace,
+			Subsystem: subsystemVCService,
 			Name:      "output_tx_status_batch_queue_size",
 			Help: "Size of the output transaction status batch queue of " +
 				"the validation and committer service manager.",

--- a/service/query/metrics.go
+++ b/service/query/metrics.go
@@ -13,6 +13,11 @@ import (
 )
 
 const (
+	namespace = "queryservice"
+
+	subsystemGRPC     = "grpc"
+	subsystemDatabase = "database"
+
 	grpcBeginView             = "begin_view"
 	grpcEndView               = "end_view"
 	grpcGetRows               = "get_rows"
@@ -51,71 +56,71 @@ func newQueryServiceMetrics() *perfMetrics {
 	return &perfMetrics{
 		Provider: p,
 		requests: p.NewCounterVec(prometheus.CounterOpts{
-			Namespace: "queryservice",
-			Subsystem: "grpc",
+			Namespace: namespace,
+			Subsystem: subsystemGRPC,
 			Name:      "requests_total",
 			Help:      "Number of requests by the service",
 		}, []string{"method"}),
 		requestsLatency: p.NewHistogramVec(prometheus.HistogramOpts{
-			Namespace: "queryservice",
-			Subsystem: "grpc",
+			Namespace: namespace,
+			Subsystem: subsystemGRPC,
 			Name:      "requests_latency_seconds",
 			Help:      "The latency (seconds) of requests by the service",
 			Buckets:   timeBuckets,
 		}, []string{"method"}),
 		keysRequested: p.NewCounter(prometheus.CounterOpts{
-			Namespace: "queryservice",
-			Subsystem: "grpc",
+			Namespace: namespace,
+			Subsystem: subsystemGRPC,
 			Name:      "key_requested_total",
 			Help:      "Number of keys requested by the service",
 		}),
 		serverConnections: monitoring.NewConnectionStatsMetrics(p, monitoring.MetricsParameters{
-			Namespace: "queryservice",
-			Subsystem: "grpc",
+			Namespace: namespace,
+			Subsystem: subsystemGRPC,
 		}),
 		keysResponded: p.NewCounter(prometheus.CounterOpts{
-			Namespace: "queryservice",
-			Subsystem: "grpc",
+			Namespace: namespace,
+			Subsystem: subsystemGRPC,
 			Name:      "key_responded_total",
 			Help:      "Number of keys responded by the service",
 		}),
 		processingSessions: p.NewGaugeVec(prometheus.GaugeOpts{
-			Namespace: "queryservice",
-			Subsystem: "database",
+			Namespace: namespace,
+			Subsystem: subsystemDatabase,
 			Name:      "processing_sessions",
 			Help:      "Number of processing sessions in the service",
 		}, []string{"session"}),
 		batchQueuingTimeSeconds: p.NewHistogram(prometheus.HistogramOpts{
-			Namespace: "queryservice",
-			Subsystem: "database",
+			Namespace: namespace,
+			Subsystem: subsystemDatabase,
 			Name:      "batch_queueing_time_seconds",
 			Help:      "The time batches waits for execution",
 			Buckets:   timeBuckets,
 		}),
 		batchQuerySize: p.NewHistogram(prometheus.HistogramOpts{
-			Namespace: "queryservice",
-			Subsystem: "database",
+			Namespace: namespace,
+			Subsystem: subsystemDatabase,
 			Name:      "batch_query_size",
 			Help:      "The size of submitted batches",
 			Buckets:   sizeBuckets,
 		}),
 		batchResponseSize: p.NewHistogram(prometheus.HistogramOpts{
-			Namespace: "queryservice",
-			Subsystem: "database",
+			Namespace: namespace,
+			Subsystem: subsystemDatabase,
 			Name:      "batch_response_size",
 			Help:      "The size of response for batch queries",
 			Buckets:   sizeBuckets,
 		}),
 		requestAssignmentLatencySeconds: p.NewHistogram(prometheus.HistogramOpts{
-			Namespace: "queryservice",
-			Subsystem: "database",
+			Namespace: namespace,
+			Subsystem: subsystemDatabase,
 			Name:      "request_assignment_latency_seconds",
 			Help:      "The latency of the query request assignment to the queue",
 			Buckets:   timeBuckets,
 		}),
 		queryLatencySeconds: p.NewHistogram(prometheus.HistogramOpts{
-			Namespace: "queryservice",
-			Subsystem: "database",
+			Namespace: namespace,
+			Subsystem: subsystemDatabase,
 			Name:      "query_latency_seconds",
 			Help:      "The latency of the queries' batches",
 			Buckets:   timeBuckets,

--- a/service/sidecar/metrics.go
+++ b/service/sidecar/metrics.go
@@ -13,6 +13,15 @@ import (
 	"github.com/hyperledger/fabric-x-committer/utils/monitoring"
 )
 
+const (
+	namespace = "sidecar"
+
+	subsystemRelay           = "relay"
+	subsystemNotifier        = "notifier"
+	subsystemGRPCCoordinator = "grpc_coordinator"
+	subsystemLedger          = "ledger"
+)
+
 type perfMetrics struct {
 	*monitoring.Provider
 
@@ -60,121 +69,121 @@ func newPerformanceMetrics() *perfMetrics {
 	return &perfMetrics{
 		Provider: p,
 		transactionsSentTotal: p.NewCounter(prometheus.CounterOpts{
-			Namespace: "sidecar",
-			Subsystem: "grpc_coordinator",
+			Namespace: namespace,
+			Subsystem: subsystemGRPCCoordinator,
 			Name:      "sent_transaction_total",
 			Help:      "Total number of transactions sent to the coordinator service.",
 		}),
 		transactionsStatusReceivedTotal: p.NewCounterVec(prometheus.CounterOpts{
-			Namespace: "sidecar",
-			Subsystem: "grpc_coordinator",
+			Namespace: namespace,
+			Subsystem: subsystemGRPCCoordinator,
 			Name:      "received_transaction_status_total",
 			Help:      "Total number of transactions statuses received from the coordinator service.",
 		}, []string{"status"}),
 		blockMappingInRelaySeconds: p.NewHistogram(prometheus.HistogramOpts{
-			Namespace: "sidecar",
-			Subsystem: "relay",
+			Namespace: namespace,
+			Subsystem: subsystemRelay,
 			Name:      "block_mapping_seconds",
 			Help:      "Time spent mapping a received block to an internal block.",
 			Buckets:   histoBuckets,
 		}),
 		mappedBlockProcessingInRelaySeconds: p.NewHistogram(prometheus.HistogramOpts{
-			Namespace: "sidecar",
-			Subsystem: "relay",
+			Namespace: namespace,
+			Subsystem: subsystemRelay,
 			Name:      "mapped_block_processing_seconds",
 			Help:      "Time spent processing an internal block and sending it to the coordinator.",
 			Buckets:   histoBuckets,
 		}),
 		transactionStatusesProcessingInRelaySeconds: p.NewHistogram(prometheus.HistogramOpts{
-			Namespace: "sidecar",
-			Subsystem: "relay",
+			Namespace: namespace,
+			Subsystem: subsystemRelay,
 			Name:      "transaction_status_batch_processing_seconds",
 			Help:      "Time spent processing a received status batch from the coordinator.",
 			Buckets:   histoBuckets,
 		}),
 		waitingTransactionsQueueSize: p.NewGauge(prometheus.GaugeOpts{
-			Namespace: "sidecar",
-			Subsystem: "relay",
+			Namespace: namespace,
+			Subsystem: subsystemRelay,
 			Name:      "waiting_transactions_queue_size",
 			Help:      "Total number of transactions waiting at the relay for statuses.",
 		}),
 		yetToBeCommittedBlocksQueueSize: p.NewGauge(prometheus.GaugeOpts{
-			Namespace: "sidecar",
-			Subsystem: "relay",
+			Namespace: namespace,
+			Subsystem: subsystemRelay,
 			Name:      "input_block_queue_size",
 			Help:      "Size of the input block queue of the relay service.",
 		}),
 		committedBlocksQueueSize: p.NewGauge(prometheus.GaugeOpts{
-			Namespace: "sidecar",
-			Subsystem: "relay",
+			Namespace: namespace,
+			Subsystem: subsystemRelay,
 			Name:      "output_committed_block_queue_size",
 			Help:      "Size of the output committed block queue of the relay service.",
 		}),
 		coordConnection: monitoring.NewConnectionMetrics(p, monitoring.MetricsParameters{
-			Namespace: "sidecar",
+			Namespace: namespace,
 			Subsystem: "coordinator",
 		}),
 		serverConnections: monitoring.NewConnectionStatsMetrics(p, monitoring.MetricsParameters{
-			Namespace: "sidecar",
+			Namespace: namespace,
 			Subsystem: "grpc",
 		}),
 		appendBlockToLedgerSeconds: p.NewHistogram(prometheus.HistogramOpts{
-			Namespace: "sidecar",
-			Subsystem: "ledger",
+			Namespace: namespace,
+			Subsystem: subsystemLedger,
 			Name:      "append_block_seconds",
 			Help:      "Time spent appending a block to the ledger.",
 			Buckets:   histoBuckets,
 		}),
 		blockHeight: p.NewGauge(prometheus.GaugeOpts{
-			Namespace: "sidecar",
-			Subsystem: "ledger",
+			Namespace: namespace,
+			Subsystem: subsystemLedger,
 			Name:      "block_height",
 			Help:      "The current block height of the ledger.",
 		}),
 		transactionInThroughput: p.NewCounter(prometheus.CounterOpts{
-			Namespace: "sidecar",
-			Subsystem: "relay",
+			Namespace: namespace,
+			Subsystem: subsystemRelay,
 			Name:      "transaction_in_total",
 			Help:      "Total number of transactions received from the orderer.",
 		}),
 		transactionOutThroughput: p.NewCounter(prometheus.CounterOpts{
-			Namespace: "sidecar",
-			Subsystem: "relay",
+			Namespace: namespace,
+			Subsystem: subsystemRelay,
 			Name:      "transaction_out_total",
 			Help:      "Total number of transaction statuses processed from the coordinator.",
 		}),
 		notifierActiveStreams: p.NewGauge(prometheus.GaugeOpts{
-			Namespace: "sidecar",
-			Subsystem: "notifier",
+			Namespace: namespace,
+			Subsystem: subsystemNotifier,
 			Name:      "active_streams",
 			Help:      "Number of active notification streams.",
 		}),
 		notifierPendingTxIDs: p.NewGauge(prometheus.GaugeOpts{
-			Namespace: "sidecar",
-			Subsystem: "notifier",
+			Namespace: namespace,
+			Subsystem: subsystemNotifier,
 			Name:      "pending_tx_ids",
 			Help:      "Number of pending (txID, request) subscriptions waiting for status notification.",
 		}),
 		notifierUniquePendingTxIDs: p.NewGauge(prometheus.GaugeOpts{
-			Namespace: "sidecar",
-			Subsystem: "notifier",
+			Namespace: namespace,
+			Subsystem: subsystemNotifier,
 			Name:      "unique_pending_tx_ids",
 			Help:      "Number of unique transaction IDs pending across all requests.",
 		}),
 		notifierTxIDsStatusDeliveries: p.NewCounter(prometheus.CounterOpts{
-			Namespace: "sidecar",
-			Subsystem: "notifier",
+			Namespace: namespace,
+			Subsystem: subsystemNotifier,
 			Name:      "tx_ids_status_deliveries_total",
 			Help:      "Total number of transaction IDs' status deliveries to clients.",
 		}),
 		notifierTxIDsTimeoutDeliveries: p.NewCounter(prometheus.CounterOpts{
-			Namespace: "sidecar",
-			Subsystem: "notifier",
+			Namespace: namespace,
+			Subsystem: subsystemNotifier,
 			Name:      "tx_ids_timeout_deliveries_total",
 			Help:      "Total number of transaction IDs' timeout deliveries to clients.",
 		}),
 		delivery: deliverorderer.NewMetrics(p, monitoring.MetricsParameters{
-			Namespace: "sidecar",
+			Namespace: namespace,
 			Subsystem: "delivery",
 		}),
 	}

--- a/service/vc/metrics.go
+++ b/service/vc/metrics.go
@@ -12,6 +12,19 @@ import (
 	"github.com/hyperledger/fabric-x-committer/utils/monitoring"
 )
 
+const (
+	namespace = "vcservice"
+
+	subsystemGRPC      = "grpc"
+	subsystemPreparer  = "preparer"
+	subsystemValidator = "validator"
+	subsystemCommitter = "committer"
+	subsystemDatabase  = "database"
+
+	nameInputQueueSize        = "input_queue_size"
+	nameTxBatchLatencySeconds = "tx_batch_latency_seconds"
+)
+
 var buckets = []float64{.0001, .001, .002, .003, .004, .005, .01, .03, .05, .1, .3, .5, 1}
 
 type perfMetrics struct {
@@ -49,116 +62,116 @@ func newVCServiceMetrics() *perfMetrics {
 	return &perfMetrics{
 		Provider: p,
 		transactionReceivedTotal: p.NewCounter(prometheus.CounterOpts{
-			Namespace: "vcservice",
-			Subsystem: "grpc",
+			Namespace: namespace,
+			Subsystem: subsystemGRPC,
 			Name:      "received_transaction_total",
 			Help:      "Number of transactions received by the service",
 		}),
 		transactionProcessedTotal: p.NewCounter(prometheus.CounterOpts{
-			Namespace: "vcservice",
-			Subsystem: "grpc",
+			Namespace: namespace,
+			Subsystem: subsystemGRPC,
 			Name:      "processed_transaction_total",
 			Help:      "Number of transactions processed by the service",
 		}),
 		transactionCommittedTotal: p.NewCounter(prometheus.CounterOpts{
-			Namespace: "vcservice",
+			Namespace: namespace,
 			Name:      "committed_transaction_total",
 			Help:      "The total number of transactions committed",
 		}),
 		transactionMVCCConflictTotal: p.NewCounter(prometheus.CounterOpts{
-			Namespace: "vcservice",
+			Namespace: namespace,
 			Name:      "mvcc_conflict_total",
 			Help:      "The total number of transactions that failed due to MVCC conflict",
 		}),
 		transactionDuplicateTxTotal: p.NewCounter(prometheus.CounterOpts{
-			Namespace: "vcservice",
+			Namespace: namespace,
 			Name:      "duplicate_transaction_total",
 			Help:      "The total number of duplicate transactions",
 		}),
 		preparerInputQueueSize: p.NewGauge(prometheus.GaugeOpts{
-			Namespace: "vcservice",
-			Subsystem: "preparer",
-			Name:      "input_queue_size",
+			Namespace: namespace,
+			Subsystem: subsystemPreparer,
+			Name:      nameInputQueueSize,
 			Help:      "The preparer input queue size",
 		}),
 		validatorInputQueueSize: p.NewGauge(prometheus.GaugeOpts{
-			Namespace: "vcservice",
-			Subsystem: "validator",
-			Name:      "input_queue_size",
+			Namespace: namespace,
+			Subsystem: subsystemValidator,
+			Name:      nameInputQueueSize,
 			Help:      "The validator input queue size",
 		}),
 		committerInputQueueSize: p.NewGauge(prometheus.GaugeOpts{
-			Namespace: "vcservice",
-			Subsystem: "committer",
-			Name:      "input_queue_size",
+			Namespace: namespace,
+			Subsystem: subsystemCommitter,
+			Name:      nameInputQueueSize,
 			Help:      "The committer input queue size",
 		}),
 		txStatusOutputQueueSize: p.NewGauge(prometheus.GaugeOpts{
-			Namespace: "vcservice",
+			Namespace: namespace,
 			Subsystem: "txstatus",
 			Name:      "output_queue_size",
 			Help:      "The txstatus output queue size",
 		}),
 		preparerTxBatchLatencySeconds: p.NewHistogram(prometheus.HistogramOpts{
-			Namespace: "vcservice",
-			Subsystem: "preparer",
-			Name:      "tx_batch_latency_seconds",
+			Namespace: namespace,
+			Subsystem: subsystemPreparer,
+			Name:      nameTxBatchLatencySeconds,
 			Help:      "The latency of the preparer processing a batch of transactions",
 			Buckets:   buckets,
 		}),
 		validatorTxBatchLatencySeconds: p.NewHistogram(prometheus.HistogramOpts{
-			Namespace: "vcservice",
-			Subsystem: "validator",
-			Name:      "tx_batch_latency_seconds",
+			Namespace: namespace,
+			Subsystem: subsystemValidator,
+			Name:      nameTxBatchLatencySeconds,
 			Help:      "The latency of the validator processing a batch of transactions",
 			Buckets:   buckets,
 		}),
 		committerTxBatchLatencySeconds: p.NewHistogram(prometheus.HistogramOpts{
-			Namespace: "vcservice",
-			Subsystem: "committer",
-			Name:      "tx_batch_latency_seconds",
+			Namespace: namespace,
+			Subsystem: subsystemCommitter,
+			Name:      nameTxBatchLatencySeconds,
 			Help:      "The latency of the committer processing a batch of transactions",
 			Buckets:   buckets,
 		}),
 		databaseTxBatchValidationLatencySeconds: p.NewHistogram(prometheus.HistogramOpts{
-			Namespace: "vcservice",
-			Subsystem: "database",
+			Namespace: namespace,
+			Subsystem: subsystemDatabase,
 			Name:      "tx_batch_validation_latency_seconds",
 			Help:      "The latency of the database validating a batch of transactions",
 			Buckets:   buckets,
 		}),
 		databaseTxBatchQueryVersionLatencySeconds: p.NewHistogram(prometheus.HistogramOpts{
-			Namespace: "vcservice",
-			Subsystem: "database",
+			Namespace: namespace,
+			Subsystem: subsystemDatabase,
 			Name:      "tx_batch_query_version_latency_seconds",
 			Help:      "The latency of the database querying version for keys in a batch of transactions",
 			Buckets:   buckets,
 		}),
 		databaseTxBatchCommitLatencySeconds: p.NewHistogram(prometheus.HistogramOpts{
-			Namespace: "vcservice",
-			Subsystem: "database",
+			Namespace: namespace,
+			Subsystem: subsystemDatabase,
 			Name:      "tx_batch_commit_latency_seconds",
 			Help:      "The latency of the database committing a batch of transactions",
 			Buckets:   buckets,
 		}),
 		databaseTxBatchCommitTxsStatusLatencySeconds: p.NewHistogram(prometheus.HistogramOpts{
-			Namespace: "vcservice",
-			Subsystem: "database",
+			Namespace: namespace,
+			Subsystem: subsystemDatabase,
 			Name:      "tx_batch_commit_txs_status_latency_seconds",
 			Help:      "The latency of the database committing a batch of transactions and updating their status",
 			Buckets:   buckets,
 		}),
 		databaseTxBatchCommitUpdateLatencySeconds: p.NewHistogram(prometheus.HistogramOpts{
-			Namespace: "vcservice",
-			Subsystem: "database",
+			Namespace: namespace,
+			Subsystem: subsystemDatabase,
 			Name:      "tx_batch_commit_update_latency_seconds",
 			Help: "The latency of the database committing a batch of transactions which involes " +
 				"updating existing keys",
 			Buckets: buckets,
 		}),
 		databaseTxBatchCommitInsertNewKeyWithValueLatencySeconds: p.NewHistogram(prometheus.HistogramOpts{
-			Namespace: "vcservice",
-			Subsystem: "database",
+			Namespace: namespace,
+			Subsystem: subsystemDatabase,
 			Name:      "tx_batch_commit_insert_new_key_with_value_latency_seconds",
 			Help: "The latency of the database committing a batch of transactions which involes " +
 				"inserting new keys with values",

--- a/service/verifier/metrics.go
+++ b/service/verifier/metrics.go
@@ -12,6 +12,8 @@ import (
 	"github.com/hyperledger/fabric-x-committer/utils/monitoring"
 )
 
+const namespace = "verifier_server"
+
 type metrics struct {
 	*monitoring.Provider
 	VerifierServerTxs *monitoring.ThroughputMetrics
@@ -24,17 +26,17 @@ func newMonitoring() *metrics {
 	return &metrics{
 		Provider: p,
 		VerifierServerTxs: monitoring.NewThroughputMetrics(p, monitoring.MetricsParameters{
-			Namespace: "verifier_server",
+			Namespace: namespace,
 			Subsystem: "tx",
 		}),
 		ActiveStreams: p.NewGauge(prometheus.GaugeOpts{
-			Namespace: "verifier_server",
+			Namespace: namespace,
 			Subsystem: "grpc",
 			Name:      "active_streams",
 			Help:      "The total number of started streams",
 		}),
 		ActiveRequests: p.NewGauge(prometheus.GaugeOpts{
-			Namespace: "verifier_server",
+			Namespace: namespace,
 			Subsystem: "parallel_executor",
 			Name:      "active_requests",
 			Help:      "The total number of active requests",


### PR DESCRIPTION
#### Type of change

- Improvement (improvement to code, performance, etc)

#### Description

Building on the extractor's new const support, this replaces the repeated `Namespace`/`Subsystem` literals (and the `Name` values intentionally shared across subsystems in vc and dependencygraph) with local consts across every service's `metrics.go`. 

#### Related issues

- resolves #764
