### PR TITLE
[vc] Verify Yugabyte snapshot clone readiness

### DIFF
--- a/docs/validator-committer.md
+++ b/docs/validator-committer.md
@@ -279,16 +279,21 @@ back to the Coordinator, completing the workflow for the transaction batch.
 
 When a `_snapshot` marker transaction is committed, the VC creates a native,
 zero-copy clone of the state database **before** the marker's transaction ID is
-committed, preserving the invariant `txID committed <=> clone exists <=> PENDING row`.
-The clone is a consistent copy of the drained state cut and is never dropped by
-the VC (dropping is forbidden because it could delete a clone whose txID has not
-yet committed). See [database_snapshot.go](/service/vc/database_snapshot.go).
+committed, preserving the invariant `txID committed <=> clone ready <=> PENDING row`.
+For YugabyteDB, ready means `yb_database_clones().state = 'COMPLETE'`; a
+`pg_database` row alone is insufficient. The clone is a consistent copy of the
+drained state cut and is never dropped by the VC (dropping is forbidden because
+it could delete a clone whose txID has not yet committed). See
+[database_snapshot.go](/service/vc/database_snapshot.go).
 
 A `_snapshot` transaction is submitted standalone: the sidecar drains the pipeline
 before and after it, so no user transaction commits until the snapshot is fully
 processed. The clone therefore captures the exact snapshot cut with a plain
 `CREATE DATABASE <clone> TEMPLATE <source>` (as of current time), with no `AS OF`
-timestamp required.
+timestamp required. After either initial creation or duplicate-name reuse,
+YugabyteDB clone state is polled until `COMPLETE`. An `ABORTED` state fails
+promptly and reports YugabyteDB's `failure_reason`. PostgreSQL clone creation is
+synchronous and retains its existing duplicate-reuse behavior.
 
 > **YugabyteDB prerequisite — a PITR snapshot schedule is mandatory.** YugabyteDB
 > database cloning is built on Point-in-Time Recovery: `CREATE DATABASE ... TEMPLATE`

