### PR TITLE
[BREAKING] [sidecar] Unify sidecar RPCs into SidecarService, keep Fabric Deliver

### DIFF
--- a/docs/notification-service.md
+++ b/docs/notification-service.md
@@ -16,25 +16,28 @@ The Sidecar exposes a Notification Service that provides two mechanisms for rece
    containing transaction IDs of interest, and the server pushes status responses as transactions
    complete. Multiple subscription requests can be sent on the same stream.
 
-2. **All Transactions Stream** — Allows clients to subscribe to a stream of all committed transactions in block order,
-   with optional filtering by namespace and status. This is useful for audit, monitoring, event-driven applications, and
+2. **Committed Block Stream** — Allows clients to subscribe to every committed block in order, with optional
+   transaction filtering by namespace and status. This is useful for audit, monitoring, event-driven applications, and
    replication systems.
 
 For internal architecture details, see [sidecar.md — Section 6](sidecar.md#6-notification-service).
 
 ## 1. API Definition
 
-The Notification Service provides two streaming RPCs:
+The notification RPCs live on the sidecar's unified `SidecarService`, alongside its
+block-query and snapshot-administration RPCs.
 
 From [fabric-x-common/api/committerpb](https://github.com/hyperledger/fabric-x-common)
 
 ```protobuf
-service Notifier {
-    // Subscribe to specific transaction IDs
+service SidecarService {
+    // Subscribe to specific transaction IDs.
     rpc OpenNotificationStream (stream NotificationRequest) returns (stream NotificationResponse);
 
-    // Subscribe to all committed transactions
-    rpc StreamAllTransactions (StreamAllRequest) returns (stream TxBatch);
+    // Subscribe to committed blocks.
+    rpc StreamBlocks (StreamBlocksRequest) returns (stream BlockEvent);
+
+    // Block-query and snapshot-administration RPCs are omitted here; see sidecar.md.
 }
 ```
 
@@ -90,7 +93,7 @@ Create a gRPC connection to the Sidecar, open a notification stream, and send a
 
 ```go
 conn, err := grpc.NewClient(sidecarEndpoint, dialOpts...)
-client := committerpb.NewNotifierClient(conn)
+client := committerpb.NewSidecarServiceClient(conn)
 
 stream, err := client.OpenNotificationStream(ctx)
 if err != nil {
@@ -183,24 +186,28 @@ If the notification stream breaks (e.g., sidecar restart) or the timeout expires
 the transaction completes, the client should fall back to the Block Query API to check
 the transaction status.
 
-## 3. All Transactions Stream API
+## 3. Committed Block Stream API
 
 ### 3.1. API Definition
 
-The `StreamAllTransactions` RPC provides a server-streaming interface that delivers all committed transactions in block
-order. Unlike the transaction ID subscription API, this stream does not require clients to know transaction IDs in
-advance.
+The `StreamBlocks` RPC provides a server-streaming interface that delivers every committed block in order. Optional
+filters control which transactions appear in each block event; they do not suppress delivery of blocks. Unlike the
+transaction ID subscription API, this stream does not require clients to know transaction IDs in advance.
 
 ```protobuf
-message StreamAllRequest {
+message StreamBlocksRequest {
     repeated string filter_namespaces = 1;  // Optional: filter by namespace(s)
     repeated Status filter_status = 2;      // Optional: filter by status
     bool include_read_write_sets = 3;       // Optional: include read/write sets
     bool include_endorsements = 4;          // Optional: include endorsements
+    bool include_metadata = 5;              // Optional: include metadata
 }
 
-message TxBatch {
-    repeated TxEvent events = 1;
+message BlockEvent {
+    uint64 block_number = 1;
+    repeated TxEvent events = 2;
+    bytes block_hash = 3;
+    bytes prev_block_hash = 4;
 }
 
 message TxEvent {
@@ -208,16 +215,17 @@ message TxEvent {
     Status status = 2;                      // Transaction status
     repeated TxNamespace namespaces = 3;    // Namespaces (if filtering enabled)
     repeated Endorsement endorsements = 4;  // Endorsements (if requested)
+    repeated bytes metadata = 5;            // Metadata (if requested)
 }
 ```
 
 ### 3.2. Opening a Stream
 
-Create a gRPC connection to the Sidecar and call `StreamAllTransactions`:
+Create a gRPC connection to the Sidecar and call `StreamBlocks`:
 
 ```go
-client := committerpb.NewNotifierClient(conn)
-stream, err := client.StreamAllTransactions(ctx, &committerpb.StreamAllRequest{
+client := committerpb.NewSidecarServiceClient(conn)
+stream, err := client.StreamBlocks(ctx, &committerpb.StreamBlocksRequest{
     FilterNamespaces: []string{"namespace-1", "namespace-2"},
     FilterStatus: []committerpb.Status{committerpb.Status_COMMITTED},
     IncludeReadWriteSets: true,
@@ -240,10 +248,14 @@ stream, err := client.StreamAllTransactions(ctx, &committerpb.StreamAllRequest{
 - **`include_endorsements`** (optional): If true, the `endorsements` field in each `TxEvent`
   includes the transaction endorsements. Default: false.
 
-### 3.3. Receiving Transaction Events
+- **`include_metadata`** (optional): If true, the `metadata` field in each `TxEvent`
+  includes the transaction metadata. Default: false.
 
-The server sends `TxBatch` messages containing one or more `TxEvent` entries. Transactions are batched by block. All
-transactions from the same block are delivered in a single `TxBatch`.
+### 3.3. Receiving Block Events
+
+The server sends one `BlockEvent` for every committed block, containing block number, block hash, previous block hash,
+and the `TxEvent` entries that pass the requested filters. A `BlockEvent` may contain zero `TxEvent` entries when no
+transactions in that block match.
 
 ```go
 for {
@@ -259,18 +271,18 @@ for {
 ### 3.4. Stream Behavior
 
 **Block Order Guarantee:**
-Transactions are streamed in deterministic block order. All transactions from block N are delivered before any
-transactions from block N+1.
+Committed blocks are streamed in deterministic order. Block N is delivered before block N+1, even when either block
+contains no transactions matching the requested filters.
 
 **Starting Point:**
-The stream starts from the currently processed block when the client connects. Historical transactions are not included.
+The stream starts from the currently processed block when the client connects. Historical blocks are not included.
 
 **No Recovery:**
-If the stream disconnects, the client must reconnect and will resume from the current block. Transactions from missed
-blocks are not replayed. For guaranteed delivery, use the Block Delivery API instead.
+If the stream disconnects, the client must reconnect and will resume from the current block. Missed blocks are not
+replayed. For guaranteed delivery, use the Block Delivery API instead.
 
 **Backpressure:**
-If the client cannot keep up with the transaction rate, the server will block sending to that client. The server uses a
+If the client cannot keep up with the block rate, the server will block sending to that client. The server uses a
 configurable write timeout (default: 30 seconds) to prevent slow clients from blocking the system.
 
 ## 4. Concurrency Limits
@@ -286,11 +298,11 @@ status code. Clients should handle this error with appropriate backoff and retry
 
 The following configuration options in `sidecar.yaml` control notification behavior:
 
-| Setting                             | Default | Description                                                                                     |
-|-------------------------------------|---------|-------------------------------------------------------------------------------------------------|
-| `notification.max-timeout`          | `1m`    | Upper limit on per-request timeout for transaction ID subscriptions.                            |
-| `notification.stream-write-timeout` | `30s`   | Write timeout for all transactions stream. Prevents slow clients from blocking.                 |
-| `server.max-concurrent-streams`     | `10`    | Maximum concurrent streaming RPCs across all stream types (Deliver + Notification + StreamAll). |
+| Setting                             | Default | Description                                                                                        |
+|-------------------------------------|---------|----------------------------------------------------------------------------------------------------|
+| `notification.max-timeout`          | `1m`    | Upper limit on per-request timeout for transaction ID subscriptions.                               |
+| `notification.stream-write-timeout` | `30s`   | Write timeout for the block stream. Prevents slow clients from blocking.                           |
+| `server.max-concurrent-streams`     | `10`    | Maximum concurrent streaming RPCs across all stream types (Deliver + Notification + StreamBlocks). |
 
 Sample configuration:
 

--- a/docs/sidecar.md
+++ b/docs/sidecar.md
@@ -416,6 +416,23 @@ The ledger service then:
 We use Fabric block store package located at https://github.com/hyperledger/fabric/common/ledger/blkstorage
 to manage these blocks in the file system.
 
+## 4a. gRPC Surface
+
+`Service.RegisterService` exposes two gRPC services on the sidecar's port:
+
+| Service | RPCs | Why separate |
+| --- | --- | --- |
+| `committerpb.SidecarService` | `GetBlockchainInfo`, `GetBlockByNumber`, `GetBlockByTxID`, `GetTxByID`, `OpenNotificationStream`, `StreamBlocks`, `DeleteDBCloneForSnapshot` | Every sidecar RPC that is ours to define. New sidecar RPCs are added here. |
+| Fabric `protos.Deliver` | `Deliver`, `DeliverFiltered`, `DeliverWithPrivateData` | Fabric's own wire contract, so Fabric clients dial the sidecar unchanged. |
+
+One object, `*sidecar.Service`, backs both. It serves the block-store reads directly,
+the two event streams through its embedded notifier, and answers `UNIMPLEMENTED` for
+`DeleteDBCloneForSnapshot` until the snapshot clone-deletion pipeline lands.
+`committerpb.BlockQueryService` and `committerpb.Notifier` were folded into
+`SidecarService` and no longer exist; clients replace `NewBlockQueryServiceClient` and
+`NewNotifierClient` with `NewSidecarServiceClient`, keeping the same method names and
+messages.
+
 ## 5. Delivering Committed Block to Registered Clients
 
 Similar to how the Sidecar connects to the Ordering Service to fetch blocks, Clients 

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0
 	github.com/hyperledger/fabric-lib-go v1.1.5-0.20260708100132-163bcc919208
 	github.com/hyperledger/fabric-protos-go-apiv2 v0.3.7
-	github.com/hyperledger/fabric-x-common v0.2.9-0.20260723091942-e43f1af10c7e
+	github.com/hyperledger/fabric-x-common v0.2.9-0.20260910095823-4b946650f960
 	github.com/jackc/pgerrcode v0.0.0-20250907135507-afb5586c32a6
 	github.com/jackc/puddle/v2 v2.2.2
 	github.com/moby/moby/api v1.55.0

--- a/go.sum
+++ b/go.sum
@@ -184,8 +184,8 @@ github.com/hyperledger/fabric-lib-go v1.1.5-0.20260708100132-163bcc919208 h1:qA4
 github.com/hyperledger/fabric-lib-go v1.1.5-0.20260708100132-163bcc919208/go.mod h1:EKqTudBsC2yovZdcJq5ekWvkq3USF1mbau07I0y8zMs=
 github.com/hyperledger/fabric-protos-go-apiv2 v0.3.7 h1:sQ5qv8vQQfwewa1JlCiSCC8dLElmaU2/frLolpgibEY=
 github.com/hyperledger/fabric-protos-go-apiv2 v0.3.7/go.mod h1:bJnwzfv03oZQeCc863pdGTDgf5nmCy6Za3RAE7d2XsQ=
-github.com/hyperledger/fabric-x-common v0.2.9-0.20260723091942-e43f1af10c7e h1:1TiqmKe1L3/KnKXHHId+i1WHY/4hIaI8sCyLrhWFpsI=
-github.com/hyperledger/fabric-x-common v0.2.9-0.20260723091942-e43f1af10c7e/go.mod h1:f30Yws3c5Cg22yHLy2oT2XR0wwZI+JdqbUqB2fwFIsM=
+github.com/hyperledger/fabric-x-common v0.2.9-0.20260910095823-4b946650f960 h1:wWlXeUnX9crzMHAzmK984GV7sXTZKsvgAfyZkd/SiSU=
+github.com/hyperledger/fabric-x-common v0.2.9-0.20260910095823-4b946650f960/go.mod h1:Fi9+ggppKZp6r9NXi7wOuM4N6kxwEjgkqodvMmhNFQk=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imkira/go-interpol v1.1.0 h1:KIiKr0VSG2CUW1hl1jpiyuzuJeKUUpC8iM1AIE7N1Vk=
 github.com/imkira/go-interpol v1.1.0/go.mod h1:z0h2/2T3XF8kyEPpRgJ3kmNv+C43p+I/CoI+jC3w2iA=

--- a/integration/runner/runtime.go
+++ b/integration/runner/runtime.go
@@ -17,6 +17,7 @@ import (
 	"github.com/hyperledger/fabric-protos-go-apiv2/common"
 	"github.com/hyperledger/fabric-x-common/api/applicationpb"
 	"github.com/hyperledger/fabric-x-common/api/committerpb"
+	"github.com/hyperledger/fabric-x-common/protoutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -60,9 +61,9 @@ type (
 		CoordinatorClient   servicepb.CoordinatorClient
 		QueryServiceClient  committerpb.QueryServiceClient
 		SidecarClientConfig *connection.ClientConfig
-		NotifyClient        committerpb.NotifierClient
-		NotifyStream        committerpb.Notifier_OpenNotificationStreamClient
-		StreamAllTxStream   committerpb.Notifier_StreamAllTransactionsClient
+		NotifyClient        committerpb.SidecarServiceClient
+		NotifyStream        committerpb.SidecarService_OpenNotificationStreamClient
+		StreamBlocksStream  committerpb.SidecarService_StreamBlocksClient
 
 		CommittedBlock          chan *common.Block
 		TxBuilder               *workload.TxBuilder
@@ -336,7 +337,7 @@ func (c *CommitterRuntime) CreateRuntimeClients(ctx context.Context, t *testing.
 	c.QueryServiceClient = committerpb.NewQueryServiceClient(
 		test.NewSecuredConnection(t, services.Query.GrpcEndpoint, c.SystemConfig.ClientTLS),
 	)
-	c.NotifyClient = committerpb.NewNotifierClient(
+	c.NotifyClient = committerpb.NewSidecarServiceClient(
 		test.NewSecuredConnection(t, services.Sidecar.GrpcEndpoint, c.SystemConfig.ClientTLS),
 	)
 	var err error
@@ -355,7 +356,7 @@ func (c *CommitterRuntime) OpenNotificationStream(ctx context.Context, t *testin
 	var err error
 	c.NotifyStream, err = c.NotifyClient.OpenNotificationStream(ctx)
 	require.NoError(t, err)
-	c.StreamAllTxStream, err = c.NotifyClient.StreamAllTransactions(ctx, nil)
+	c.StreamBlocksStream, err = c.NotifyClient.StreamBlocks(ctx, nil)
 	require.NoError(t, err)
 }
 
@@ -640,7 +641,15 @@ func (c *CommitterRuntime) ValidateExpectedResultsInCommittedBlock(t *testing.T,
 	}
 
 	sidecar.RequireNotifications(t, c.NotifyStream, blk.Header.Number, expected.TxIDs, expected.Statuses)
-	sidecar.RequireStreamAllTransactions(t, c.StreamAllTxStream, blk.Header.Number, expected.TxIDs, expected.Statuses)
+	sidecar.RequireStreamBlocks(
+		t,
+		c.StreamBlocksStream,
+		blk.Header.Number,
+		protoutil.BlockHeaderHash(blk.Header),
+		blk.Header.PreviousHash,
+		expected.TxIDs,
+		expected.Statuses,
+	)
 }
 
 // CountStatus returns the number of transactions with a given tx status.

--- a/integration/test/keep_alive_test.go
+++ b/integration/test/keep_alive_test.go
@@ -171,7 +171,7 @@ func TestKeepAliveSidecarStreamSlotRelease(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = conn2.Close() })
 
-	client2 := committerpb.NewNotifierClient(conn2)
+	client2 := committerpb.NewSidecarServiceClient(conn2)
 	stream2, err := client2.OpenNotificationStream(ctx)
 	if err == nil {
 		_, err = stream2.Recv()
@@ -267,7 +267,7 @@ func sendSidecarInitialMessage(t *testing.T, conn *grpc.ClientConn) {
 	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Minute)
 	t.Cleanup(cancel)
 
-	stream, err := committerpb.NewNotifierClient(conn).OpenNotificationStream(ctx)
+	stream, err := committerpb.NewSidecarServiceClient(conn).OpenNotificationStream(ctx)
 	require.NoError(t, err)
 	require.NoError(t, stream.Send(&committerpb.NotificationRequest{
 		TxStatusRequest: &committerpb.TxIDsBatch{TxIds: []string{dummyTxID}},

--- a/integration/test/rate_limit_test.go
+++ b/integration/test/rate_limit_test.go
@@ -75,7 +75,7 @@ func TestRateLimit(t *testing.T) {
 			name:     "Sidecar_WithoutRetry_ReturnsResourceExhausted",
 			endpoint: c.SystemConfig.Services.Sidecar.GrpcEndpoint,
 			requestFn: func(ctx context.Context, conn *grpc.ClientConn) error {
-				_, err := committerpb.NewBlockQueryServiceClient(conn).GetBlockchainInfo(ctx, &emptypb.Empty{})
+				_, err := committerpb.NewSidecarServiceClient(conn).GetBlockchainInfo(ctx, &emptypb.Empty{})
 				return err
 			},
 			timeout: 10 * time.Second,
@@ -85,7 +85,7 @@ func TestRateLimit(t *testing.T) {
 			endpoint: c.SystemConfig.Services.Sidecar.GrpcEndpoint,
 			useRetry: true,
 			requestFn: func(ctx context.Context, conn *grpc.ClientConn) error {
-				_, err := committerpb.NewBlockQueryServiceClient(conn).GetBlockByNumber(ctx, &committerpb.BlockNumber{})
+				_, err := committerpb.NewSidecarServiceClient(conn).GetBlockByNumber(ctx, &committerpb.BlockNumber{})
 				return err
 			},
 			expectAllSucceed: true,

--- a/integration/test/server_stats_metrics_test.go
+++ b/integration/test/server_stats_metrics_test.go
@@ -30,7 +30,7 @@ const (
 	sidecarStreamDurationMetric = "sidecar_grpc_stream_duration_seconds"
 
 	getTransactionStatusMethod   = committerpb.QueryService_GetTransactionStatus_FullMethodName
-	openNotificationStreamMethod = committerpb.Notifier_OpenNotificationStream_FullMethodName
+	openNotificationStreamMethod = committerpb.SidecarService_OpenNotificationStream_FullMethodName
 
 	method = "method"
 )

--- a/integration/test/stream_concurrency_test.go
+++ b/integration/test/stream_concurrency_test.go
@@ -25,11 +25,11 @@ import (
 func TestStreamConcurrencyLimit(t *testing.T) {
 	t.Parallel()
 
-	// The runtime's Start opens 2 long-lived streams:
+	// The runtime's Start opens 3 long-lived streams:
 	//   1. Deliver stream (startBlockDelivery)
 	//   2. Notification stream (OpenNotificationStream)
-	//   3. Notification block stream (StreamAllTransactions)
-	// With MaxConcurrentStreams=4, exactly 1 slot remain for the test.
+	//   3. Notification block stream (StreamBlocks)
+	// With MaxConcurrentStreams=4, exactly 1 slot remains for the test.
 	const maxStreams = 4
 	c := runner.NewRuntime(t, &runner.Config{
 		BlockTimeout:         2 * time.Second,
@@ -50,24 +50,23 @@ func TestStreamConcurrencyLimit(t *testing.T) {
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = conn.Close() })
 
-	// Fill remaining slots with one Deliver + one Notification stream.
-	// This proves both stream types share the same concurrency pool.
+	// Fill the remaining slot with one Deliver stream.
 	// The Deliver stream uses a cancellable context so we can release it later.
 	deliverClient := peer.NewDeliverClient(conn)
-	notifyClient := committerpb.NewNotifierClient(conn)
+	notifyClient := committerpb.NewSidecarServiceClient(conn)
 
 	deliverCtx, deliverCancel := context.WithCancel(t.Context())
 	_, err = deliverClient.Deliver(deliverCtx)
 	require.NoError(t, err)
 
-	// Wait for the server to start the stream handlers above and acquire
-	// their semaphore slots. The server processes new streams asynchronously
+	// Wait for the server to start the stream handler above and acquire
+	// its semaphore slot. The server processes new streams asynchronously
 	// (goroutine per stream), so without this the interceptor may not have
 	// called TryAcquire yet when we check for rejection below.
 	time.Sleep(2 * time.Second)
 
-	// All 4 slots are now occupied (2 from Start + 1 Deliver + 1 Notification).
-	// The next stream of either type should be rejected.
+	// All 4 slots are now occupied (3 from Start + 1 Deliver).
+	// The next stream of any type should be rejected.
 	//
 	// For bidirectional streaming RPCs, the server-side interceptor error
 	// (ResourceExhausted) is NOT returned from the initial stream creation
@@ -86,9 +85,9 @@ func TestStreamConcurrencyLimit(t *testing.T) {
 	}
 	requireResourceExhausted(t, err)
 
-	rejectedStreamAll, err := notifyClient.StreamAllTransactions(t.Context(), nil)
+	rejectedStreamBlocks, err := notifyClient.StreamBlocks(t.Context(), nil)
 	if err == nil {
-		_, err = rejectedStreamAll.Recv()
+		_, err = rejectedStreamBlocks.Recv()
 	}
 	requireResourceExhausted(t, err)
 

--- a/service/sidecar/block_query_test.go
+++ b/service/sidecar/block_query_test.go
@@ -24,7 +24,7 @@ type blockQueryWrapper struct {
 }
 
 func (w *blockQueryWrapper) RegisterService(s serve.Servers) {
-	committerpb.RegisterBlockQueryServiceServer(s.GRPC, w.Service)
+	committerpb.RegisterSidecarServiceServer(s.GRPC, w.Service)
 }
 
 func TestBlockQuery(t *testing.T) {
@@ -33,13 +33,15 @@ func TestBlockQuery(t *testing.T) {
 	bs, txIDs := newBlockStoreWithBlocks(t, 2)
 
 	// Create the query service and register on a gRPC server.
-	queryService := &blockQueryWrapper{Service: &Service{blockStore: bs}}
+	// The notifier must be non-nil: Service reaches the Unimplemented fallbacks
+	// for RPCs it does not serve (DeleteDBCloneForSnapshot) through this pointer.
+	queryService := &blockQueryWrapper{Service: &Service{blockStore: bs, notifier: &notifier{}}}
 
 	serverConfig := test.NewLocalHostServiceConfig(test.InsecureTLSConfig)
 	test.ServeForTest(t.Context(), t, serverConfig, queryService)
 
 	conn := test.NewInsecureConnection(t, &serverConfig.GRPC.Endpoint)
-	client := committerpb.NewBlockQueryServiceClient(conn)
+	client := committerpb.NewSidecarServiceClient(conn)
 
 	t.Run("GetBlockchainInfo", func(t *testing.T) {
 		t.Parallel()

--- a/service/sidecar/mapping.go
+++ b/service/sidecar/mapping.go
@@ -57,7 +57,7 @@ type (
 		txStatus     []committerpb.Status
 		pendingCount atomic.Int32
 
-		// Fields for StreamAllTransactions support
+		// Fields for StreamBlocks support
 		blockNumber uint64                 // Block number
 		txs         []*servicepb.TxWithRef // Transaction content (from coordinatorBatch.Txs)
 	}

--- a/service/sidecar/notify.go
+++ b/service/sidecar/notify.go
@@ -33,7 +33,10 @@ type (
 	// writing to each stream's notificationQueue.
 	// Deadlock is prevented by buffered channels and single-threaded processing in run().
 	notifier struct {
-		committerpb.UnimplementedNotifierServer
+		// Embedded on the notifier rather than on Service so the notifier's own
+		// stream RPCs win at selector depth 1 while these fallbacks resolve at
+		// depth 2, letting Service satisfy SidecarServiceServer without forwarders.
+		committerpb.UnimplementedSidecarServiceServer
 		bufferSize         int
 		maxTimeout         time.Duration
 		maxActiveTxIDs     int
@@ -45,7 +48,7 @@ type (
 		// timeoutQueue receives requests whose deadline has passed.
 		timeoutQueue chan *notificationRequest
 
-		// StreamAllTransactions support
+		// StreamBlocks support
 		allTxStreams   []*allTxStream
 		allTxStreamsMu sync.RWMutex
 	}
@@ -69,15 +72,17 @@ type (
 	}
 
 	// committedBlockWithTxs contains the essential data from a committed block
-	// for streaming to StreamAllTransactions clients. This is a clean interface
+	// for streaming to StreamBlocks clients. This is a clean interface
 	// that separates the notifier from relay's internal blockWithStatus structure.
 	committedBlockWithTxs struct {
-		blockNumber uint64
-		txs         []*servicepb.TxWithRef
-		statuses    []committerpb.Status
+		blockNumber   uint64
+		blockHash     []byte
+		prevBlockHash []byte
+		txs           []*servicepb.TxWithRef
+		statuses      []committerpb.Status
 	}
 
-	// allTxStream represents a single StreamAllTransactions client subscription.
+	// allTxStream represents a single StreamBlocks client subscription.
 	// Each stream has its own filters and receives committed blocks via a channel.
 	allTxStream struct {
 		// Filters (empty = no filter)
@@ -186,8 +191,8 @@ func (n *notifier) recordRemovals(pendingTxIDsRemoved, uniquePendingTxIDsRemoved
 	promutil.AddToGauge(n.metrics.notifierUniquePendingTxIDs, -uniquePendingTxIDsRemoved)
 }
 
-// OpenNotificationStream implements the [protonotify.NotifierServer] API.
-func (n *notifier) OpenNotificationStream(stream committerpb.Notifier_OpenNotificationStreamServer) error {
+// OpenNotificationStream implements the [committerpb.SidecarServiceServer] API.
+func (n *notifier) OpenNotificationStream(stream committerpb.SidecarService_OpenNotificationStreamServer) error {
 	g, gCtx := errgroup.WithContext(stream.Context())
 	requestQueue := channel.NewWriter(gCtx, n.requestQueue)
 	streamEventQueue := channel.Make[*committerpb.NotificationResponse](gCtx, n.bufferSize)
@@ -221,12 +226,12 @@ func (n *notifier) OpenNotificationStream(stream committerpb.Notifier_OpenNotifi
 	return wrapNotifierError(g.Wait())
 }
 
-// StreamAllTransactions implements the [committerpb.NotifierServer] API.
+// StreamBlocks implements the [committerpb.SidecarServiceServer] API.
 // It streams all committed transactions to the client, with optional filtering
 // by namespace and transaction status.
-func (n *notifier) StreamAllTransactions(
-	req *committerpb.StreamAllRequest,
-	stream committerpb.Notifier_StreamAllTransactionsServer,
+func (n *notifier) StreamBlocks(
+	req *committerpb.StreamBlocksRequest,
+	stream committerpb.SidecarService_StreamBlocksServer,
 ) error {
 	// Create stream context with cancellation
 	ctx, cancel := context.WithCancel(stream.Context())
@@ -372,7 +377,7 @@ func (m *subscriptions) removeAndEnqueueTimeoutEvents(
 }
 
 // dispatchBlockToAllTxStreams dispatches a committed block to all registered
-// StreamAllTransactions clients. It handles slow clients by using a timeout
+// StreamBlocks clients. It handles slow clients by using a timeout
 // and canceling streams that cannot keep up.
 func (n *notifier) dispatchBlockToAllTxStreams(ctx context.Context, block *committedBlockWithTxs) {
 	// Get snapshot of streams with minimal lock time
@@ -397,7 +402,7 @@ func (n *notifier) dispatchBlockToAllTxStreams(ctx context.Context, block *commi
 	}
 }
 
-// registerAllTxStream adds a new StreamAllTransactions client to the notifier.
+// registerAllTxStream adds a new StreamBlocks client to the notifier.
 // The stream will receive all committed blocks until it is unregistered or cancelled.
 func (n *notifier) registerAllTxStream(stream *allTxStream) {
 	n.allTxStreamsMu.Lock()
@@ -411,7 +416,7 @@ func (n *notifier) registerAllTxStream(stream *allTxStream) {
 	n.allTxStreams = streams
 }
 
-// unregisterAllTxStream removes a StreamAllTransactions client from the notifier.
+// unregisterAllTxStream removes a StreamBlocks client from the notifier.
 func (n *notifier) unregisterAllTxStream(stream *allTxStream) {
 	n.allTxStreamsMu.Lock()
 	defer n.allTxStreamsMu.Unlock()
@@ -429,10 +434,10 @@ func (n *notifier) unregisterAllTxStream(stream *allTxStream) {
 	n.allTxStreams = streams
 }
 
-// streamWorker runs in its own goroutine for each StreamAllTransactions client.
+// streamWorker runs in its own goroutine for each StreamBlocks client.
 // It receives committed blocks from the blockQueue, filters and enriches them
 // according to the stream's configuration, and sends the results to the client.
-func (s *allTxStream) streamWorker(stream committerpb.Notifier_StreamAllTransactionsServer) error {
+func (s *allTxStream) streamWorker(stream committerpb.SidecarService_StreamBlocksServer) error {
 	q := channel.NewReader(s.ctx, s.blockQueue)
 	for {
 		block, ok := q.Read()
@@ -442,14 +447,12 @@ func (s *allTxStream) streamWorker(stream committerpb.Notifier_StreamAllTransact
 
 		// Filter and build transactions in this worker thread
 		filteredEvents := s.filterAndBuildEvents(block)
-		// Only send if there are events after filtering
-		if len(filteredEvents) == 0 {
-			continue
-		}
 
-		batch := &committerpb.TxEventBatch{
-			BlockNumber: block.blockNumber,
-			Events:      filteredEvents,
+		batch := &committerpb.BlockEvent{
+			BlockNumber:   block.blockNumber,
+			Events:        filteredEvents,
+			BlockHash:     block.blockHash,
+			PrevBlockHash: block.prevBlockHash,
 		}
 		if err := stream.Send(batch); err != nil {
 			return errors.Wrap(err, "failed to send transaction batch")

--- a/service/sidecar/notify_test.go
+++ b/service/sidecar/notify_test.go
@@ -33,7 +33,7 @@ type notifierWrapper struct {
 }
 
 func (w *notifierWrapper) RegisterService(s serve.Servers) {
-	committerpb.RegisterNotifierServer(s.GRPC, w.notifier)
+	committerpb.RegisterSidecarServiceServer(s.GRPC, w.notifier)
 	serve.RegisterServerMetrics(s.StatsHandler, w.metrics.serverMetrics)
 }
 
@@ -128,7 +128,7 @@ type notifierTestEnv struct {
 	statusQueue                channel.Writer[[]*committerpb.TxStatus]
 	committedBlockWithTxsQueue channel.Writer[*committedBlockWithTxs]
 	responseQueues             []channel.ReaderWriter[*committerpb.NotificationResponse]
-	client                     committerpb.NotifierClient
+	client                     committerpb.SidecarServiceClient
 }
 
 func TestNotifierDirect(t *testing.T) {
@@ -338,7 +338,7 @@ func TestNotifierStream(t *testing.T) {
 
 	// Verify the active-stream gauge for the method we opened (labelled by full gRPC method).
 	activeStreams := m.serverMetrics.ActiveStreams.WithLabelValues(
-		committerpb.Notifier_OpenNotificationStream_FullMethodName,
+		committerpb.SidecarService_OpenNotificationStream_FullMethodName,
 	)
 	test.EventuallyIntMetric(t, 1, activeStreams, 5*time.Second, 100*time.Millisecond)
 
@@ -599,26 +599,31 @@ func newNotifierTestEnvWithConfig(tb testing.TB, numOfClients int, conf *Notific
 	wrapper := &notifierWrapper{env.n}
 	test.ServeForTest(tb.Context(), tb, serverConfig, wrapper)
 	endpoint := &serverConfig.GRPC.Endpoint
-	env.client = committerpb.NewNotifierClient(test.NewInsecureConnection(tb, endpoint))
+	env.client = committerpb.NewSidecarServiceClient(test.NewInsecureConnection(tb, endpoint))
 	return env
 }
 
 //nolint:gocognit // test complexity is acceptable.
-func TestStreamAllTransactions(t *testing.T) {
+func TestStreamBlocks(t *testing.T) {
 	t.Parallel()
 
 	const (
-		testTxID1 = "tx1"
-		testTxID2 = "tx2"
-		testTxID3 = "tx3"
-		testTxID4 = "tx4"
-		testNs1   = "ns1"
-		testNs2   = "ns2"
-		testNs3   = "ns3"
+		testTxID1                = "tx1"
+		testTxID2                = "tx2"
+		testTxID3                = "tx3"
+		testTxID4                = "tx4"
+		testNs1                  = "ns1"
+		testNs2                  = "ns2"
+		testNs3                  = "ns3"
+		testNonexistentNamespace = "nonexistent"
 	)
 
+	blockHash := []byte("block-hash")
+	prevBlockHash := []byte("previous-block-hash")
 	block := &committedBlockWithTxs{
-		blockNumber: 1,
+		blockNumber:   1,
+		blockHash:     blockHash,
+		prevBlockHash: prevBlockHash,
 		txs: []*servicepb.TxWithRef{
 			createTestTx(testTxID1, 0, testNs1),
 			createTestTx(testTxID2, 1, testNs2),
@@ -635,38 +640,45 @@ func TestStreamAllTransactions(t *testing.T) {
 
 	cases := []struct {
 		name          string
-		request       *committerpb.StreamAllRequest
+		request       *committerpb.StreamBlocksRequest
 		expectedTxIDs []string
 	}{
 		{
 			name:          "NoFilters",
-			request:       &committerpb.StreamAllRequest{},
+			request:       &committerpb.StreamBlocksRequest{},
 			expectedTxIDs: []string{testTxID1, testTxID2, testTxID3, testTxID4},
 		},
 		{
 			name: "NamespaceFilter_ns1",
-			request: &committerpb.StreamAllRequest{
+			request: &committerpb.StreamBlocksRequest{
 				FilterNamespaces: []string{testNs1},
 			},
 			expectedTxIDs: []string{testTxID1, testTxID3}, // tx1 has ns1, tx3 has ns1+ns2
 		},
 		{
 			name: "NamespaceFilter_ns2",
-			request: &committerpb.StreamAllRequest{
+			request: &committerpb.StreamBlocksRequest{
 				FilterNamespaces: []string{testNs2},
 			},
 			expectedTxIDs: []string{testTxID2, testTxID3}, // tx2 has ns2, tx3 has ns1+ns2
 		},
 		{
+			name: "NamespaceFilter_noMatches",
+			request: &committerpb.StreamBlocksRequest{
+				FilterNamespaces: []string{testNonexistentNamespace},
+			},
+			expectedTxIDs: []string{},
+		},
+		{
 			name: "StatusFilter_COMMITTED",
-			request: &committerpb.StreamAllRequest{
+			request: &committerpb.StreamBlocksRequest{
 				FilterStatus: []committerpb.Status{committerpb.Status_COMMITTED},
 			},
 			expectedTxIDs: []string{testTxID1, testTxID3}, // Only COMMITTED txs
 		},
 		{
 			name: "CombinedFilters",
-			request: &committerpb.StreamAllRequest{
+			request: &committerpb.StreamBlocksRequest{
 				FilterNamespaces: []string{testNs1},
 				FilterStatus:     []committerpb.Status{committerpb.Status_COMMITTED},
 			},
@@ -674,21 +686,21 @@ func TestStreamAllTransactions(t *testing.T) {
 		},
 		{
 			name: "WithNamespaces",
-			request: &committerpb.StreamAllRequest{
+			request: &committerpb.StreamBlocksRequest{
 				IncludeReadWriteSets: true,
 			},
 			expectedTxIDs: []string{testTxID1, testTxID2, testTxID3, testTxID4},
 		},
 		{
 			name: "WithEndorsements",
-			request: &committerpb.StreamAllRequest{
+			request: &committerpb.StreamBlocksRequest{
 				IncludeEndorsements: true,
 			},
 			expectedTxIDs: []string{testTxID1, testTxID2, testTxID3, testTxID4},
 		},
 		{
 			name: "WithMetadata",
-			request: &committerpb.StreamAllRequest{
+			request: &committerpb.StreamBlocksRequest{
 				IncludeMetadata: true,
 			},
 			expectedTxIDs: []string{testTxID1, testTxID2, testTxID3, testTxID4},
@@ -696,10 +708,10 @@ func TestStreamAllTransactions(t *testing.T) {
 	}
 
 	env := newNotifierTestEnv(t, 0)
-	streams := make([]committerpb.Notifier_StreamAllTransactionsClient, len(cases))
+	streams := make([]committerpb.SidecarService_StreamBlocksClient, len(cases))
 	for i, tc := range cases {
 		var err error
-		streams[i], err = env.client.StreamAllTransactions(t.Context(), tc.request)
+		streams[i], err = env.client.StreamBlocks(t.Context(), tc.request)
 		require.NoError(t, err)
 	}
 
@@ -717,6 +729,8 @@ func TestStreamAllTransactions(t *testing.T) {
 			batch, err := streams[i].Recv()
 			require.NoError(t, err)
 			require.EqualValues(t, 1, batch.BlockNumber)
+			require.Equal(t, blockHash, batch.BlockHash)
+			require.Equal(t, prevBlockHash, batch.PrevBlockHash)
 
 			actualTxIDs := make([]string, len(batch.Events))
 			for j, event := range batch.Events {

--- a/service/sidecar/relay.go
+++ b/service/sidecar/relay.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/hyperledger/fabric-protos-go-apiv2/common"
 	"github.com/hyperledger/fabric-x-common/api/committerpb"
+	"github.com/hyperledger/fabric-x-common/protoutil"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/hyperledger/fabric-x-committer/api/servicepb"
@@ -407,9 +408,11 @@ func (r *relay) processCommittedBlocksInOrder(
 
 		// Create committedBlockWithTxs from blockWithStatus for notifier
 		outgoingCommittedBlockWithTxs.Write(&committedBlockWithTxs{
-			blockNumber: blkWithStatus.blockNumber,
-			txs:         blkWithStatus.txs,
-			statuses:    blkWithStatus.txStatus,
+			blockNumber:   blkWithStatus.blockNumber,
+			blockHash:     protoutil.BlockHeaderHash(blkWithStatus.block.Header),
+			prevBlockHash: blkWithStatus.block.Header.PreviousHash,
+			txs:           blkWithStatus.txs,
+			statuses:      blkWithStatus.txStatus,
 		})
 	}
 }

--- a/service/sidecar/sidecar.go
+++ b/service/sidecar/sidecar.go
@@ -50,13 +50,16 @@ var logger = flogging.MustGetLogger("sidecar")
 // it aggregates the transaction status and forwards the validated block to clients who have
 // registered on the ledger server.
 //   - Implements peer.DeliverServer by streaming blocks from a blockStore.
-//   - Implements committerpb.BlockQueryServiceServer by delegating
-//     read-only queries directly to the underlying block store.
+//   - Implements committerpb.SidecarServiceServer: block-store reads are served
+//     here, event streams by the embedded notifier, and RPCs the sidecar does not
+//     implement yet fall through to the notifier's UnimplementedSidecarServiceServer.
 type Service struct {
-	committerpb.UnimplementedBlockQueryServiceServer
+	// Embedded so the notifier's stream RPCs and the Unimplemented fallbacks are
+	// promoted onto Service. The field keeps the name `notifier`, so existing
+	// s.notifier call sites are unaffected.
+	*notifier
 	deliveryParams deliverorderer.Parameters
 	relay          *relay
-	notifier       *notifier
 	blockStore     *blockStore
 	coordConn      *grpc.ClientConn
 	queues         *queues
@@ -210,9 +213,10 @@ func (s *Service) Run(ctx context.Context) error {
 
 // RegisterService registers the sidecar's gRPC services and monitoring server.
 func (s *Service) RegisterService(srv serve.Servers) {
+	committerpb.RegisterSidecarServiceServer(srv.GRPC, s)
+	// Fabric block delivery keeps its own service so Fabric clients dial the
+	// sidecar with the wire contract they already implement.
 	peer.RegisterDeliverServer(srv.GRPC, s)
-	committerpb.RegisterBlockQueryServiceServer(srv.GRPC, s)
-	committerpb.RegisterNotifierServer(srv.GRPC, s.notifier)
 	healthgrpc.RegisterHealthServer(srv.GRPC, s.healthcheck)
 	serve.RegisterDynamicTLSUpdater(srv.GrpcTLSProvider, &s.tlsUpdater)
 	monitoring.RegisterMonitoringServer(srv.HTTP, s.metrics.Provider)

--- a/service/sidecar/sidecar_test.go
+++ b/service/sidecar/sidecar_test.go
@@ -26,6 +26,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/durationpb"
 
@@ -51,7 +53,7 @@ type sidecarTestEnv struct {
 
 	sidecar        *Service
 	committedBlock chan *common.Block
-	notifyStream   committerpb.Notifier_OpenNotificationStreamClient
+	notifyStream   committerpb.SidecarService_OpenNotificationStreamClient
 }
 
 type sidecarTestConfig struct {
@@ -157,7 +159,7 @@ func (env *sidecarTestEnv) startNotificationStream(
 	t.Helper()
 	conn := test.NewSecuredConnection(t, &env.serverConfig.GRPC.Endpoint, sidecarClientCreds)
 	var err error
-	env.notifyStream, err = committerpb.NewNotifierClient(conn).OpenNotificationStream(ctx)
+	env.notifyStream, err = committerpb.NewSidecarServiceClient(conn).OpenNotificationStream(ctx)
 	require.NoError(t, err)
 }
 
@@ -897,4 +899,22 @@ func TestSidecarRecoveryUpdatesOrdererEndpointsBeforeLedgerRecovery(t *testing.T
 
 	t.Log("Verify normal operation continues with recovered state")
 	env.sendTransactionsAndEnsureCommitted(newCtx, t, 12)
+}
+
+// TestDeleteDBCloneForSnapshotUnimplemented pins the snapshot-administration
+// extension point: the RPC is reachable on the unified service and reports
+// UNIMPLEMENTED until the clone-deletion pipeline lands.
+func TestDeleteDBCloneForSnapshotUnimplemented(t *testing.T) {
+	t.Parallel()
+
+	env := newSidecarTestEnvWithTLS(t, sidecarTestConfig{})
+	env.startSidecarService(t.Context(), t)
+
+	conn := test.NewInsecureConnection(t, &env.serverConfig.GRPC.Endpoint)
+	client := committerpb.NewSidecarServiceClient(conn)
+
+	_, err := client.DeleteDBCloneForSnapshot(t.Context(), &committerpb.DeleteDBCloneForSnapshotRequest{
+		TxId: "tx1",
+	})
+	require.Equal(t, codes.Unimplemented, status.Code(err))
 }

--- a/service/sidecar/test_exports.go
+++ b/service/sidecar/test_exports.go
@@ -27,7 +27,7 @@ import (
 // RequireNotifications verifies that the expected notification were received.
 func RequireNotifications( //nolint:revive // argument-limit.
 	t *testing.T,
-	notifyStream committerpb.Notifier_OpenNotificationStreamClient,
+	notifyStream committerpb.SidecarService_OpenNotificationStreamClient,
 	expectedBlockNumber uint64,
 	txIDs []string,
 	status []committerpb.Status,
@@ -56,12 +56,14 @@ func RequireNotifications( //nolint:revive // argument-limit.
 	}, 15*time.Second, 50*time.Millisecond)
 }
 
-// RequireStreamAllTransactions verifies that the expected transactions were received
-// from the StreamAllTransactions stream.
-func RequireStreamAllTransactions( //nolint:revive // argument-limit.
+// RequireStreamBlocks verifies that the expected transactions were received
+// from the StreamBlocks stream.
+func RequireStreamBlocks( //nolint:revive // argument-limit.
 	t *testing.T,
-	stream committerpb.Notifier_StreamAllTransactionsClient,
+	stream committerpb.SidecarService_StreamBlocksClient,
 	expectedBlockNumber uint64,
+	expectedBlockHash []byte,
+	expectedPrevBlockHash []byte,
 	txIDs []string,
 	status []committerpb.Status,
 ) {
@@ -84,6 +86,8 @@ func RequireStreamAllTransactions( //nolint:revive // argument-limit.
 		require.NoError(ct, err)
 		require.NotNil(ct, batch)
 		require.Equal(ct, expectedBlockNumber, batch.BlockNumber)
+		require.Equal(ct, expectedBlockHash, batch.BlockHash)
+		require.Equal(ct, expectedPrevBlockHash, batch.PrevBlockHash)
 		events = batch.Events
 	}, 15*time.Second, 50*time.Millisecond)
 

--- a/utils/deliverorderer/orderer.go
+++ b/utils/deliverorderer/orderer.go
@@ -114,8 +114,8 @@ func ToQueue(ctx context.Context, odp Parameters) (*SessionInfo, error) {
 
 	return &SessionInfo{
 		LastBlock:                   d.dataStream.lastBlock,
-		NextBlockVerificationConfig: d.dataStream.ConfigBlock,
-		LatestKnownConfig:           d.latestConfig.ConfigBlock,
+		NextBlockVerificationConfig: d.dataStream.configBlock(),
+		LatestKnownConfig:           d.latestConfig.configBlock(),
 	}, err
 }
 

--- a/utils/deliverorderer/orderer_test.go
+++ b/utils/deliverorderer/orderer_test.go
@@ -249,6 +249,23 @@ func TestNewOrdererDeliverEdgeCases(t *testing.T) {
 		})
 		require.ErrorContains(t, err, "config block number [3] is ahead of the next expected block [2]")
 	})
+
+	t.Run("no config block at all", func(t *testing.T) {
+		t.Parallel()
+
+		// The session ends before any config block is processed, so the config state holds no
+		// config block material. Reading the session's config blocks must not panic.
+		session, err := deliverorderer.ToQueue(cancelledContext, deliverorderer.Parameters{
+			FaultToleranceLevel:          ordererdial.BFT,
+			TLS:                          *tls,
+			OutputBlock:                  make(chan *common.Block, 10),
+			SuspicionGracePeriodPerBlock: time.Second,
+		})
+		require.ErrorIs(t, err, context.Canceled)
+		require.NotNil(t, session)
+		require.Nil(t, session.NextBlockVerificationConfig)
+		require.Nil(t, session.LatestKnownConfig)
+	})
 }
 
 func TestOrdererDeliverCFT(t *testing.T) {

--- a/utils/deliverorderer/verify.go
+++ b/utils/deliverorderer/verify.go
@@ -235,7 +235,7 @@ func (s *blockVerificationStateMachine) verifyBlockPolicy(block *common.Block) e
 	// If we got block #0, we must also have the config block #0, as we assert that the config
 	// block is never ahead of the next expected block.
 	if blockNumber == 0 {
-		ok := proto.Equal(block, s.ConfigBlock)
+		ok := proto.Equal(block, s.configBlock())
 		if !ok {
 			return ErrGenesisBlockMismatch
 		}
@@ -248,6 +248,16 @@ func (s *blockVerificationStateMachine) verifyBlockPolicy(block *common.Block) e
 		return errors.Wrapf(errors.Join(ErrSignatureVerification, err), "on block [%d]", blockNumber)
 	}
 	return nil
+}
+
+// configBlock returns the config block, or nil if no config block was loaded yet.
+// The embedded ConfigBlockMaterial is nil until the first config block is processed,
+// so the field must never be dereferenced directly.
+func (cs *configState) configBlock() *common.Block {
+	if cs.ConfigBlockMaterial == nil {
+		return nil
+	}
+	return cs.ConfigBlock
 }
 
 // updateIfConfigBlock sets the config by which blocks are verified.


### PR DESCRIPTION
#### Type of change

- Improvement (improvement to code, performance, etc)
- Bug fix
- Breaking change

#### Description

- Register a single `committerpb.SidecarService` in `Service.RegisterService`,
  replacing the separate `BlockQueryService` and `Notifier` registrations.
- Embed `*notifier` in `Service` and `UnimplementedSidecarServiceServer` in
  `notifier`, so selector depth promotes the block-query methods, the stream
  methods, and the not-yet-implemented fallbacks onto one object without
  forwarder methods.
- Keep Fabric block delivery on the Fabric `protos.Deliver` service, a separate
  gRPC service, so Fabric clients dial the sidecar unchanged.
- Move clients to `NewSidecarServiceClient`, and consume the renamed upstream
  block stream API (`StreamBlocks`, `StreamBlocksRequest`, `BlockEvent`),
  including `block_hash` and `prev_block_hash`.
- `StreamBlocks` now emits every committed block, including blocks whose
  filters match no transactions.
- `DeleteDBCloneForSnapshot` is reachable and answers `UNIMPLEMENTED` until its
  pipeline lands.
- Guard the delivery session's config blocks behind `configState.configBlock()`: the
  embedded `*ConfigBlockMaterial` is nil until the first config block is processed, so
  `ToQueue` panicked when a session ended before that (also fixes the same nil deref in
  the genesis-block comparison).

#### Additional details (Optional)

Requires the fabric-x-common release containing the unified `SidecarService`
(hyperledger/fabric-x-common#179), pinned here as
`v0.2.9-0.20260910095823-4b946650f960`.

`UnimplementedSidecarServiceServer` is embedded on `notifier` rather than on
`Service` on purpose: embedding it on `Service` would put it at the same
selector depth as the notifier's stream methods, making those selectors
ambiguous so `Service` would silently stop satisfying `SidecarServiceServer`.

#### Related issues

- resolves #659


