### PR TITLE
[sidecar] add blockhash and prevblockhash to allTxStream block event

### DIFF
--- a/docs/notification-service.md
+++ b/docs/notification-service.md
@@ -197,10 +197,14 @@ message StreamAllRequest {
     repeated Status filter_status = 2;      // Optional: filter by status
     bool include_read_write_sets = 3;       // Optional: include read/write sets
     bool include_endorsements = 4;          // Optional: include endorsements
+    bool include_metadata = 5;              // Optional: include transaction metadata
 }
 
-message TxBatch {
-    repeated TxEvent events = 1;
+message BlockEvent {
+    uint64 block_number = 1;                // The block these events originated from
+    repeated TxEvent events = 2;
+    bytes block_hash = 3;                   // The hash of this block
+    bytes prev_block_hash = 4;              // The hash of the previous block
 }
 
 message TxEvent {
@@ -208,6 +212,7 @@ message TxEvent {
     Status status = 2;                      // Transaction status
     repeated TxNamespace namespaces = 3;    // Namespaces (if filtering enabled)
     repeated Endorsement endorsements = 4;  // Endorsements (if requested)
+    repeated bytes metadata = 5;            // Transaction metadata (if requested)
 }
 ```
 
@@ -240,10 +245,14 @@ stream, err := client.StreamAllTransactions(ctx, &committerpb.StreamAllRequest{
 - **`include_endorsements`** (optional): If true, the `endorsements` field in each `TxEvent`
   includes the transaction endorsements. Default: false.
 
+- **`include_metadata`** (optional): If true, the `metadata` field in each `TxEvent`
+  includes the transaction metadata. Default: false.
+
 ### 3.3. Receiving Transaction Events
 
-The server sends `TxBatch` messages containing one or more `TxEvent` entries. Transactions are batched by block. All
-transactions from the same block are delivered in a single `TxBatch`.
+The server sends `BlockEvent` messages containing one or more `TxEvent` entries, along with the block's hash and its
+predecessor's hash. Transactions are batched by block. All transactions from the same block are delivered in a single
+`BlockEvent`.
 
 ```go
 for {

--- a/docs/notification-service.md
+++ b/docs/notification-service.md
@@ -250,16 +250,16 @@ stream, err := client.StreamAllTransactions(ctx, &committerpb.StreamAllRequest{
 
 ### 3.3. Receiving Transaction Events
 
-The server sends `BlockEvent` messages containing one or more `TxEvent` entries, along with the block's hash and its
-predecessor's hash. Transactions are batched by block. All transactions from the same block are delivered in a single
-`BlockEvent`.
+The server sends one `BlockEvent` per committed block, containing zero or more `TxEvent` entries (zero if none matched
+the request's filters), along with the block's hash and its predecessor's hash. Transactions are batched by block: all
+transactions from the same block are delivered in a single `BlockEvent`.
 
 ```go
 for {
-    batch, err := stream.Recv()
+    blockEvent, err := stream.Recv()
     ...
 
-    for _, event := range batch.Events {
+    for _, event := range blockEvent.Events {
         ...
     }
 }
@@ -270,6 +270,11 @@ for {
 **Block Order Guarantee:**
 Transactions are streamed in deterministic block order. All transactions from block N are delivered before any
 transactions from block N+1.
+
+**Unbroken Hash Chain:**
+A `BlockEvent` is delivered for every block, even one whose filters match no transactions. `block_hash`/
+`prev_block_hash` therefore form an unbroken chain for every client regardless of its filters, so a client that only
+needs to verify block linkage does not need to receive matching transactions to do so.
 
 **Starting Point:**
 The stream starts from the currently processed block when the client connects. Historical transactions are not included.

--- a/docs/notification-service.md
+++ b/docs/notification-service.md
@@ -16,7 +16,7 @@ The Sidecar exposes a Notification Service that provides two mechanisms for rece
    containing transaction IDs of interest, and the server pushes status responses as transactions
    complete. Multiple subscription requests can be sent on the same stream.
 
-2. **All Transactions Stream** — Allows clients to subscribe to a stream of all committed transactions in block order,
+2. **Blocks Stream** — Allows clients to subscribe to a stream of all committed transactions in block order,
    with optional filtering by namespace and status. This is useful for audit, monitoring, event-driven applications, and
    replication systems.
 
@@ -34,7 +34,7 @@ service Notifier {
     rpc OpenNotificationStream (stream NotificationRequest) returns (stream NotificationResponse);
 
     // Subscribe to all committed transactions
-    rpc StreamAllTransactions (StreamAllRequest) returns (stream TxBatch);
+    rpc StreamBlocks (StreamBlocksRequest) returns (stream BlockEvent);
 }
 ```
 
@@ -183,16 +183,16 @@ If the notification stream breaks (e.g., sidecar restart) or the timeout expires
 the transaction completes, the client should fall back to the Block Query API to check
 the transaction status.
 
-## 3. All Transactions Stream API
+## 3. Blocks Stream API
 
 ### 3.1. API Definition
 
-The `StreamAllTransactions` RPC provides a server-streaming interface that delivers all committed transactions in block
+The `StreamBlocks` RPC provides a server-streaming interface that delivers all committed transactions in block
 order. Unlike the transaction ID subscription API, this stream does not require clients to know transaction IDs in
 advance.
 
 ```protobuf
-message StreamAllRequest {
+message StreamBlocksRequest {
     repeated string filter_namespaces = 1;  // Optional: filter by namespace(s)
     repeated Status filter_status = 2;      // Optional: filter by status
     bool include_read_write_sets = 3;       // Optional: include read/write sets
@@ -218,11 +218,11 @@ message TxEvent {
 
 ### 3.2. Opening a Stream
 
-Create a gRPC connection to the Sidecar and call `StreamAllTransactions`:
+Create a gRPC connection to the Sidecar and call `StreamBlocks`:
 
 ```go
 client := committerpb.NewNotifierClient(conn)
-stream, err := client.StreamAllTransactions(ctx, &committerpb.StreamAllRequest{
+stream, err := client.StreamBlocks(ctx, &committerpb.StreamBlocksRequest{
     FilterNamespaces: []string{"namespace-1", "namespace-2"},
     FilterStatus: []committerpb.Status{committerpb.Status_COMMITTED},
     IncludeReadWriteSets: true,
@@ -304,7 +304,7 @@ The following configuration options in `sidecar.yaml` control notification behav
 |-------------------------------------|---------|-------------------------------------------------------------------------------------------------|
 | `notification.max-timeout`          | `1m`    | Upper limit on per-request timeout for transaction ID subscriptions.                            |
 | `notification.stream-write-timeout` | `30s`   | Write timeout for all transactions stream. Prevents slow clients from blocking.                 |
-| `server.max-concurrent-streams`     | `10`    | Maximum concurrent streaming RPCs across all stream types (Deliver + Notification + StreamAll). |
+| `server.max-concurrent-streams`     | `10`    | Maximum concurrent streaming RPCs across all stream types (Deliver + Notification + Blocks). |
 
 Sample configuration:
 

--- a/docs/sidecar.md
+++ b/docs/sidecar.md
@@ -40,7 +40,7 @@ The Sidecar performs four main tasks:
 5. **Deliver to Clients:** Delivers the committed blocks to registered client applications.
 6. **Notification:** Provides two notification mechanisms:
    - **Transaction ID Subscription:** Notifies subscribers when specific transactions (by ID) are committed or aborted.
-   - **All Transactions Stream:** Streams all committed transactions in block order with optional filtering.
+   - **Blocks Stream:** Streams all committed transactions in block order with optional filtering.
 
 Note that the fourth task is executed only when users/clients creates a stream with the sidecar.
 

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0
 	github.com/hyperledger/fabric-lib-go v1.1.5-0.20260708100132-163bcc919208
 	github.com/hyperledger/fabric-protos-go-apiv2 v0.3.7
-	github.com/hyperledger/fabric-x-common v0.2.9-0.20260831072618-17086b345c4e
+	github.com/hyperledger/fabric-x-common v0.2.9-0.20260901113056-19797db6b1d6
 	github.com/jackc/pgerrcode v0.0.0-20250907135507-afb5586c32a6
 	github.com/jackc/puddle/v2 v2.2.2
 	github.com/moby/moby/api v1.55.0

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0
 	github.com/hyperledger/fabric-lib-go v1.1.5-0.20260708100132-163bcc919208
 	github.com/hyperledger/fabric-protos-go-apiv2 v0.3.7
-	github.com/hyperledger/fabric-x-common v0.2.9-0.20260723091942-e43f1af10c7e
+	github.com/hyperledger/fabric-x-common v0.2.9-0.20260831072618-17086b345c4e
 	github.com/jackc/pgerrcode v0.0.0-20250907135507-afb5586c32a6
 	github.com/jackc/puddle/v2 v2.2.2
 	github.com/moby/moby/api v1.55.0

--- a/go.sum
+++ b/go.sum
@@ -184,8 +184,8 @@ github.com/hyperledger/fabric-lib-go v1.1.5-0.20260708100132-163bcc919208 h1:qA4
 github.com/hyperledger/fabric-lib-go v1.1.5-0.20260708100132-163bcc919208/go.mod h1:EKqTudBsC2yovZdcJq5ekWvkq3USF1mbau07I0y8zMs=
 github.com/hyperledger/fabric-protos-go-apiv2 v0.3.7 h1:sQ5qv8vQQfwewa1JlCiSCC8dLElmaU2/frLolpgibEY=
 github.com/hyperledger/fabric-protos-go-apiv2 v0.3.7/go.mod h1:bJnwzfv03oZQeCc863pdGTDgf5nmCy6Za3RAE7d2XsQ=
-github.com/hyperledger/fabric-x-common v0.2.9-0.20260831072618-17086b345c4e h1:YYnzPJ8sVJmQIYxYJCVZ/Zq4yp9Y7QUazl3p1Q+ldyo=
-github.com/hyperledger/fabric-x-common v0.2.9-0.20260831072618-17086b345c4e/go.mod h1:9IP6vlsn6WfFadbyEkggEJV5hIhfqseLsxeJ8h4xX10=
+github.com/hyperledger/fabric-x-common v0.2.9-0.20260901113056-19797db6b1d6 h1:YxoqQjiG//VdhGZPBBuyiKu3d+SE2FgZrC/g2TxjMJk=
+github.com/hyperledger/fabric-x-common v0.2.9-0.20260901113056-19797db6b1d6/go.mod h1:9IP6vlsn6WfFadbyEkggEJV5hIhfqseLsxeJ8h4xX10=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imkira/go-interpol v1.1.0 h1:KIiKr0VSG2CUW1hl1jpiyuzuJeKUUpC8iM1AIE7N1Vk=
 github.com/imkira/go-interpol v1.1.0/go.mod h1:z0h2/2T3XF8kyEPpRgJ3kmNv+C43p+I/CoI+jC3w2iA=

--- a/go.sum
+++ b/go.sum
@@ -184,8 +184,8 @@ github.com/hyperledger/fabric-lib-go v1.1.5-0.20260708100132-163bcc919208 h1:qA4
 github.com/hyperledger/fabric-lib-go v1.1.5-0.20260708100132-163bcc919208/go.mod h1:EKqTudBsC2yovZdcJq5ekWvkq3USF1mbau07I0y8zMs=
 github.com/hyperledger/fabric-protos-go-apiv2 v0.3.7 h1:sQ5qv8vQQfwewa1JlCiSCC8dLElmaU2/frLolpgibEY=
 github.com/hyperledger/fabric-protos-go-apiv2 v0.3.7/go.mod h1:bJnwzfv03oZQeCc863pdGTDgf5nmCy6Za3RAE7d2XsQ=
-github.com/hyperledger/fabric-x-common v0.2.9-0.20260723091942-e43f1af10c7e h1:1TiqmKe1L3/KnKXHHId+i1WHY/4hIaI8sCyLrhWFpsI=
-github.com/hyperledger/fabric-x-common v0.2.9-0.20260723091942-e43f1af10c7e/go.mod h1:f30Yws3c5Cg22yHLy2oT2XR0wwZI+JdqbUqB2fwFIsM=
+github.com/hyperledger/fabric-x-common v0.2.9-0.20260831072618-17086b345c4e h1:YYnzPJ8sVJmQIYxYJCVZ/Zq4yp9Y7QUazl3p1Q+ldyo=
+github.com/hyperledger/fabric-x-common v0.2.9-0.20260831072618-17086b345c4e/go.mod h1:9IP6vlsn6WfFadbyEkggEJV5hIhfqseLsxeJ8h4xX10=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imkira/go-interpol v1.1.0 h1:KIiKr0VSG2CUW1hl1jpiyuzuJeKUUpC8iM1AIE7N1Vk=
 github.com/imkira/go-interpol v1.1.0/go.mod h1:z0h2/2T3XF8kyEPpRgJ3kmNv+C43p+I/CoI+jC3w2iA=

--- a/integration/runner/runtime.go
+++ b/integration/runner/runtime.go
@@ -62,7 +62,7 @@ type (
 		SidecarClientConfig *connection.ClientConfig
 		NotifyClient        committerpb.NotifierClient
 		NotifyStream        committerpb.Notifier_OpenNotificationStreamClient
-		BlockStream         committerpb.Notifier_StreamAllTransactionsClient
+		BlockStream         committerpb.Notifier_StreamBlocksClient
 
 		CommittedBlock          chan *common.Block
 		TxBuilder               *workload.TxBuilder
@@ -355,7 +355,7 @@ func (c *CommitterRuntime) OpenNotificationStream(ctx context.Context, t *testin
 	var err error
 	c.NotifyStream, err = c.NotifyClient.OpenNotificationStream(ctx)
 	require.NoError(t, err)
-	c.BlockStream, err = c.NotifyClient.StreamAllTransactions(ctx, nil)
+	c.BlockStream, err = c.NotifyClient.StreamBlocks(ctx, nil)
 	require.NoError(t, err)
 }
 
@@ -640,7 +640,7 @@ func (c *CommitterRuntime) ValidateExpectedResultsInCommittedBlock(t *testing.T,
 	}
 
 	sidecar.RequireNotifications(t, c.NotifyStream, blk.Header.Number, expected.TxIDs, expected.Statuses)
-	sidecar.RequireStreamAllTransactions(t, c.BlockStream, blk.Header.Number, expected.TxIDs, expected.Statuses)
+	sidecar.RequireStreamBlocks(t, c.BlockStream, blk.Header.Number, expected.TxIDs, expected.Statuses)
 }
 
 // CountStatus returns the number of transactions with a given tx status.

--- a/integration/runner/runtime.go
+++ b/integration/runner/runtime.go
@@ -62,7 +62,7 @@ type (
 		SidecarClientConfig *connection.ClientConfig
 		NotifyClient        committerpb.NotifierClient
 		NotifyStream        committerpb.Notifier_OpenNotificationStreamClient
-		StreamAllTxStream   committerpb.Notifier_StreamAllTransactionsClient
+		BlockStream         committerpb.Notifier_StreamAllTransactionsClient
 
 		CommittedBlock          chan *common.Block
 		TxBuilder               *workload.TxBuilder
@@ -355,7 +355,7 @@ func (c *CommitterRuntime) OpenNotificationStream(ctx context.Context, t *testin
 	var err error
 	c.NotifyStream, err = c.NotifyClient.OpenNotificationStream(ctx)
 	require.NoError(t, err)
-	c.StreamAllTxStream, err = c.NotifyClient.StreamAllTransactions(ctx, nil)
+	c.BlockStream, err = c.NotifyClient.StreamAllTransactions(ctx, nil)
 	require.NoError(t, err)
 }
 
@@ -640,7 +640,7 @@ func (c *CommitterRuntime) ValidateExpectedResultsInCommittedBlock(t *testing.T,
 	}
 
 	sidecar.RequireNotifications(t, c.NotifyStream, blk.Header.Number, expected.TxIDs, expected.Statuses)
-	sidecar.RequireStreamAllTransactions(t, c.StreamAllTxStream, blk.Header.Number, expected.TxIDs, expected.Statuses)
+	sidecar.RequireStreamAllTransactions(t, c.BlockStream, blk.Header.Number, expected.TxIDs, expected.Statuses)
 }
 
 // CountStatus returns the number of transactions with a given tx status.

--- a/integration/test/stream_concurrency_test.go
+++ b/integration/test/stream_concurrency_test.go
@@ -28,7 +28,7 @@ func TestStreamConcurrencyLimit(t *testing.T) {
 	// The runtime's Start opens 2 long-lived streams:
 	//   1. Deliver stream (startBlockDelivery)
 	//   2. Notification stream (OpenNotificationStream)
-	//   3. Notification block stream (StreamAllTransactions)
+	//   3. Notification block stream (StreamBlocks)
 	// With MaxConcurrentStreams=4, exactly 1 slot remain for the test.
 	const maxStreams = 4
 	c := runner.NewRuntime(t, &runner.Config{
@@ -86,9 +86,9 @@ func TestStreamConcurrencyLimit(t *testing.T) {
 	}
 	requireResourceExhausted(t, err)
 
-	rejectedStreamAll, err := notifyClient.StreamAllTransactions(t.Context(), nil)
+	rejectedStreamBlocks, err := notifyClient.StreamBlocks(t.Context(), nil)
 	if err == nil {
-		_, err = rejectedStreamAll.Recv()
+		_, err = rejectedStreamBlocks.Recv()
 	}
 	requireResourceExhausted(t, err)
 

--- a/service/sidecar/mapping.go
+++ b/service/sidecar/mapping.go
@@ -50,7 +50,7 @@ type (
 		txStatus     []committerpb.Status
 		pendingCount atomic.Int32
 
-		// Fields for StreamAllTransactions support
+		// Fields for StreamBlocks support
 		blockNumber uint64                 // Block number
 		txs         []*servicepb.TxWithRef // Transaction content (from coordinatorBatch.Txs)
 	}

--- a/service/sidecar/notify.go
+++ b/service/sidecar/notify.go
@@ -72,9 +72,11 @@ type (
 	// for streaming to StreamAllTransactions clients. This is a clean interface
 	// that separates the notifier from relay's internal blockWithStatus structure.
 	committedBlockWithTxs struct {
-		blockNumber uint64
-		txs         []*servicepb.TxWithRef
-		statuses    []committerpb.Status
+		blockNumber   uint64
+		txs           []*servicepb.TxWithRef
+		statuses      []committerpb.Status
+		blockHash     []byte
+		prevBlockHash []byte
 	}
 
 	// allTxStream represents a single StreamAllTransactions client subscription.
@@ -447,12 +449,14 @@ func (s *allTxStream) streamWorker(stream committerpb.Notifier_StreamAllTransact
 			continue
 		}
 
-		batch := &committerpb.TxEventBatch{
-			BlockNumber: block.blockNumber,
-			Events:      filteredEvents,
+		blockEvent := &committerpb.BlockEvent{
+			BlockNumber:   block.blockNumber,
+			Events:        filteredEvents,
+			BlockHash:     block.blockHash,
+			PrevBlockHash: block.prevBlockHash,
 		}
-		if err := stream.Send(batch); err != nil {
-			return errors.Wrap(err, "failed to send transaction batch")
+		if err := stream.Send(blockEvent); err != nil {
+			return errors.Wrap(err, "failed to send block event")
 		}
 	}
 }

--- a/service/sidecar/notify.go
+++ b/service/sidecar/notify.go
@@ -45,7 +45,7 @@ type (
 		// timeoutQueue receives requests whose deadline has passed.
 		timeoutQueue chan *notificationRequest
 
-		// StreamAllTransactions support
+		// StreamBlocks support
 		blockStreams   []*blockStream
 		blockStreamsMu sync.RWMutex
 	}
@@ -69,7 +69,7 @@ type (
 	}
 
 	// committedBlockWithTxs contains the essential data from a committed block
-	// for streaming to StreamAllTransactions clients. This is a clean interface
+	// for streaming to StreamBlocks clients. This is a clean interface
 	// that separates the notifier from relay's internal blockWithStatus structure.
 	committedBlockWithTxs struct {
 		blockNumber   uint64
@@ -79,7 +79,7 @@ type (
 		prevBlockHash []byte
 	}
 
-	// blockStream represents a single StreamAllTransactions client subscription.
+	// blockStream represents a single StreamBlocks client subscription.
 	// Each stream has its own filters and receives committed blocks via a channel.
 	blockStream struct {
 		// Filters (empty = no filter)
@@ -223,12 +223,12 @@ func (n *notifier) OpenNotificationStream(stream committerpb.Notifier_OpenNotifi
 	return wrapNotifierError(g.Wait())
 }
 
-// StreamAllTransactions implements the [committerpb.NotifierServer] API.
+// StreamBlocks implements the [committerpb.NotifierServer] API.
 // It streams all committed transactions to the client, with optional filtering
 // by namespace and transaction status.
-func (n *notifier) StreamAllTransactions(
-	req *committerpb.StreamAllRequest,
-	stream committerpb.Notifier_StreamAllTransactionsServer,
+func (n *notifier) StreamBlocks(
+	req *committerpb.StreamBlocksRequest,
+	stream committerpb.Notifier_StreamBlocksServer,
 ) error {
 	// Create stream context with cancellation
 	ctx, cancel := context.WithCancel(stream.Context())
@@ -374,7 +374,7 @@ func (m *subscriptions) removeAndEnqueueTimeoutEvents(
 }
 
 // dispatchBlockToStreams dispatches a committed block to all registered
-// StreamAllTransactions clients. It handles slow clients by using a timeout
+// StreamBlocks clients. It handles slow clients by using a timeout
 // and canceling streams that cannot keep up.
 func (n *notifier) dispatchBlockToStreams(ctx context.Context, block *committedBlockWithTxs) {
 	// Get snapshot of streams with minimal lock time
@@ -399,7 +399,7 @@ func (n *notifier) dispatchBlockToStreams(ctx context.Context, block *committedB
 	}
 }
 
-// registerBlockStream adds a new StreamAllTransactions client to the notifier.
+// registerBlockStream adds a new StreamBlocks client to the notifier.
 // The stream will receive all committed blocks until it is unregistered or cancelled.
 func (n *notifier) registerBlockStream(stream *blockStream) {
 	n.blockStreamsMu.Lock()
@@ -413,7 +413,7 @@ func (n *notifier) registerBlockStream(stream *blockStream) {
 	n.blockStreams = streams
 }
 
-// unregisterBlockStream removes a StreamAllTransactions client from the notifier.
+// unregisterBlockStream removes a StreamBlocks client from the notifier.
 func (n *notifier) unregisterBlockStream(stream *blockStream) {
 	n.blockStreamsMu.Lock()
 	defer n.blockStreamsMu.Unlock()
@@ -431,10 +431,10 @@ func (n *notifier) unregisterBlockStream(stream *blockStream) {
 	n.blockStreams = streams
 }
 
-// streamWorker runs in its own goroutine for each StreamAllTransactions client.
+// streamWorker runs in its own goroutine for each StreamBlocks client.
 // It receives committed blocks from the blockQueue, filters and enriches them
 // according to the stream's configuration, and sends the results to the client.
-func (s *blockStream) streamWorker(stream committerpb.Notifier_StreamAllTransactionsServer) error {
+func (s *blockStream) streamWorker(stream committerpb.Notifier_StreamBlocksServer) error {
 	q := channel.NewReader(s.ctx, s.blockQueue)
 	for {
 		block, ok := q.Read()

--- a/service/sidecar/notify.go
+++ b/service/sidecar/notify.go
@@ -46,8 +46,8 @@ type (
 		timeoutQueue chan *notificationRequest
 
 		// StreamAllTransactions support
-		allTxStreams   []*allTxStream
-		allTxStreamsMu sync.RWMutex
+		blockStreams   []*blockStream
+		blockStreamsMu sync.RWMutex
 	}
 
 	notificationRequest struct {
@@ -79,9 +79,9 @@ type (
 		prevBlockHash []byte
 	}
 
-	// allTxStream represents a single StreamAllTransactions client subscription.
+	// blockStream represents a single StreamAllTransactions client subscription.
 	// Each stream has its own filters and receives committed blocks via a channel.
-	allTxStream struct {
+	blockStream struct {
 		// Filters (empty = no filter)
 		filterNamespaces []string
 		filterStatuses   []committerpb.Status
@@ -178,7 +178,7 @@ func (n *notifier) run(
 			n.recordRemovals(pendingTxIDsRemoved, uniquePendingTxIDsRemoved)
 			promutil.AddToCounter(n.metrics.notifierTxIDsTimeoutDeliveries, pendingTxIDsRemoved)
 		case block := <-committedBlockWithTxs:
-			n.dispatchBlockToAllTxStreams(ctx, block)
+			n.dispatchBlockToStreams(ctx, block)
 		}
 	}
 }
@@ -235,7 +235,7 @@ func (n *notifier) StreamAllTransactions(
 	defer cancel()
 
 	// Create stream state with filters from request
-	s := &allTxStream{
+	s := &blockStream{
 		filterNamespaces:     req.FilterNamespaces,
 		filterStatuses:       req.FilterStatus,
 		includeReadWriteSets: req.IncludeReadWriteSets,
@@ -247,8 +247,8 @@ func (n *notifier) StreamAllTransactions(
 	}
 
 	// Register stream to receive blocks
-	n.registerAllTxStream(s)
-	defer n.unregisterAllTxStream(s)
+	n.registerBlockStream(s)
+	defer n.unregisterBlockStream(s)
 
 	// Run worker to process blocks and send to client
 	// The worker handles filtering, enrichment, and sending
@@ -373,14 +373,14 @@ func (m *subscriptions) removeAndEnqueueTimeoutEvents(
 	return pendingTxIDsRemoved, uniquePendingTxIDsRemoved
 }
 
-// dispatchBlockToAllTxStreams dispatches a committed block to all registered
+// dispatchBlockToStreams dispatches a committed block to all registered
 // StreamAllTransactions clients. It handles slow clients by using a timeout
 // and canceling streams that cannot keep up.
-func (n *notifier) dispatchBlockToAllTxStreams(ctx context.Context, block *committedBlockWithTxs) {
+func (n *notifier) dispatchBlockToStreams(ctx context.Context, block *committedBlockWithTxs) {
 	// Get snapshot of streams with minimal lock time
-	n.allTxStreamsMu.RLock()
-	streams := n.allTxStreams
-	n.allTxStreamsMu.RUnlock()
+	n.blockStreamsMu.RLock()
+	streams := n.blockStreams
+	n.blockStreamsMu.RUnlock()
 
 	// Write to each stream's channel with configured timeout
 	for _, stream := range streams {
@@ -399,42 +399,42 @@ func (n *notifier) dispatchBlockToAllTxStreams(ctx context.Context, block *commi
 	}
 }
 
-// registerAllTxStream adds a new StreamAllTransactions client to the notifier.
+// registerBlockStream adds a new StreamAllTransactions client to the notifier.
 // The stream will receive all committed blocks until it is unregistered or cancelled.
-func (n *notifier) registerAllTxStream(stream *allTxStream) {
-	n.allTxStreamsMu.Lock()
-	defer n.allTxStreamsMu.Unlock()
+func (n *notifier) registerBlockStream(stream *blockStream) {
+	n.blockStreamsMu.Lock()
+	defer n.blockStreamsMu.Unlock()
 
 	// We create a new slice to prevent modifying the slice while
-	// it is being iterated over in dispatchBlockToAllTxStreams.
-	streams := make([]*allTxStream, len(n.allTxStreams)+1)
-	copy(streams, n.allTxStreams)
-	streams[len(n.allTxStreams)] = stream
-	n.allTxStreams = streams
+	// it is being iterated over in dispatchBlockToStreams.
+	streams := make([]*blockStream, len(n.blockStreams)+1)
+	copy(streams, n.blockStreams)
+	streams[len(n.blockStreams)] = stream
+	n.blockStreams = streams
 }
 
-// unregisterAllTxStream removes a StreamAllTransactions client from the notifier.
-func (n *notifier) unregisterAllTxStream(stream *allTxStream) {
-	n.allTxStreamsMu.Lock()
-	defer n.allTxStreamsMu.Unlock()
+// unregisterBlockStream removes a StreamAllTransactions client from the notifier.
+func (n *notifier) unregisterBlockStream(stream *blockStream) {
+	n.blockStreamsMu.Lock()
+	defer n.blockStreamsMu.Unlock()
 
-	idx := slices.Index(n.allTxStreams, stream)
+	idx := slices.Index(n.blockStreams, stream)
 	if idx < 0 {
 		return
 	}
 
 	// We create a new slice to prevent modifying the slice while
-	// it is being iterated over in dispatchBlockToAllTxStreams.
-	streams := make([]*allTxStream, len(n.allTxStreams)-1)
-	copy(streams, n.allTxStreams[:idx])
-	copy(streams[idx:], n.allTxStreams[idx+1:])
-	n.allTxStreams = streams
+	// it is being iterated over in dispatchBlockToStreams.
+	streams := make([]*blockStream, len(n.blockStreams)-1)
+	copy(streams, n.blockStreams[:idx])
+	copy(streams[idx:], n.blockStreams[idx+1:])
+	n.blockStreams = streams
 }
 
 // streamWorker runs in its own goroutine for each StreamAllTransactions client.
 // It receives committed blocks from the blockQueue, filters and enriches them
 // according to the stream's configuration, and sends the results to the client.
-func (s *allTxStream) streamWorker(stream committerpb.Notifier_StreamAllTransactionsServer) error {
+func (s *blockStream) streamWorker(stream committerpb.Notifier_StreamAllTransactionsServer) error {
 	q := channel.NewReader(s.ctx, s.blockQueue)
 	for {
 		block, ok := q.Read()
@@ -442,16 +442,9 @@ func (s *allTxStream) streamWorker(stream committerpb.Notifier_StreamAllTransact
 			return errors.New("block queue closed")
 		}
 
-		// Filter and build transactions in this worker thread
-		filteredEvents := s.filterAndBuildEvents(block)
-		// Only send if there are events after filtering
-		if len(filteredEvents) == 0 {
-			continue
-		}
-
 		blockEvent := &committerpb.BlockEvent{
 			BlockNumber:   block.blockNumber,
-			Events:        filteredEvents,
+			Events:        s.filterAndBuildEvents(block),
 			BlockHash:     block.blockHash,
 			PrevBlockHash: block.prevBlockHash,
 		}
@@ -463,7 +456,7 @@ func (s *allTxStream) streamWorker(stream committerpb.Notifier_StreamAllTransact
 
 // filterAndBuildEvents processes all transactions in a block, applying filters
 // and enriching with optional content based on the stream's configuration.
-func (s *allTxStream) filterAndBuildEvents(
+func (s *blockStream) filterAndBuildEvents(
 	block *committedBlockWithTxs,
 ) []*committerpb.TxEvent {
 	// Pre-allocate with capacity for efficiency

--- a/service/sidecar/notify_test.go
+++ b/service/sidecar/notify_test.go
@@ -631,6 +631,8 @@ func TestStreamAllTransactions(t *testing.T) {
 			committerpb.Status_COMMITTED,
 			committerpb.Status_REJECTED_DUPLICATE_TX_ID,
 		},
+		blockHash:     []byte("block-hash-1"),
+		prevBlockHash: []byte("block-hash-0"),
 	}
 
 	cases := []struct {
@@ -714,17 +716,19 @@ func TestStreamAllTransactions(t *testing.T) {
 	for i, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			batch, err := streams[i].Recv()
+			blockEvent, err := streams[i].Recv()
 			require.NoError(t, err)
-			require.EqualValues(t, 1, batch.BlockNumber)
+			require.EqualValues(t, 1, blockEvent.BlockNumber)
+			require.Equal(t, block.blockHash, blockEvent.BlockHash)
+			require.Equal(t, block.prevBlockHash, blockEvent.PrevBlockHash)
 
-			actualTxIDs := make([]string, len(batch.Events))
-			for j, event := range batch.Events {
+			actualTxIDs := make([]string, len(blockEvent.Events))
+			for j, event := range blockEvent.Events {
 				actualTxIDs[j] = event.Ref.TxId
 			}
 			require.ElementsMatch(t, tc.expectedTxIDs, actualTxIDs)
 
-			for _, event := range batch.Events {
+			for _, event := range blockEvent.Events {
 				if tc.request.IncludeReadWriteSets {
 					require.NotEmpty(t, event.Namespaces)
 				} else {

--- a/service/sidecar/notify_test.go
+++ b/service/sidecar/notify_test.go
@@ -695,6 +695,13 @@ func TestStreamAllTransactions(t *testing.T) {
 			},
 			expectedTxIDs: []string{testTxID1, testTxID2, testTxID3, testTxID4},
 		},
+		{
+			name: "NamespaceFilter_NoMatch",
+			request: &committerpb.StreamAllRequest{
+				FilterNamespaces: []string{"no-such-namespace"},
+			},
+			expectedTxIDs: []string{}, // we expect the block but without any txs
+		},
 	}
 
 	env := newNotifierTestEnv(t, 0)
@@ -706,9 +713,9 @@ func TestStreamAllTransactions(t *testing.T) {
 	}
 
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
-		env.n.allTxStreamsMu.RLock()
-		activeStreams := env.n.allTxStreams
-		env.n.allTxStreamsMu.RUnlock()
+		env.n.blockStreamsMu.RLock()
+		activeStreams := env.n.blockStreams
+		env.n.blockStreamsMu.RUnlock()
 		require.Len(ct, activeStreams, len(cases))
 	}, 10*time.Second, 100*time.Millisecond)
 	env.committedBlockWithTxsQueue.Write(block)

--- a/service/sidecar/notify_test.go
+++ b/service/sidecar/notify_test.go
@@ -604,7 +604,7 @@ func newNotifierTestEnvWithConfig(tb testing.TB, numOfClients int, conf *Notific
 }
 
 //nolint:gocognit // test complexity is acceptable.
-func TestStreamAllTransactions(t *testing.T) {
+func TestStreamBlocks(t *testing.T) {
 	t.Parallel()
 
 	const (
@@ -637,38 +637,38 @@ func TestStreamAllTransactions(t *testing.T) {
 
 	cases := []struct {
 		name          string
-		request       *committerpb.StreamAllRequest
+		request       *committerpb.StreamBlocksRequest
 		expectedTxIDs []string
 	}{
 		{
 			name:          "NoFilters",
-			request:       &committerpb.StreamAllRequest{},
+			request:       &committerpb.StreamBlocksRequest{},
 			expectedTxIDs: []string{testTxID1, testTxID2, testTxID3, testTxID4},
 		},
 		{
 			name: "NamespaceFilter_ns1",
-			request: &committerpb.StreamAllRequest{
+			request: &committerpb.StreamBlocksRequest{
 				FilterNamespaces: []string{testNs1},
 			},
 			expectedTxIDs: []string{testTxID1, testTxID3}, // tx1 has ns1, tx3 has ns1+ns2
 		},
 		{
 			name: "NamespaceFilter_ns2",
-			request: &committerpb.StreamAllRequest{
+			request: &committerpb.StreamBlocksRequest{
 				FilterNamespaces: []string{testNs2},
 			},
 			expectedTxIDs: []string{testTxID2, testTxID3}, // tx2 has ns2, tx3 has ns1+ns2
 		},
 		{
 			name: "StatusFilter_COMMITTED",
-			request: &committerpb.StreamAllRequest{
+			request: &committerpb.StreamBlocksRequest{
 				FilterStatus: []committerpb.Status{committerpb.Status_COMMITTED},
 			},
 			expectedTxIDs: []string{testTxID1, testTxID3}, // Only COMMITTED txs
 		},
 		{
 			name: "CombinedFilters",
-			request: &committerpb.StreamAllRequest{
+			request: &committerpb.StreamBlocksRequest{
 				FilterNamespaces: []string{testNs1},
 				FilterStatus:     []committerpb.Status{committerpb.Status_COMMITTED},
 			},
@@ -676,28 +676,28 @@ func TestStreamAllTransactions(t *testing.T) {
 		},
 		{
 			name: "WithNamespaces",
-			request: &committerpb.StreamAllRequest{
+			request: &committerpb.StreamBlocksRequest{
 				IncludeReadWriteSets: true,
 			},
 			expectedTxIDs: []string{testTxID1, testTxID2, testTxID3, testTxID4},
 		},
 		{
 			name: "WithEndorsements",
-			request: &committerpb.StreamAllRequest{
+			request: &committerpb.StreamBlocksRequest{
 				IncludeEndorsements: true,
 			},
 			expectedTxIDs: []string{testTxID1, testTxID2, testTxID3, testTxID4},
 		},
 		{
 			name: "WithMetadata",
-			request: &committerpb.StreamAllRequest{
+			request: &committerpb.StreamBlocksRequest{
 				IncludeMetadata: true,
 			},
 			expectedTxIDs: []string{testTxID1, testTxID2, testTxID3, testTxID4},
 		},
 		{
 			name: "NamespaceFilter_NoMatch",
-			request: &committerpb.StreamAllRequest{
+			request: &committerpb.StreamBlocksRequest{
 				FilterNamespaces: []string{"no-such-namespace"},
 			},
 			expectedTxIDs: []string{}, // we expect the block but without any txs
@@ -705,10 +705,10 @@ func TestStreamAllTransactions(t *testing.T) {
 	}
 
 	env := newNotifierTestEnv(t, 0)
-	streams := make([]committerpb.Notifier_StreamAllTransactionsClient, len(cases))
+	streams := make([]committerpb.Notifier_StreamBlocksClient, len(cases))
 	for i, tc := range cases {
 		var err error
-		streams[i], err = env.client.StreamAllTransactions(t.Context(), tc.request)
+		streams[i], err = env.client.StreamBlocks(t.Context(), tc.request)
 		require.NoError(t, err)
 	}
 

--- a/service/sidecar/relay.go
+++ b/service/sidecar/relay.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/hyperledger/fabric-protos-go-apiv2/common"
 	"github.com/hyperledger/fabric-x-common/api/committerpb"
+	"github.com/hyperledger/fabric-x-common/protoutil"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/hyperledger/fabric-x-committer/api/servicepb"
@@ -414,9 +415,11 @@ func (r *relay) processCommittedBlocksInOrder(
 
 		// Create committedBlockWithTxs from blockWithStatus for notifier
 		outgoingCommittedBlockWithTxs.Write(&committedBlockWithTxs{
-			blockNumber: blkWithStatus.blockNumber,
-			txs:         blkWithStatus.txs,
-			statuses:    blkWithStatus.txStatus,
+			blockNumber:   blkWithStatus.blockNumber,
+			txs:           blkWithStatus.txs,
+			statuses:      blkWithStatus.txStatus,
+			blockHash:     protoutil.BlockHeaderHash(blkWithStatus.block.Header),
+			prevBlockHash: blkWithStatus.block.Header.PreviousHash,
 		})
 	}
 }

--- a/service/sidecar/relay_test.go
+++ b/service/sidecar/relay_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hyperledger/fabric-protos-go-apiv2/common"
 	"github.com/hyperledger/fabric-x-common/api/applicationpb"
 	"github.com/hyperledger/fabric-x-common/api/committerpb"
+	"github.com/hyperledger/fabric-x-common/protoutil"
 	"github.com/hyperledger/fabric-x-common/utils/testcrypto"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
@@ -300,6 +301,31 @@ func TestRelayUnprocessableConfigBlock(t *testing.T) {
 	err := relayService.preProcessBlock(t.Context(), make(chan *blockMappingResult, 1))
 	require.ErrorContains(t, err, "cannot process the config TX [blk:1,num:0]")
 	require.ErrorIs(t, err, retry.ErrBackOff)
+}
+
+// TestProcessCommittedBlocksInOrderBlockHash verifies that processCommittedBlocksInOrder
+// computes the committed block's hash and forwards its previous block hash unchanged into
+// committedBlockWithTxs, for StreamAllTransactions clients.
+func TestProcessCommittedBlocksInOrderBlockHash(t *testing.T) {
+	t.Parallel()
+	relayService := newRelay(time.Second, newPerformanceMetrics(newQueues(10)))
+
+	blk, _ := createBlockForTest(t, 0, []byte("prev-hash"))
+	blk.Metadata = &common.BlockMetadata{Metadata: make([][]byte, statusIdx+1)}
+	relayService.blkNumToBlkWithStatus.Store(0, &blockWithStatus{block: blk, blockNumber: 0})
+	relayService.activeBlocksCount.Store(1)
+
+	outgoingCommittedBlock := make(chan *common.Block, 1)
+	outgoingCommittedBlockWithTxs := make(chan *committedBlockWithTxs, 1)
+	relayService.processCommittedBlocksInOrder(
+		t.Context(),
+		channel.NewWriter(t.Context(), outgoingCommittedBlock),
+		channel.NewWriter(t.Context(), outgoingCommittedBlockWithTxs),
+	)
+
+	got := <-outgoingCommittedBlockWithTxs
+	require.Equal(t, protoutil.BlockHeaderHash(blk.Header), got.blockHash)
+	require.Equal(t, []byte("prev-hash"), got.prevBlockHash)
 }
 
 func TestRelaySnapshotBlockSplitAndDrain(t *testing.T) {

--- a/service/sidecar/relay_test.go
+++ b/service/sidecar/relay_test.go
@@ -305,7 +305,7 @@ func TestRelayUnprocessableConfigBlock(t *testing.T) {
 
 // TestProcessCommittedBlocksInOrderBlockHash verifies that processCommittedBlocksInOrder
 // computes the committed block's hash and forwards its previous block hash unchanged into
-// committedBlockWithTxs, for StreamAllTransactions clients.
+// committedBlockWithTxs, for StreamBlocks clients.
 func TestProcessCommittedBlocksInOrderBlockHash(t *testing.T) {
 	t.Parallel()
 	relayService := newRelay(time.Second, newPerformanceMetrics(newQueues(10)))

--- a/service/sidecar/test_exports.go
+++ b/service/sidecar/test_exports.go
@@ -56,11 +56,11 @@ func RequireNotifications( //nolint:revive // argument-limit.
 	}, 15*time.Second, 50*time.Millisecond)
 }
 
-// RequireStreamAllTransactions verifies that the expected transactions were received
-// from the StreamAllTransactions stream.
-func RequireStreamAllTransactions( //nolint:revive // argument-limit.
+// RequireStreamBlocks verifies that the expected transactions were received
+// from the StreamBlocks stream.
+func RequireStreamBlocks( //nolint:revive // argument-limit.
 	t *testing.T,
-	stream committerpb.Notifier_StreamAllTransactionsClient,
+	stream committerpb.Notifier_StreamBlocksClient,
 	expectedBlockNumber uint64,
 	txIDs []string,
 	status []committerpb.Status,


### PR DESCRIPTION
#### Type of change

- New feature
 
#### Description

- upgrade fabric-x-common to latest `main`
- rename TxEventBatch to BlockEvent, as updated in fabric-x-common
- add blockHash and prevBlockHash to all BlockEvents. 

Impact on code: users of `Notifier_StreamAllTransactionsClient` that upgrade their committer dependency must rename TxEventBatch to BlockEvent.

~GRPC API and protos remain backwards compatible.~. This change is *not* backwards compatible on the wire. Clients of the upcoming fabric-x-committer version must also upgrade their fabric-x-common dependency; Notifier_StreamAllTransactionsClient itself is renamed to Notifier_StreamBlocksClient in fabric-x-common, with a new `StreamBlocks` GRPC endpoint replacing StreamAllTransactions.

#### Related issues

Closes https://github.com/hyperledger/fabric-x-committer/issues/773