--- a/service/vc/database_snapshot.go
+++ b/service/vc/database_snapshot.go
@@ -39,7 +39,16 @@ import (
 // connection itself from being one of the sessions that gets terminated or
 // locked out by that sequence. Does not apply to YugabyteDB (DocDB cloning
 // keeps the source live, so no lockout dance is needed there).
-const maintenanceDBName = "postgres"
+const (
+	maintenanceDBName = "postgres"
+
+	yugabyteCloneStateComplete = "COMPLETE"
+	yugabyteCloneStateAborted  = "ABORTED"
+	yugabyteCloneStateQuery    = `
+SELECT state, COALESCE(failure_reason, '')
+FROM yb_database_clones()
+WHERE db_name = $1`
+)
 
 // rejectSnapshotIfPriorNotCheckpointed gates a new _snapshot request so that at
 // most one snapshot lifecycle is active. The request is accepted only when the
@@ -294,12 +303,11 @@ func (db *database) createSnapshotDatabaseAndRewriteRecord(
 	return snapshotState, nil
 }
 
-// createSnapshotDatabase creates native zero-copy database named databaseName
-// from source database. CREATE-only: it never DROPs. A "database already exists"
-// result is treated as success (reuse) — name is deterministic and database
-// content is drained deterministic cut, so a sibling VC's database is
-// equivalent. Dropping here could delete a database whose txID has not yet
-// committed, so it is forbidden.
+// createSnapshotDatabase creates or reuses a native zero-copy database. A duplicate
+// name is a reuse candidate: YugabyteDB still verifies clone completion before success.
+// Name is deterministic and database content is a drained deterministic cut, so a
+// sibling VC's complete database is equivalent. Dropping here could delete a database
+// whose txID has not yet committed, so it is forbidden.
 //
 // TODO: a hard-kill of the PostgreSQL path between
 // ALLOW_CONNECTIONS false and the deferred re-enable locks out src for ALL
@@ -311,25 +319,41 @@ func (db *database) createSnapshotDatabase(ctx context.Context, databaseName str
 	if err != nil {
 		return err
 	}
+	if isYuga {
+		return db.createYugabyteSnapshotDatabase(ctx, databaseName, db.config.Database)
+	}
+
 	src := pgx.Identifier{db.config.Database}.Sanitize()
 	snapshotDatabase := pgx.Identifier{databaseName}.Sanitize()
-
-	if isYuga {
-		return db.createYugabyteSnapshotDatabase(ctx, snapshotDatabase, src)
-	}
 	return db.createPostgresSnapshotDatabase(ctx, snapshotDatabase, src)
 }
 
-// createYugabyteSnapshotDatabase uses DocDB cloning via CREATE DATABASE ... TEMPLATE; the
-// source stays live. We clone as of current time (no AS OF): the sidecar drains
-// before and after the snapshot TX and no user TX commits until the snapshot is
-// fully processed, so "now" already is the exact snapshot cut. Cloning still
-// requires a snapshot schedule to exist on the source keyspace (a standing PITR
-// object provisioned out of band); without it YugabyteDB returns "Could not
-// find snapshot schedule for namespace".
-func (db *database) createYugabyteSnapshotDatabase(ctx context.Context, clone, src string) error {
+// createYugabyteSnapshotDatabase uses DocDB cloning and waits for YugabyteDB's clone
+// catalog to report COMPLETE after either creation or duplicate-name reuse. Source stays
+// live. We clone as of current time (no AS OF): sidecar drains before and after snapshot
+// TX and no user TX commits until snapshot is fully processed, so "now" is exact cut.
+// Cloning requires a snapshot schedule on source keyspace; without it YugabyteDB returns
+// "Could not find snapshot schedule for namespace".
+func (db *database) createYugabyteSnapshotDatabase(ctx context.Context, cloneName, srcName string) error {
+	clone := pgx.Identifier{cloneName}.Sanitize()
+	src := pgx.Identifier{srcName}.Sanitize()
 	sql := fmt.Sprintf("CREATE DATABASE %s TEMPLATE %s", clone, src)
-	return ignoreDuplicateDatabase(db.adminExec(ctx, sql))
+	if err := ignoreDuplicateDatabase(db.adminExec(ctx, sql)); err != nil {
+		return err
+	}
+	return db.waitForYugabyteClone(ctx, cloneName)
+}
+
+func (db *database) waitForYugabyteClone(ctx context.Context, clone string) error {
+	_, err := retry.ExecuteWithResult(ctx, db.retryProfile, func() (any, error) {
+		var state, failureReason string
+		err := db.pool.QueryRow(ctx, yugabyteCloneStateQuery, clone).Scan(&state, &failureReason)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to read state for YugabyteDB clone %s", clone)
+		}
+		return nil, yugabyteCloneStateError(clone, state, failureReason)
+	}, retry.ErrNonRetryable)
+	return err
 }
 
 // createPostgresSnapshotDatabase uses STRATEGY=FILE_COPY. PostgreSQL requires the source
@@ -411,9 +435,8 @@ func (db *database) adminExec(ctx context.Context, sql string) error {
 	return errors.Wrapf(err, "failed to execute admin statement [%s]", sql)
 }
 
-// ignoreDuplicateDatabase maps the "database already exists" error (PG SQLSTATE
-// 42P04) to success: a concurrent sibling VC created the clone first, which is
-// exactly the clone we need (reuse).
+// ignoreDuplicateDatabase maps 42P04 to nil so backend-specific callers can reuse
+// a deterministic clone name. YugabyteDB callers must still verify clone readiness.
 func ignoreDuplicateDatabase(err error) error {
 	if err == nil {
 		return nil
@@ -423,6 +446,25 @@ func ignoreDuplicateDatabase(err error) error {
 		return nil
 	}
 	return err
+}
+
+func yugabyteCloneStateError(clone, state, failureReason string) error {
+	switch state {
+	case yugabyteCloneStateComplete:
+		return nil
+	case yugabyteCloneStateAborted:
+		if failureReason == "" {
+			failureReason = "not reported"
+		}
+		return errors.Wrapf(
+			retry.ErrNonRetryable,
+			"YugabyteDB clone %s aborted; failure reason: %s",
+			clone,
+			failureReason,
+		)
+	default:
+		return errors.Newf("YugabyteDB clone %s is not ready: state %s", clone, state)
+	}
 }
 
 // snapshotDatabaseName returns deterministic database name for a snapshot at

--- a/service/vc/database_snapshot_test.go
+++ b/service/vc/database_snapshot_test.go
@@ -41,6 +41,63 @@ func TestSnapshotDatabaseName(t *testing.T) {
 	}
 }
 
+func TestYugabyteCloneStateError(t *testing.T) {
+	t.Parallel()
+
+	require.NoError(t, yugabyteCloneStateError("snapshot_1", "COMPLETE", ""))
+
+	for _, tc := range []struct {
+		name               string
+		state              string
+		failureReason      string
+		expectedError      string
+		expectNonRetryable bool
+	}{
+		{
+			name:          "aborted clone reports server reason",
+			state:         "ABORTED",
+			failureReason: "tablet limit exceeded",
+			expectedError: "YugabyteDB clone snapshot_1 aborted; " +
+				"failure reason: tablet limit exceeded",
+			expectNonRetryable: true,
+		},
+		{
+			name:  "aborted clone reports absent reason",
+			state: "ABORTED",
+			expectedError: "YugabyteDB clone snapshot_1 aborted; " +
+				"failure reason: not reported",
+			expectNonRetryable: true,
+		},
+		{
+			name:          "schema creation remains retryable",
+			state:         "CLONE_SCHEMA_STARTED",
+			expectedError: "YugabyteDB clone snapshot_1 is not ready: state CLONE_SCHEMA_STARTED",
+		},
+		{
+			name:          "restoring clone remains retryable",
+			state:         "RESTORING",
+			expectedError: "YugabyteDB clone snapshot_1 is not ready: state RESTORING",
+		},
+		{
+			name:          "unknown clone state remains retryable",
+			state:         "FUTURE_STATE",
+			expectedError: "YugabyteDB clone snapshot_1 is not ready: state FUTURE_STATE",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := yugabyteCloneStateError("snapshot_1", tc.state, tc.failureReason)
+			require.ErrorContains(t, err, tc.expectedError)
+			if tc.expectNonRetryable {
+				require.ErrorIs(t, err, retry.ErrNonRetryable)
+			} else {
+				require.NotErrorIs(t, err, retry.ErrNonRetryable)
+			}
+		})
+	}
+}
+
 func TestCreateSnapshotDatabase(t *testing.T) {
 	t.Parallel()
 	env := NewDatabaseTestEnv(t)
@@ -108,16 +165,23 @@ func requireCloneHasRow(t *testing.T, db *database, cloneName string, row cloneR
 
 func cloneExists(t *testing.T, db *database, name string) bool {
 	t.Helper()
-	// createSnapshotDatabase's PostgreSQL path terminates all connections to source
-	// database (see createPostgresSnapshotDatabase), which can include this pool's own connection
-	// to db.config.Database, not just the clone name being polled for; the very next
-	// pool acquisition can hit that severed connection (SQLSTATE 57P01) before pgxpool
-	// notices and redials. Production callers tolerate this via db.retryProfile
-	// (e.g. commit's post-clone follow-up query); do the same here instead of a bare query.
+	// PostgreSQL clone creation terminates source connections, so catalog queries
+	// need retries while pgxpool redials. YugabyteDB readiness requires both a
+	// database catalog entry and an asynchronous clone state of COMPLETE.
 	exists, err := retry.ExecuteWithResult(t.Context(), db.retryProfile, func() (bool, error) {
+		isYuga, err := statedb.IsYugabyteDB(t.Context(), db.pool)
+		if err != nil {
+			return false, err
+		}
+
+		query := "SELECT EXISTS(SELECT 1 FROM pg_database WHERE datname = $1)"
+		if isYuga {
+			query += " AND EXISTS(" +
+				"SELECT 1 FROM yb_database_clones() WHERE db_name = $1 AND state = 'COMPLETE')"
+		}
+
 		var exists bool
-		err := db.pool.QueryRow(t.Context(),
-			"SELECT EXISTS(SELECT 1 FROM pg_database WHERE datname = $1)", name).Scan(&exists)
+		err = db.pool.QueryRow(t.Context(), query, name).Scan(&exists)
 		return exists, err
 	})
 	require.NoError(t, err)

--- a/utils/retry/executor.go
+++ b/utils/retry/executor.go
@@ -23,10 +23,11 @@ type executor interface {
 var errConditionNotSatisfied = errors.New("condition not satisfied")
 
 // ExecuteWithResult executes the given operation repeatedly until it succeeds or a timeout occurs.
-// It returns the result of the operation on success, or an error on timeout.
-// This is a generic version that can return any type T.
-func ExecuteWithResult[T any](ctx context.Context, p *Profile, operation func() (T, error)) (T, error) {
-	return executeWithResult(ctx, p, operation)
+// Errors matching terminalErrors stop retries immediately.
+func ExecuteWithResult[T any](
+	ctx context.Context, p *Profile, operation func() (T, error), terminalErrors ...error,
+) (T, error) {
+	return executeWithResult(ctx, p, operation, terminalErrors...)
 }
 
 // Execute executes the given operation repeatedly until it succeeds or a timeout occurs.

--- a/utils/retry/executor_test.go
+++ b/utils/retry/executor_test.go
@@ -135,6 +135,40 @@ func TestExecute(t *testing.T) {
 	}
 }
 
+func TestExecuteWithResultRetries(t *testing.T) {
+	t.Parallel()
+
+	callCount := 0
+	result, err := ExecuteWithResult(t.Context(), &Profile{
+		InitialInterval: time.Millisecond,
+		MaxElapsedTime:  new(time.Second),
+	}, func() (int, error) {
+		callCount++
+		if callCount < 3 {
+			return 0, errors.New("transient error")
+		}
+		return 42, nil
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, 42, result)
+	require.Equal(t, 3, callCount)
+}
+
+func TestExecuteWithResultTerminalError(t *testing.T) {
+	t.Parallel()
+
+	terminalErr := errors.New("terminal error")
+	callCount := 0
+	_, err := ExecuteWithResult(t.Context(), nil, func() (int, error) {
+		callCount++
+		return 0, errors.Wrap(terminalErr, "operation failed")
+	}, terminalErr)
+
+	require.ErrorIs(t, err, terminalErr)
+	require.Equal(t, 1, callCount)
+}
+
 // TestExecuteLogLevel is used to manually verify the log output is using the correct
 // method name when logging.
 //


### PR DESCRIPTION
#### Type of change

- Bug fix
- Test update
- Documentation update

#### Description

- Poll YugabyteDB clone state after both creation and duplicate-name reuse.
- Stop retries for aborted clones and preserve their reported failure reason.
- Require clone completion in snapshot test readiness checks.
- Document YugabyteDB clone readiness semantics.

#### Related issues

- resolves #762
