### PR TITLE
Upgrade to Go 1.27.0

### DIFF
--- a/.bob/skills/development/SKILL.md
+++ b/.bob/skills/development/SKILL.md
@@ -3,7 +3,7 @@ name: development
 description: >-
   Conventions for writing NEW Go code in the Fabric-X Committer repo: code
   organization/ordering, concurrency (errgroup + context-aware channels), Go
-  1.26 idioms, error handling, logging, and service/config/metrics structure.
+  1.27 idioms, error handling, logging, and service/config/metrics structure.
   Use this skill BEFORE writing or modifying any Go source in this repository —
   adding a service, component, function, gRPC handler, or config field, or
   refactoring existing code — so the new code matches established patterns and
@@ -290,7 +290,7 @@ Use `context.AfterFunc(ctx, fn)` for cancel-driven teardown (the standard primit
 Reach for `atomic` for counters/flags/pointers, `Mutex`/`RWMutex` for compound state, and
 `TryLock` to reject a second concurrent stream (`grpcerror.WrapFailedPrecondition`).
 
-## Modern Go idioms (1.26)
+## Modern Go idioms (1.27)
 
 The codebase is aggressively modern. **Prefer** in new code:
 
@@ -301,6 +301,12 @@ The codebase is aggressively modern. **Prefer** in new code:
 - Built-in `min` / `max` (pervasive), e.g. `min(high, max(low, v))`.
 - Range-over-integer: `for range n` / `for i := range n` (the `intrange` linter pushes this).
 - `iter.Seq` / `iter.Seq2` for custom iterators (`utils/sync_map.go`).
+- Stdlib iterator forms over `Len`/`At` and slice-returning helpers:
+  `reflect.Type.Fields()` (`cmd/config/config_preload.go:38`), `strings.FieldsSeq` /
+  `strings.SplitSeq` (`cmd/config/config_preload.go:83`).
+- Promoted (embedded) field names directly in composite literals — Go 1.27 accepts
+  `&PostgresClusterController{dbType: ..., networkName: ...}` in place of spelling out
+  the embedded `DBClusterController{...}` literal (`integration/runner/postgres.go:78`).
 - `errors.Join` — especially to combine a retry sentinel with a cause:
   `errors.Join(retry.ErrBackOff, err)`.
 - `context.AfterFunc`, and `context.WithCancelCause` / `context.Cause` where a cancel

--- a/.bob/skills/pr-review/SKILL.md
+++ b/.bob/skills/pr-review/SKILL.md
@@ -46,7 +46,7 @@ Before starting any review, read:
 - `@guidelines.md` — coding standards, review comment labels, simplicity principles
 - `@docs/core-concurrency-pattern.md` — required concurrency patterns
 - `@.claude/skills/development/SKILL.md` — the conventions for writing NEW code (code
-  ordering/caller-before-callee, errgroup + context-aware channels, error handling, Go 1.26
+  ordering/caller-before-callee, errgroup + context-aware channels, error handling, Go 1.27
   idioms, and reuse of `utils/` + `fabric-x-common` helpers). New or changed code that
   deviates from this skill is a review finding — cite the specific convention it breaks.
 - `@.claude/skills/tests/SKILL.md` — the testing conventions (table-driven + `t.Parallel`,

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -228,7 +228,8 @@ formatters:
     - goimports
   settings:
     gofumpt:
-      extra-rules: true
+      extra:
+        group-params: true
     goimports:
       # A comma-separated list of prefixes, which, if set, checks import paths
       # with the given prefixes are grouped after 3rd-party packages.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ The system consists of four main microservices that communicate via gRPC:
 
 ### Key Technologies
 
-- **Language**: Go 1.26
+- **Language**: Go 1.27
 - **Communication**: gRPC with Protocol Buffers
 - **Database**: PostgreSQL or YugabyteDB (for state storage)
 - **Testing**: Standard Go testing with binaries integration tests and Docker-based integration tests
@@ -25,7 +25,7 @@ The system consists of four main microservices that communicate via gRPC:
 
 ### Prerequisites
 
-- Go 1.26 or later
+- Go 1.27 or later
 - Docker (for integration tests and containerized builds)
 - PostgreSQL or YugabyteDB (for tests requiring database)
 
@@ -67,7 +67,7 @@ authoritative, detailed source for these conventions and keeps them in one place
   functions it calls (caller before callee).
 - **Reuse `utils/` and `fabric-x-common` helpers**; run `make lint` (or `make lint-go`).
 
-See the skill for concurrency (`errgroup` + `utils/channel`), Go 1.26 idioms,
+See the skill for concurrency (`errgroup` + `utils/channel`), Go 1.27 idioms,
 service/config/metrics structure, and the full linter cheat sheet.
 
 ### Performance Considerations

--- a/cmd/config/config_preload.go
+++ b/cmd/config/config_preload.go
@@ -35,8 +35,7 @@ func setDefaultsAndEnv(v *viper.Viper, objType reflect.Type, keyParts ...string)
 	case reflect.Array, reflect.Slice:
 		setDefaultsAndEnv(v, objType.Elem(), keyParts...)
 	case reflect.Struct:
-		for i := range objType.NumField() {
-			field := objType.Field(i)
+		for field := range objType.Fields() {
 			fieldKeyParts, ok := getFieldKeyParts(field, keyParts...)
 			if !ok {
 				continue
@@ -81,7 +80,7 @@ func registerDefault(v *viper.Viper, path, defaultValue string) {
 		v.SetDefault(path, defaultValue)
 		return
 	}
-	for _, pair := range strings.Fields(defaultValue) {
+	for pair := range strings.FieldsSeq(defaultValue) {
 		if key, val, ok := strings.Cut(pair, "="); ok {
 			v.SetDefault(path+"."+key, val)
 		}

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -17,9 +17,9 @@ brew install go@1.24.3
 
 ```shell
 apt-get update
-wget https://go.dev/dl/go1.24.3.linux-amd64.tar.gz
-tar xvf ./go1.24.3.linux-amd64.tar.gz
-rm ./go1.24.3.linux-amd64.tar.gz
+wget https://go.dev/dl/go1.27.0.linux-amd64.tar.gz
+tar xvf ./go1.27.0.linux-amd64.tar.gz
+rm ./go1.27.0.linux-amd64.tar.gz
 mv ./go/ /usr/local/
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@
 //
 module github.com/hyperledger/fabric-x-committer
 
-go 1.26.5
+go 1.27.0
 
 require (
 	github.com/Shopify/toxiproxy/v2 v2.12.0

--- a/integration/runner/postgres.go
+++ b/integration/runner/postgres.go
@@ -75,8 +75,8 @@ func StartPostgresCluster(ctx context.Context, t *testing.T) (*PostgresClusterCo
 	})
 
 	cluster := &PostgresClusterController{
-		DBClusterController: DBClusterController{dbType: testdb.PostgresDBType},
-		networkName:         networkName,
+		dbType:      testdb.PostgresDBType,
+		networkName: networkName,
 	}
 
 	t.Log("starting postgres cluster")

--- a/integration/runner/yugabyte.go
+++ b/integration/runner/yugabyte.go
@@ -95,9 +95,9 @@ func StartYugaCluster(ctx context.Context, t *testing.T, numberOfMasters, number
 	}
 
 	cluster := &YugaClusterController{
-		DBClusterController: DBClusterController{dbType: testdb.YugaDBType},
-		replicationFactor:   rf,
-		NetworkName:         fmt.Sprintf("%s%s", networkPrefix, uuid.NewString()),
+		dbType:            testdb.YugaDBType,
+		replicationFactor: rf,
+		NetworkName:       fmt.Sprintf("%s%s", networkPrefix, uuid.NewString()),
 	}
 	// A dedicated Docker network enables container-to-container communication
 	// via container names (Docker DNS). Masters and tservers use each other's

--- a/loadgen/adapters/coordinator.go
+++ b/loadgen/adapters/coordinator.go
@@ -28,8 +28,8 @@ type (
 // NewCoordinatorAdapter instantiate CoordinatorAdapter.
 func NewCoordinatorAdapter(config *connection.ClientConfig, res *ClientResources) *CoordinatorAdapter {
 	return &CoordinatorAdapter{
-		commonAdapter: commonAdapter{res: res},
-		config:        config,
+		res:    res,
+		config: config,
 	}
 }
 

--- a/loadgen/adapters/loadgen.go
+++ b/loadgen/adapters/loadgen.go
@@ -36,8 +36,8 @@ type (
 // NewLoadGenAdapter instantiate LoadGenAdapter.
 func NewLoadGenAdapter(config *connection.ClientConfig, res *ClientResources) *LoadGenAdapter {
 	return &LoadGenAdapter{
-		commonAdapter: commonAdapter{res: res},
-		config:        config,
+		res:    res,
+		config: config,
 	}
 }
 

--- a/loadgen/adapters/orderer.go
+++ b/loadgen/adapters/orderer.go
@@ -27,8 +27,8 @@ type (
 // NewOrdererAdapter instantiate OrdererAdapter.
 func NewOrdererAdapter(config *OrdererClientConfig, res *ClientResources) *OrdererAdapter {
 	return &OrdererAdapter{
-		commonAdapter: commonAdapter{res: res},
-		config:        config,
+		res:    res,
+		config: config,
 	}
 }
 

--- a/loadgen/adapters/sidecar.go
+++ b/loadgen/adapters/sidecar.go
@@ -28,8 +28,8 @@ type (
 // NewSidecarAdapter instantiate SidecarAdapter.
 func NewSidecarAdapter(config *SidecarClientConfig, res *ClientResources) (*SidecarAdapter, error) {
 	return &SidecarAdapter{
-		commonAdapter: commonAdapter{res: res},
-		config:        config,
+		res:    res,
+		config: config,
 	}, nil
 }
 

--- a/loadgen/adapters/vcservice.go
+++ b/loadgen/adapters/vcservice.go
@@ -28,8 +28,8 @@ type (
 // NewVCAdapter instantiate VcAdapter.
 func NewVCAdapter(config *connection.MultiClientConfig, res *ClientResources) *VcAdapter {
 	return &VcAdapter{
-		commonAdapter: commonAdapter{res: res},
-		config:        config,
+		res:    res,
+		config: config,
 	}
 }
 

--- a/loadgen/adapters/verifier.go
+++ b/loadgen/adapters/verifier.go
@@ -31,8 +31,8 @@ type (
 // NewVerifierAdapter instantiate VerifierAdapter.
 func NewVerifierAdapter(config *connection.MultiClientConfig, res *ClientResources) *VerifierAdapter {
 	return &VerifierAdapter{
-		commonAdapter: commonAdapter{res: res},
-		config:        config,
+		res:    res,
+		config: config,
 	}
 }
 

--- a/scripts/install-dev-dependencies.sh
+++ b/scripts/install-dev-dependencies.sh
@@ -8,7 +8,7 @@ set -e
 
 # Versions for non-Go tools
 protoc_bin_version="35.1"
-golangci_lint_version="v2.12.2"
+golangci_lint_version="v2.13.1"
 sqlfluff_version="4.2.2"
 
 # Install protoc binary (C++ based, not available via go install)

--- a/utils/connection/client.go
+++ b/utils/connection/client.go
@@ -206,7 +206,7 @@ func CloseConnections[T io.Closer](connections ...T) error {
 	errs := make([]error, len(connections))
 	for i, closer := range connections {
 		v := reflect.ValueOf(closer)
-		if !v.IsValid() || (v.Kind() == reflect.Ptr && v.IsNil()) {
+		if !v.IsValid() || (v.Kind() == reflect.Pointer && v.IsNil()) {
 			continue
 		}
 		errs[i] = filterAcceptableCloseErr(closer.Close())


### PR DESCRIPTION
#### Type of change

- Dependencies Upgrade
- Improvement (improvement to code, performance, etc)

#### Description

- Upgrade to Go 1.27.0.
- Upgrade golangci-lint to v2.13.1. This is required, not optional: v2.12.2
  vendors staticcheck v0.7.0, which panics with `unexpected expr:
  *ast.KeyValueExpr` on Go 1.27's promoted-field composite literals — including
  the ones in the standard library, so it cannot lint any Go 1.27 module.
- Replace the now-deprecated gofumpt `extra-rules` setting with
  `extra.group-params`.
- Apply `go fix ./...`: `reflect.Ptr` -> `reflect.Pointer`, `strings.Fields` ->
  `strings.FieldsSeq`, `reflect.Type.NumField`/`Field` -> the `Fields()`
  iterator, and promoted embedded field names in composite literals.

#### Additional details (Optional)

`go fix` also rewrote the `ecdsa.PrivateKey` literal in
`utils/testsig/key_factory.go`. That rewrite is reverted here: flattening the
nested `ecdsa.PublicKey` literal turns `D: privateKey` into a changed line, which
trips a pre-existing `SA1019` on the deprecated raw-field ECDSA API. That
function already relies on `ScalarBaseMult`, `PublicKey.X`/`Y` and
`PrivateKey.D`, and migrating it means reworking seeded deterministic test-key
derivation — tracked separately in #776 rather than folded into a toolchain bump.

#### Related issues

- resolves #775
