### PR TITLE
[utils] Migrate testsig off the deprecated raw-field ECDSA API

### DIFF
--- a/utils/testsig/certificates_test.go
+++ b/utils/testsig/certificates_test.go
@@ -113,7 +113,7 @@ func TestParseSigningKey(t *testing.T) {
 		parsed, err := ParseSigningKey(serialized)
 		require.NoError(t, err)
 		require.NotNil(t, parsed)
-		require.Equal(t, privateKey.D, parsed.D)
+		require.True(t, privateKey.Equal(parsed), "parsed key differs from the original")
 	})
 
 	t.Run("parse PRIVATE KEY (PKCS8) format", func(t *testing.T) {
@@ -129,7 +129,7 @@ func TestParseSigningKey(t *testing.T) {
 		parsed, err := ParseSigningKey(pemBytes)
 		require.NoError(t, err)
 		require.NotNil(t, parsed)
-		require.Equal(t, privateKey.D, parsed.D)
+		require.True(t, privateKey.Equal(parsed), "parsed key differs from the original")
 	})
 
 	t.Run("nil block returns error", func(t *testing.T) {

--- a/utils/testsig/key_factory.go
+++ b/utils/testsig/key_factory.go
@@ -124,22 +124,24 @@ func ecdsaNewKeyPairWithSeed(seed int64) (signature.PrivateKey, signature.Public
 	hasher := sha3.New256()
 	_, err := hasher.Write(seedBytes)
 	utils.Must(err)
-	privateKey := new(big.Int).SetBytes(hasher.Sum(nil))
+	scalar := new(big.Int).SetBytes(hasher.Sum(nil))
 
-	privateKey.Mod(privateKey, curve.Params().N)
-	if privateKey.Sign() == 0 {
+	scalar.Mod(scalar, curve.Params().N)
+	if scalar.Sign() == 0 {
 		// generated zero private key
 		return nil, nil
 	}
 
-	x, y := curve.ScalarBaseMult(privateKey.Bytes())
-	pk := &ecdsa.PrivateKey{
-		PublicKey: ecdsa.PublicKey{Curve: curve, X: x, Y: y},
-		D:         privateKey,
-	}
-	serializedPrivateKey, err := SerializeSigningKey(pk)
+	// ParseRawPrivateKey derives the public key itself, and wants the scalar in SEC 1
+	// fixed-length form, so FillBytes restores the leading zeros that big.Int drops.
+	rawKey := make([]byte, (curve.Params().N.BitLen()+7)/8)
+	scalar.FillBytes(rawKey)
+	privateKey, err := ecdsa.ParseRawPrivateKey(curve, rawKey)
 	utils.Must(err)
-	serializedPublicKey, err := SerializeVerificationKey(&pk.PublicKey)
+
+	serializedPrivateKey, err := SerializeSigningKey(privateKey)
+	utils.Must(err)
+	serializedPublicKey, err := SerializeVerificationKey(&privateKey.PublicKey)
 	utils.Must(err)
 	return serializedPrivateKey, serializedPublicKey
 }

--- a/utils/testsig/key_factory_test.go
+++ b/utils/testsig/key_factory_test.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package testsig
 
 import (
+	"encoding/hex"
 	"encoding/pem"
 	"fmt"
 	"os"
@@ -99,6 +100,64 @@ func TestEcdsaPem(t *testing.T) {
 	require.NoError(t, err)
 	tx.Endorsements = []*applicationpb.Endorsements{endorsement}
 	require.NoError(t, v.VerifyNs(txID, tx, 0))
+}
+
+// TestEcdsaKeyPairWithSeedIsStable pins the seed -> key mapping. Fixed seeds are used across
+// the load generator and its tests, so a change to either the scalar derivation or the way the
+// key is built from it silently invalidates every artifact generated from a given seed. The
+// expected scalars were captured from the original implementation.
+func TestEcdsaKeyPairWithSeedIsStable(t *testing.T) {
+	t.Parallel()
+	for _, tc := range []struct {
+		name       string
+		seed       int64
+		wantScalar string
+	}{
+		{
+			name:       "zero seed",
+			seed:       0,
+			wantScalar: "48dda5bbe9171a6656206ec56c595c5834b6cf38c5fe71bcb44fe43833aee9df",
+		},
+		{
+			name:       "one",
+			seed:       1,
+			wantScalar: "6c70d57af53dbf4d95253503dd5abe8c49e953236fd23851108b92bbec8ac907",
+		},
+		{
+			name:       "arbitrary seed",
+			seed:       42,
+			wantScalar: "0d0960b18e45fc0f2c2242904eb4d50921f2b6fa8434bd7015904e28ba55ba81",
+		},
+		{
+			// This scalar is only 31 bytes wide, so it must be left-padded to the curve's
+			// 32-byte size. A raw big.Int encoding would be rejected as a short key.
+			name:       "scalar narrower than the curve size",
+			seed:       115,
+			wantScalar: "0063661b93d5639df7ef18c3372f2c10a51c2a41d36cb2e2b308bb165dcad263",
+		},
+		{
+			name:       "negative seed",
+			seed:       -1,
+			wantScalar: "dab9bad679ac69aab7717528842fb867663afa6d4822d159cfcedbe5b6819eb9",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			priv, pub := NewKeyPairWithSeed(signature.Ecdsa, tc.seed)
+
+			key, err := ParseSigningKey(priv)
+			require.NoError(t, err)
+			rawScalar, err := key.Bytes()
+			require.NoError(t, err)
+			require.Equal(t, tc.wantScalar, hex.EncodeToString(rawScalar))
+
+			// Pinning the scalar alone would not catch a change to how the public point is
+			// derived from it, which would hand out a pair that cannot verify its own signatures.
+			wantPub, err := SerializeVerificationKey(&key.PublicKey)
+			require.NoError(t, err)
+			require.Equal(t, wantPub, pub)
+		})
+	}
 }
 
 func readPem(certPath string) (map[string][]byte, error) {


### PR DESCRIPTION
#### Type of change

- Improvement (improvement to code, performance, etc)
- Test update

#### Description

- Build the seeded ECDSA key with `ecdsa.ParseRawPrivateKey` instead of
  `elliptic.Curve.ScalarBaseMult` plus raw `PublicKey.X`/`Y` and `PrivateKey.D`
  assignment, clearing all five `SA1019`s in the package.
- Compare keys with `PrivateKey.Equal` rather than the deprecated `D` field.
- Add `TestEcdsaKeyPairWithSeedIsStable`, pinning the seed -> scalar mapping.

#### Additional details (Optional)

`ParseRawPrivateKey` requires a fixed-length scalar and rejects a short one, while
`big.Int.Bytes()` returns the minimal encoding — so seeds whose scalar has a leading
zero byte need `FillBytes` to pad to the curve size. Seed 115 is such a case and is
covered explicitly; the previous `ScalarBaseMult` call accepted the short slice.

The explicit zero-scalar check is kept rather than folded into `ParseRawPrivateKey`'s
error, so a zero scalar keeps returning `nil, nil` instead of panicking.

#### Related issues

- resolves #776
