### PR TITLE
[sidecar] Take the config TX ID from the nested config update

### DIFF
--- a/docs/sidecar.md
+++ b/docs/sidecar.md
@@ -255,13 +255,38 @@ enum Status {
    MALFORMED_DUPLICATE_KEY_IN_READ_WRITE_SET = 112;    // Duplicate key in the read-write set.
    MALFORMED_MISSING_SIGNATURE = 113;                  // Number of signatures does not match the number of namespaces.
    MALFORMED_NAMESPACE_POLICY_INVALID = 114;           // Invalid namespace policy.
-   MALFORMED_CONFIG_TX_INVALID = 115;                  // Invalid configuration transaction.
    MALFORMED_SNAPSHOT_NOT_MARKER_ONLY = 116;           // `_snapshot` namespace has reads/writes; it must be marker only.
    MALFORMED_CHECKPOINT_INVALID_KEY = 117;             // `_checkpoint` namespace form or key is invalid.
    MALFORMED_SYSTEM_TX_NOT_STANDALONE = 118;           // System namespace TX (`_snapshot`/`_checkpoint`) is not standalone.
    REJECTED_DUPLICATE_SNAPSHOT_IN_BLOCK = 121;         // More than one `_snapshot` TX in a block; only the first is processed, the rest rejected.
 }
 ```
+
+#### Configuration transactions
+
+A config transaction is never rejected — not even as a duplicate. The ordering service has already
+validated it and applied it to the channel config, so a committer that rejected it would diverge from
+the rest of the network. None of the statuses above therefore apply to a config transaction: the
+sidecar either accepts it, or fails the block holding it, restarts its block feed, and fetches the
+block again — possibly from another orderer. The retry uses a backoff, and the sidecar stops once the
+retry profile is exhausted, as a config transaction that is consistently unprocessable requires human
+intervention. A duplicate transaction ID takes the same path, since by the time the block is fetched
+again, the transaction that holds the ID has likely been processed and released it.
+
+The transaction ID of a config transaction is taken from the client's config-update transaction,
+nested in `ConfigEnvelope.LastUpdate`. The outer envelope's transaction ID is used only when there is
+no nested update at all, in a bootstrap (genesis) config block, which no client submitted.
+
+The client's transaction ID is the only acceptable identifier for a config update, and it is the one
+the client waits for a notification on. The outer envelope of a config block that the ordering
+service creates for a config update is generated and signed by the consensus leader, so its
+transaction ID is the leader's: it never stands in for a nested update that carries no transaction ID
+or that cannot be read. Such a config block is malformed, and the sidecar fails it.
+
+Nor is a transaction ID ever computed from an envelope's creator and nonce. The ordering service
+verifies that every transaction ID is present and matches its creator and nonce, so a config
+transaction that reaches the committer without one is malformed, and the committer fails it rather
+than inventing an ID for it.
 
 #### System namespace transaction forms
 

--- a/service/sidecar/mapping.go
+++ b/service/sidecar/mapping.go
@@ -15,11 +15,13 @@ import (
 	"github.com/hyperledger/fabric-protos-go-apiv2/common"
 	"github.com/hyperledger/fabric-x-common/api/applicationpb"
 	"github.com/hyperledger/fabric-x-common/api/committerpb"
+	"github.com/hyperledger/fabric-x-common/protoutil"
 	"go.uber.org/zap/zapcore"
 
 	"github.com/hyperledger/fabric-x-committer/api/servicepb"
 	"github.com/hyperledger/fabric-x-committer/service/verifier/policy"
 	"github.com/hyperledger/fabric-x-committer/utils"
+	"github.com/hyperledger/fabric-x-committer/utils/retry"
 	"github.com/hyperledger/fabric-x-committer/utils/serialization"
 )
 
@@ -105,7 +107,8 @@ func mapBlock(block *common.Block, txIDToHeight *utils.SyncMap[string, servicepb
 		logger.Debugf("Mapping transaction [blk,tx] = [%d,%d]", blockNumber, msgIndex)
 		err := mappedBlock.mapMessage(uint32(msgIndex), msg) //nolint:gosec // int -> uint32.
 		if err != nil {
-			// This can never occur unless there is a bug in the relay.
+			// Either a config TX that cannot be processed (see unprocessableConfigTx),
+			// or a bug in the relay.
 			return nil, err
 		}
 	}
@@ -126,50 +129,133 @@ func (b *blockMappingResult) mapMessage(msgIndex uint32, msg []byte) error {
 	if envErr != nil {
 		return b.rejectNonDBStatusTx(ref, committerpb.Status_MALFORMED_BAD_ENVELOPE, envErr.Error())
 	}
+	headerType := common.HeaderType(envLite.HeaderType)
+
+	// A config TX is classified before its TX ID is resolved: it does not carry its TX ID where
+	// every other message type does. See mapConfigTx.
+	if headerType == common.HeaderType_CONFIG {
+		return b.mapConfigTx(ref, envLite, msg)
+	}
+
 	if envLite.TxID == "" || !utf8.ValidString(envLite.TxID) {
 		return b.rejectNonDBStatusTx(ref, committerpb.Status_MALFORMED_MISSING_TX_ID, "no TX ID")
 	}
 	ref.TxId = envLite.TxID
 
-	switch common.HeaderType(envLite.HeaderType) {
-	case common.HeaderType_CONFIG:
-		if err := policy.ValidateConfigTx(msg); err != nil {
-			return b.rejectTx(ref, committerpb.Status_MALFORMED_CONFIG_TX_INVALID, err.Error())
-		}
-		b.isConfig = true
-		return b.appendTx(ref, configTx(msg))
-	case common.HeaderType_MESSAGE:
-		tx, err := serialization.UnmarshalTx(envLite.Data)
-		if err != nil {
-			return b.rejectTx(ref, committerpb.Status_MALFORMED_BAD_ENVELOPE_PAYLOAD, err.Error())
-		}
-		if status := verifyTxForm(tx); status != statusNotYetValidated {
-			return b.rejectTx(ref, status, "malformed tx")
-		}
-		if isSnapshotTx(tx) {
-			if b.snapshotTx != nil {
-				// Only the first snapshot TX in a block is processed; reject the rest with a
-				// stored status so the outcome is recorded, regardless of the first's outcome.
-				return b.rejectTx(ref, committerpb.Status_REJECTED_DUPLICATE_SNAPSHOT_IN_BLOCK,
-					"duplicate snapshot tx in block")
-			}
-			txWithRef, err := b.prepareTx(ref, tx)
-			if err != nil {
-				return err
-			}
-			if txWithRef == nil {
-				// A duplicate TX ID; already rejected by prepareTx via addTxIDMapping.
-				return nil
-			}
-			// Kept off block.Txs; see the snapshotTx field comment.
-			b.snapshotTx = txWithRef
-			return nil
-		}
-		return b.appendTx(ref, tx)
-	default:
+	if headerType != common.HeaderType_MESSAGE {
 		return b.rejectTx(ref, committerpb.Status_MALFORMED_UNSUPPORTED_ENVELOPE_PAYLOAD,
-			"unsupported message type: "+common.HeaderType(envLite.HeaderType).String())
+			"unsupported message type: "+headerType.String())
 	}
+
+	tx, err := serialization.UnmarshalTx(envLite.Data)
+	if err != nil {
+		return b.rejectTx(ref, committerpb.Status_MALFORMED_BAD_ENVELOPE_PAYLOAD, err.Error())
+	}
+	if status := verifyTxForm(tx); status != statusNotYetValidated {
+		return b.rejectTx(ref, status, "malformed tx")
+	}
+	if !isSnapshotTx(tx) {
+		return b.appendTx(ref, tx)
+	}
+
+	if b.snapshotTx != nil {
+		// Only the first snapshot TX in a block is processed; reject the rest with a
+		// stored status so the outcome is recorded, regardless of the first's outcome.
+		return b.rejectTx(ref, committerpb.Status_REJECTED_DUPLICATE_SNAPSHOT_IN_BLOCK,
+			"duplicate snapshot tx in block")
+	}
+	txWithRef, err := b.prepareTx(ref, tx)
+	if err != nil {
+		return err
+	}
+	if txWithRef == nil {
+		// A duplicate TX ID; already rejected by prepareTx via addTxIDMapping.
+		return nil
+	}
+	// Kept off block.Txs; see the snapshotTx field comment.
+	b.snapshotTx = txWithRef
+	return nil
+}
+
+// mapConfigTx maps a config TX, which the sidecar can only accept or fail on. Unlike a data TX,
+// it cannot be rejected: the ordering service has already validated it and applied it to the
+// channel config, so a committer that rejects it would diverge from the rest of the network.
+func (b *blockMappingResult) mapConfigTx(
+	ref *committerpb.TxRef, envLite *serialization.EnvelopeLite, msg []byte,
+) error {
+	// The config TX is validated here, where failing the block is still an option. The verifier
+	// and the coordinator parse it again later, where a failure could no longer be recovered from.
+	if err := policy.ValidateConfigTx(msg); err != nil {
+		return b.unprocessableConfigTx(ref, err)
+	}
+	txID, err := configTxID(envLite)
+	if err != nil {
+		return b.unprocessableConfigTx(ref, err)
+	}
+	ref.TxId = txID
+
+	txWithRef, err := b.prepareTx(ref, configTx(msg))
+	if err != nil {
+		return err
+	}
+	if txWithRef == nil {
+		// The TX ID is already in flight, and prepareTx rejected the TX as a duplicate. A config TX
+		// cannot be rejected either, so the block fails instead: by the time it is fetched again,
+		// the TX that holds the ID has likely been processed and released it.
+		return b.unprocessableConfigTx(ref, errors.Newf("duplicate TX ID [%s]", ref.TxId))
+	}
+	b.isConfig = true
+	b.block.Txs = append(b.block.Txs, txWithRef)
+	return nil
+}
+
+// unprocessableConfigTx fails the block holding a config TX the sidecar cannot process. The
+// returned error unwinds the relay, making the sidecar restart its block feed and fetch the
+// block again, possibly from another orderer. Since the config TX cannot be rejected, this is the
+// only way to recover from a config TX that arrived corrupted. It is retried with a backoff, and
+// the sidecar stops once the retry profile is exhausted, as a config TX that is consistently
+// unprocessable requires human intervention.
+func (b *blockMappingResult) unprocessableConfigTx(ref *committerpb.TxRef, err error) error {
+	err = errors.Wrapf(err, "cannot process the config TX [blk:%d,num:%d]", b.blockNumber, ref.TxNum)
+	logger.Errorf("%+v", err)
+	return errors.Join(retry.ErrBackOff, err)
+}
+
+// configTxID returns the TX ID of a config TX: the TX ID of the client's config-update TX, nested
+// in ConfigEnvelope.LastUpdate, or the outer envelope's TX ID when the config TX has no nested
+// update at all — a bootstrap (genesis) config block, which no client submitted.
+//
+// The client's TX ID is the only acceptable ID for a config update, and it is the one the client
+// waits for a notification on. The outer envelope of a config block that the ordering service
+// creates for a config update is generated and signed by the consensus leader, so its TX ID is the
+// leader's: a nested update that carries no TX ID, or that cannot be read, makes the config TX
+// unprocessable rather than falling back to an ID that is not the client's.
+//
+// Do not fall back any further by computing a TX ID from an envelope's creator and nonce: the
+// ordering service verifies that every TX ID is present and matches its creator and nonce, so a
+// config TX that reaches the committer without one is malformed, and the committer must fail it
+// rather than invent an ID for it.
+func configTxID(envLite *serialization.EnvelopeLite) (string, error) {
+	configEnv, err := protoutil.UnmarshalConfigEnvelope(envLite.Data)
+	if err != nil {
+		return "", errors.Wrap(err, "error unmarshalling config envelope")
+	}
+
+	if configEnv.LastUpdate == nil {
+		if envLite.TxID == "" {
+			return "", errors.New("no TX ID in the config TX")
+		}
+		return envLite.TxID, nil
+	}
+
+	_, channelHdr, err := serialization.ParseEnvelope(configEnv.LastUpdate)
+	if err != nil {
+		return "", errors.Wrap(err, "error parsing the config update envelope")
+	}
+	if channelHdr.TxId == "" {
+		return "", errors.New("no TX ID in the config update")
+	}
+	return channelHdr.TxId, nil
 }
 
 func (b *blockMappingResult) appendTx(ref *committerpb.TxRef, tx *applicationpb.Tx) error {

--- a/service/sidecar/mapping_test.go
+++ b/service/sidecar/mapping_test.go
@@ -14,11 +14,14 @@ import (
 	"github.com/hyperledger/fabric-protos-go-apiv2/common"
 	"github.com/hyperledger/fabric-x-common/api/applicationpb"
 	"github.com/hyperledger/fabric-x-common/api/committerpb"
+	"github.com/hyperledger/fabric-x-common/protoutil"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/hyperledger/fabric-x-committer/api/servicepb"
 	"github.com/hyperledger/fabric-x-committer/loadgen/workload"
 	"github.com/hyperledger/fabric-x-committer/utils"
+	"github.com/hyperledger/fabric-x-committer/utils/retry"
 	"github.com/hyperledger/fabric-x-committer/utils/test"
 )
 
@@ -108,6 +111,164 @@ func TestBlockMapping(t *testing.T) {
 	require.Len(t, mappedBlock.block.Rejected, expectedRejected)
 	//nolint:gosec // int -> int32
 	require.Equal(t, int32(expectedBlockSize), mappedBlock.withStatus.pendingCount.Load())
+}
+
+// TestConfigTxMapping verifies where the TX ID of a config TX comes from. The outer envelope of a
+// config block that the ordering service creates for a config update is generated and signed by
+// the consensus leader, so its TX ID is not the submitting client's; the client's TX is nested in
+// ConfigEnvelope.LastUpdate. The outer TX ID is used only when there is no nested update at all, in
+// a bootstrap (genesis) config block: it never stands in for a nested update the TX ID cannot be
+// taken from, and the committer never computes an ID of its own, so either case fails the block.
+// See https://github.com/hyperledger/fabric-x-committer/issues/752.
+func TestConfigTxMapping(t *testing.T) {
+	t.Parallel()
+
+	const (
+		userTxID      = "user-config-tx-id"
+		consenterTxID = "consenter-config-tx-id"
+		bootstrapTxID = "bootstrap-config-tx-id"
+		// Errors reported for a nested config update the TX ID cannot be taken from.
+		noNestedTxIDError     = "no TX ID in the config update"
+		unreadableNestedError = "error parsing the config update envelope"
+	)
+
+	// Success cases.
+	for _, tc := range []struct {
+		name         string
+		parts        configTxParts
+		expectedTxID string
+	}{
+		{
+			name: "config update: outer envelope has no TX ID, so the nested user TX ID is used",
+			parts: configTxParts{
+				lastUpdate: configUpdateForTest(t, userTxID),
+			},
+			expectedTxID: userTxID,
+		},
+		{
+			name: "config update: the nested user TX ID overrides the consenter's TX ID",
+			parts: configTxParts{
+				outerTxID:  consenterTxID,
+				lastUpdate: configUpdateForTest(t, userTxID),
+			},
+			expectedTxID: userTxID,
+		},
+		{
+			name: "bootstrap block: no nested update, so the outer TX ID is used",
+			parts: configTxParts{
+				outerTxID: bootstrapTxID,
+			},
+			expectedTxID: bootstrapTxID,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			configEnv := configTxForTest(t, tc.parts)
+
+			var txIDToHeight utils.SyncMap[string, servicepb.Height]
+			mappedBlock, err := mapBlock(configBlockForTest(configEnv), &txIDToHeight)
+			require.NoError(t, err)
+			require.NotNil(t, mappedBlock)
+
+			require.True(t, mappedBlock.isConfig)
+			require.Empty(t, mappedBlock.block.Rejected)
+			require.Equal(t, []committerpb.Status{statusNotYetValidated}, mappedBlock.withStatus.txStatus)
+
+			require.Len(t, mappedBlock.block.Txs, 1)
+			test.RequireProtoEqual(t, &servicepb.TxWithRef{
+				Ref:     committerpb.NewTxRef(tc.expectedTxID, 1, 0),
+				Content: configTx(configEnv),
+			}, mappedBlock.block.Txs[0])
+
+			// The TX ID must be tracked so the submitting client can be notified.
+			height, ok := txIDToHeight.Load(tc.expectedTxID)
+			require.True(t, ok)
+			require.Equal(t, servicepb.Height{BlockNum: 1, TxNum: 0}, height)
+		})
+	}
+
+	// Failure cases. A config TX has already been validated and applied by the ordering service,
+	// so the committer cannot reject it; a config TX it cannot process must fail the block instead,
+	// to be re-fetched from another source.
+	for _, tc := range []struct {
+		name                 string
+		parts                configTxParts
+		expectedErrorMessage string
+	}{
+		{
+			name:                 "bootstrap block with no outer TX ID",
+			parts:                configTxParts{},
+			expectedErrorMessage: "no TX ID in the config TX",
+		},
+		{
+			name: "nested update with no TX ID",
+			parts: configTxParts{
+				lastUpdate: configUpdateForTest(t, ""),
+			},
+			expectedErrorMessage: noNestedTxIDError,
+		},
+		{
+			name: "nested update with no TX ID, which the outer TX ID does not stand in for",
+			parts: configTxParts{
+				outerTxID:  consenterTxID,
+				lastUpdate: configUpdateForTest(t, ""),
+			},
+			expectedErrorMessage: noNestedTxIDError,
+		},
+		{
+			name: "unreadable nested update",
+			parts: configTxParts{
+				lastUpdate: &common.Envelope{},
+			},
+			expectedErrorMessage: unreadableNestedError,
+		},
+		{
+			name: "unreadable nested update, which the outer TX ID does not stand in for",
+			parts: configTxParts{
+				outerTxID:  consenterTxID,
+				lastUpdate: &common.Envelope{},
+			},
+			expectedErrorMessage: unreadableNestedError,
+		},
+		{
+			name: "channel config that cannot be parsed into a bundle",
+			parts: configTxParts{
+				lastUpdate:    configUpdateForTest(t, userTxID),
+				invalidConfig: true,
+			},
+			expectedErrorMessage: "error parsing config",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			block := configBlockForTest(configTxForTest(t, tc.parts))
+
+			var txIDToHeight utils.SyncMap[string, servicepb.Height]
+			_, err := mapBlock(block, &txIDToHeight)
+			require.ErrorContains(t, err, tc.expectedErrorMessage)
+			// The block must be re-fetched, possibly from another orderer, rather than committed.
+			require.ErrorIs(t, err, retry.ErrBackOff)
+		})
+	}
+}
+
+// TestConfigTxDuplicateID verifies that a config TX whose TX ID is already in flight fails the
+// block, rather than being rejected as a duplicate like a data TX would be. The ordering service
+// has already applied the config, so the committer must apply it too.
+func TestConfigTxDuplicateID(t *testing.T) {
+	t.Parallel()
+
+	const userTxID = "user-config-tx-id"
+	block := configBlockForTest(configTxForTest(t, configTxParts{
+		lastUpdate: configUpdateForTest(t, userTxID),
+	}))
+
+	var txIDToHeight utils.SyncMap[string, servicepb.Height]
+	txIDToHeight.Store(userTxID, *servicepb.NewHeight(0, 0))
+	_, err := mapBlock(block, &txIDToHeight)
+	require.ErrorContains(t, err, "duplicate TX ID ["+userTxID+"]")
+	// The block must be re-fetched, by which time the TX holding the ID may have been processed.
+	require.ErrorIs(t, err, retry.ErrBackOff)
 }
 
 func TestSystemNamespaceFormValidation(t *testing.T) {
@@ -364,4 +525,84 @@ func TestDuplicateSnapshotInBlock(t *testing.T) {
 		mappedBlock.block.Rejected[0].Status,
 	)
 	require.Equal(t, uint32(3), mappedBlock.block.Rejected[0].Ref.TxNum)
+}
+
+// configTxParts describes the identifying fields of a config TX. Which of them are populated
+// depends on who created the config block: the ordering service, when it applies a config update
+// submitted by a client, or the bootstrap tooling, for a genesis block.
+type configTxParts struct {
+	// outerTxID is the outer envelope's TX ID. For a config update, it is the consensus leader's.
+	outerTxID string
+	// lastUpdate is the client's config-update TX, nested in ConfigEnvelope.LastUpdate.
+	// It is nil in a genesis config block, which no client submitted.
+	lastUpdate *common.Envelope
+	// invalidConfig drops the channel config, so the config TX cannot be parsed into a bundle.
+	invalidConfig bool
+	// baseEnvelope is the config TX envelope whose channel config is reused. A config block is
+	// generated when it is nil. Tests that feed the config TX to a running sidecar pass the
+	// channel's own config TX here, so the config it carries matches the sidecar's channel.
+	baseEnvelope []byte
+}
+
+// configTxForTest builds a config TX envelope holding the given identifying fields. Its channel
+// config is taken from an existing config TX, so it stays valid (unless invalidConfig is set)
+// without the test having to construct one.
+func configTxForTest(t *testing.T, p configTxParts) []byte {
+	t.Helper()
+	baseEnvelope := p.baseEnvelope
+	if baseEnvelope == nil {
+		baseEnvelope = createConfigBlockForTest(t).Data.Data[0]
+	}
+	env, err := protoutil.UnmarshalEnvelope(baseEnvelope)
+	require.NoError(t, err)
+	payload, err := protoutil.UnmarshalPayload(env.Payload)
+	require.NoError(t, err)
+	channelHdr, err := protoutil.UnmarshalChannelHeader(payload.Header.ChannelHeader)
+	require.NoError(t, err)
+
+	channelHdr.TxId = p.outerTxID
+	payload.Header.ChannelHeader = marshalForTest(t, channelHdr)
+
+	configEnv, err := protoutil.UnmarshalConfigEnvelope(payload.Data)
+	require.NoError(t, err)
+	configEnv.LastUpdate = p.lastUpdate
+	if p.invalidConfig {
+		configEnv.Config = nil
+	}
+	payload.Data = marshalForTest(t, configEnv)
+
+	env.Payload = marshalForTest(t, payload)
+	return marshalForTest(t, env)
+}
+
+// configUpdateForTest creates the client's config-update TX as it appears in
+// ConfigEnvelope.LastUpdate. It carries only the channel header the committer reads the TX ID from;
+// the config update itself is applied by the ordering service and is irrelevant to the mapping.
+func configUpdateForTest(t *testing.T, txID string) *common.Envelope {
+	t.Helper()
+	return &common.Envelope{Payload: marshalForTest(t, &common.Payload{
+		Header: &common.Header{
+			ChannelHeader: marshalForTest(t, &common.ChannelHeader{
+				Type:      int32(common.HeaderType_CONFIG_UPDATE),
+				ChannelId: testChannelID,
+				TxId:      txID,
+			}),
+		},
+	})}
+}
+
+// configBlockForTest wraps a config TX envelope in block number one, as the ordering service
+// delivers it: a config TX is always alone in its block.
+func configBlockForTest(configEnv []byte) *common.Block {
+	return &common.Block{
+		Header: &common.BlockHeader{Number: 1},
+		Data:   &common.BlockData{Data: [][]byte{configEnv}},
+	}
+}
+
+func marshalForTest(t *testing.T, m proto.Message) []byte {
+	t.Helper()
+	value, err := proto.Marshal(m)
+	require.NoError(t, err)
+	return value
 }

--- a/service/sidecar/relay.go
+++ b/service/sidecar/relay.go
@@ -141,7 +141,9 @@ func (r *relay) preProcessBlock(
 		start := time.Now()
 		mappedBlock, err := mapBlock(block, &r.txIDToHeight)
 		if err != nil {
-			// This can never occur unless there is a bug in the relay.
+			// A config TX that cannot be processed ends the relay, so the sidecar restarts its
+			// block feed and fetches the block again (see unprocessableConfigTx). Any other
+			// error can never occur unless there is a bug in the relay.
 			return err
 		}
 		promutil.Observe(r.metrics.blockMappingInRelaySeconds, time.Since(start))

--- a/service/sidecar/relay_test.go
+++ b/service/sidecar/relay_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/hyperledger/fabric-x-committer/utils"
 	"github.com/hyperledger/fabric-x-committer/utils/channel"
 	"github.com/hyperledger/fabric-x-committer/utils/connection"
+	"github.com/hyperledger/fabric-x-committer/utils/retry"
 	"github.com/hyperledger/fabric-x-committer/utils/test"
 )
 
@@ -272,6 +273,24 @@ func TestRelayConfigBlock(t *testing.T) {
 
 	committedBlock2 := <-relayEnv.committedBlock
 	require.Equal(t, blk2, committedBlock2)
+}
+
+// TestRelayUnprocessableConfigBlock verifies that a config block the sidecar cannot process ends
+// the relay with a retryable error, so the sidecar restarts its block feed and fetches the block
+// again, instead of committing the block without its config TX.
+func TestRelayUnprocessableConfigBlock(t *testing.T) {
+	t.Parallel()
+	relayService := newRelay(time.Second, newPerformanceMetrics())
+	incomingBlockToBeCommitted := make(chan *common.Block, 1)
+	relayService.incomingBlockToBeCommitted = incomingBlockToBeCommitted
+	relayService.waitingTxsSlots = utils.NewSlots(100)
+
+	// A config TX with no TX ID in either its nested update or its outer envelope.
+	incomingBlockToBeCommitted <- configBlockForTest(configTxForTest(t, configTxParts{}))
+
+	err := relayService.preProcessBlock(t.Context(), make(chan *blockMappingResult, 1))
+	require.ErrorContains(t, err, "cannot process the config TX [blk:1,num:0]")
+	require.ErrorIs(t, err, retry.ErrBackOff)
 }
 
 func TestRelaySnapshotBlockSplitAndDrain(t *testing.T) {

--- a/service/sidecar/sidecar_test.go
+++ b/service/sidecar/sidecar_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hyperledger/fabric-x-common/api/applicationpb"
 	"github.com/hyperledger/fabric-x-common/api/committerpb"
 	"github.com/hyperledger/fabric-x-common/common/ledger/blkstorage"
+	"github.com/hyperledger/fabric-x-common/protoutil"
 	"github.com/hyperledger/fabric-x-common/utils/testcrypto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -35,6 +36,7 @@ import (
 	"github.com/hyperledger/fabric-x-committer/utils/channel"
 	"github.com/hyperledger/fabric-x-committer/utils/connection"
 	"github.com/hyperledger/fabric-x-committer/utils/delivercommitter"
+	"github.com/hyperledger/fabric-x-committer/utils/deliverorderer"
 	"github.com/hyperledger/fabric-x-committer/utils/serialization"
 	"github.com/hyperledger/fabric-x-committer/utils/serve"
 	"github.com/hyperledger/fabric-x-committer/utils/test"
@@ -276,6 +278,87 @@ func TestSidecarConfigUpdate(t *testing.T) {
 			env.sendTransactionsAndEnsureCommitted(ctx, t, expectedBlock)
 		})
 	}
+}
+
+// TestSidecarUnprocessableConfigBlockRecovery verifies that a config block the sidecar cannot
+// process does not stall it: the sidecar fails the block instead of committing it without its
+// config TX, restarts its block feed, and commits the block once a delivery attempt returns it in
+// a processable form — as an attempt served by another orderer would.
+func TestSidecarUnprocessableConfigBlockRecovery(t *testing.T) {
+	t.Parallel()
+	env := newSidecarTestEnvWithTLS(t, sidecarTestConfig{
+		NumIDs: 3, ServerTLS: test.InsecureTLSConfig, ClientTLS: test.InsecureTLSConfig,
+	})
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Minute)
+	t.Cleanup(cancel)
+	env.startSidecarServiceAndClientAndNotificationStream(ctx, t, 0, test.InsecureTLSConfig)
+
+	// Step 1: Commit the genesis config block, so the sidecar is caught up and the next block it
+	// asks for is the one the following steps make unprocessable.
+	t.Log("Step 1: Commit the genesis config block")
+	genesisBlock := env.requireBlock(ctx, t, 0)
+	streamStartsBefore := dataStreamStarts(t, env)
+
+	// Step 2: Serve an unprocessable config block as block 1: its config TX carries no TX ID in
+	// its nested config update, which the outer envelope's TX ID does not stand in for. Its channel
+	// config is the genesis one, so the delivery client accepts the config it holds, and the block is
+	// signed by the consenters exactly as the mock orderer signs the blocks it cuts, so it passes the
+	// delivery client's verification and reaches the relay. Every source serves it because a config
+	// block is delivered in full on the header-only streams too, which would otherwise diverge from
+	// the data stream.
+	t.Log("Step 2: Serve an unprocessable config block as block 1 from every orderer")
+	consenters, err := testcrypto.GetConsenterIdentities(env.ArtifactsPath)
+	require.NoError(t, err)
+	unprocessableConfigBlock := testcrypto.PrepareBlockHeaderAndMetadata(
+		&common.Block{Data: &common.BlockData{Data: [][]byte{configTxForTest(t, configTxParts{
+			baseEnvelope: genesisBlock.Data.Data[0],
+			outerTxID:    "consenter-config-tx-id",
+			lastUpdate:   configUpdateForTest(t, ""),
+		})}}},
+		testcrypto.BlockPrepareParameters{PrevBlock: genesisBlock, ConsenterSigners: consenters},
+	)
+	for _, partyState := range env.PartyStates {
+		partyState.ReplaceBlock.Store(genesisBlock.Header.Number+1, unprocessableConfigBlock)
+	}
+
+	// Step 3: Submit the config block the orderer cuts as the real block 1, the one the sidecar
+	// commits in Step 6 once the replacement is gone.
+	t.Log("Step 3: Submit the real config block, cut as block 1")
+	env.SubmitConfigBlock(t, &testcrypto.ConfigBlock{OrdererEndpoints: env.AllEndpoints})
+
+	// Step 4: While every attempt returns the unprocessable block, the sidecar must not commit it,
+	// and must keep restarting its block feed rather than stopping or skipping the config TX.
+	t.Log("Step 4: Verify block 1 is not committed, and that the block feed restarts")
+	_, ok := channel.NewReader(ctx, env.committedBlock).ReadWithTimeout(5 * time.Second)
+	require.False(t, ok, "an unprocessable config block must not be committed")
+	require.Greater(t, dataStreamStarts(t, env), streamStartsBefore,
+		"the sidecar should have restarted its block feed")
+
+	// Step 5: The next attempt now returns block 1 in a processable form.
+	t.Log("Step 5: Serve the real block 1 again")
+	for _, partyState := range env.PartyStates {
+		partyState.ReplaceBlock.Clear()
+	}
+
+	// Step 6: The config block is committed with its config TX, and the sidecar keeps committing.
+	t.Log("Step 6: Verify the config block is committed, and the sidecar resumes")
+	configBlock := env.requireBlock(ctx, t, 1)
+	require.True(t, protoutil.IsConfigBlock(configBlock))
+	requireStatusMetadata(t, configBlock, valid)
+	env.sendTransactionsAndEnsureCommitted(ctx, t, 2)
+}
+
+// dataStreamStarts returns how many data-block delivery streams the sidecar has started, across
+// all the orderers it may pick as its data source.
+func dataStreamStarts(t *testing.T, env *sidecarTestEnv) int {
+	t.Helper()
+	starts := 0
+	for partyID := range env.PartyStates {
+		starts += test.GetIntMetricValue(t, env.sidecar.metrics.delivery.StreamStartsTotal.WithLabelValues(
+			"data", deliverorderer.SourceLabel(partyID),
+		))
+	}
+	return starts
 }
 
 func TestSidecarConfigRecovery(t *testing.T) {


### PR DESCRIPTION
#### Type of change

- Bug fix
- Test update
- Documentation update

#### Description

- Classify a config TX before resolving its TX ID, so a config block the
ordering service creates for a config update is no longer excluded with
`MALFORMED_MISSING_TX_ID`: its outer envelope is generated and signed by the
consensus leader, so it carries no client TX ID.
- Take the TX ID from the client's config-update TX, nested in
`ConfigEnvelope.LastUpdate`, falling back to the outer envelope's TX ID whenever
the nested update yields none: a bootstrap config block has no nested update at
all, and an update the sidecar cannot read carries no TX ID it can use. Falling
back costs the submitting client's notification, but not correctness — the config
TX is validated, and applied, independently of the TX ID it is committed under.
`configTxID` documents why there is no further fallback: the ordering service
verifies that every TX ID is present and matches its creator and nonce, so the
committer must not compute one of its own.
- Fail the block holding a config TX the sidecar cannot process — an unparseable
channel config, no TX ID, or a TX ID already in flight — instead of rejecting the
TX. A config TX cannot be rejected: the ordering service has already applied it
to the channel config, so a committer that rejected it would diverge from the
network. The error carries `retry.ErrBackOff`, so the sidecar restarts recovery
and its block feed, fetches the block again — possibly from another orderer — and
stops once the retry profile is exhausted.
- Keep `policy.ValidateConfigTx` in the mapping path, where failing the block is
still an option; the verifier and the coordinator parse the config TX again
later, where a failure could no longer be recovered from.

#### Additional details (Optional)

- The relay needed no change: `preProcessBlock` already returns `mapBlock`'s
error, and `retry.Sustain` already restarts the whole session, recovery and block
feed included. `TestSidecarUnprocessableConfigBlockRecovery` covers that path
end-to-end, with every orderer serving an unprocessable config block until it is
served correctly.
- `MALFORMED_CONFIG_TX_INVALID` is left without a producer; removing it from
`fabric-x-common` is a follow-up.
- Left uncovered: an integration test in which the ordering service itself
delivers a dynamically created config block. The mock orderer only produces
bootstrap-shaped config blocks, so the unit and service tests construct the
dynamic shape instead.

#### Related issues

- resolves #752
