### PR TITLE
[coordinator] Report the dependency graph queue sizes on scrape

### DIFF
--- a/.bob/skills/development/references/service-construction.md
+++ b/.bob/skills/development/references/service-construction.md
@@ -184,14 +184,13 @@ pointers tagged `validate:"required"`. Serving knobs (server/monitoring endpoint
 keepalive, rate-limit) live in `serve.Config`, **not** the service config.
 
 ```go
-// service/coordinator/config.go:17
+// service/coordinator/config.go:14
 type Config struct {
 	Verifier           connection.MultiClientConfig `mapstructure:"verifier"`
 	ValidatorCommitter connection.MultiClientConfig `mapstructure:"validator-committer"`
 	DependencyGraph    *DependencyGraphConfig       `mapstructure:"dependency-graph" validate:"required"`
 	// Every scalar carries its default in a `default` tag, not a Default* const.
 	ChannelBufferSizePerGoroutine int `mapstructure:"per-channel-buffer-size-per-goroutine" default:"10" validate:"gt=0"`
-	QueueMonitorSamplingTime time.Duration `mapstructure:"queue-monitor-sampling-time" default:"100ms" validate:"gt=0"`
 }
 ```
 

--- a/cmd/config/app_config_test.go
+++ b/cmd/config/app_config_test.go
@@ -170,7 +170,6 @@ func TestReadConfigCoordinator(t *testing.T) {
 				ChunkSize:                 500,
 			},
 			ChannelBufferSizePerGoroutine: 10,
-			QueueMonitorSamplingTime:      100 * time.Millisecond,
 		},
 	}, {
 		name:           "sample",
@@ -189,7 +188,6 @@ func TestReadConfigCoordinator(t *testing.T) {
 				ChunkSize:                 500,
 			},
 			ChannelBufferSizePerGoroutine: 10,
-			QueueMonitorSamplingTime:      100 * time.Millisecond,
 		},
 	}}
 

--- a/cmd/config/samples/coordinator.yaml
+++ b/cmd/config/samples/coordinator.yaml
@@ -101,10 +101,6 @@ dependency-graph:
 # Default: 10
 per-channel-buffer-size-per-goroutine: 10
 
-# Sampling interval for monitoring coordinator queue sizes.
-# Default: 100ms
-queue-monitor-sampling-time: 100ms
-
 # Logging configuration
 logging:
   # Log level specification. Can be a single level (e.g., "info", "debug") or

--- a/cmd/config/templates/coordinator.yaml.tmpl
+++ b/cmd/config/templates/coordinator.yaml.tmpl
@@ -14,4 +14,3 @@ dependency-graph:
   waiting-txs-limit: 100_000
   chunk-size: 500
 per-channel-buffer-size-per-goroutine: 10
-queue-monitor-sampling-time: 100ms

--- a/docs/metrics_reference.md
+++ b/docs/metrics_reference.md
@@ -85,7 +85,7 @@ The following Coordinator metrics are exported for consumption by Prometheus.
 | coordinator_vcservice_output_tx_status_batch_queue_size                                | gauge     |               | Size of the output transaction status batch queue of the validation and committer service manager.            |
 | coordinator_local_dependency_graph_input_tx_batch_queue_size                           | gauge     |               | Size of the input transaction batch queue of the local dependency graph manager                               |
 | coordinator_global_dependency_graph_input_tx_batch_queue_size                          | gauge     |               | Size of the input transaction batch queue of the global dependency graph manager                              |
-| coordinator_global_dependency_graph_size                                               | gauge     |               | Size of the global dependency graph manager in terms of the number of transactions waiting to be processed    |
+| coordinator_global_dependency_graph_size                                               | gauge     |               | Number of transactions held in the global dependency graph waiting to be processed                            |
 | coordinator_local_dependency_graph_tx_processed_total                                  | counter   |               | Total number of new transactions processed by the local dependency graph manager                              |
 | coordinator_global_dependency_graph_tx_processed_total                                 | counter   |               | Total number of new transactions processed by the global dependency graph manager                             |
 | coordinator_global_dependency_graph_validated_tx_processed_total                       | counter   |               | Total number of validated transactions processed by the global dependency graph manager                       |
@@ -98,7 +98,7 @@ The following Coordinator metrics are exported for consumption by Prometheus.
 | coordinator_global_dependency_graph_remove_dependents_of_validated_tx_batch_seconds    | histogram |               | Time spent removing the dependents of a validated transaction batch in the global dependency graph manager    |
 | coordinator_global_dependency_graph_add_freed_tx_batch_seconds                         | histogram |               | Time spent adding a freed transaction batch to a queue in the global dependency graph manager                 |
 | coordinator_global_dependency_graph_output_freed_tx_batch_seconds                      | histogram |               | Time spent outputting a freed transaction batch in the global dependency graph manager                        |
-| coordinator_dependency_graph_dependent_transactions_queue_size                         | gauge     |               | The number of transactions currently waiting on dependencies.                                                 |
+| coordinator_dependency_graph_dependent_transactions                                    | gauge     |               | The number of transactions currently waiting on dependencies.                                                 |
 
 ## Verifier Metrics
 

--- a/loadgen/client_test.go
+++ b/loadgen/client_test.go
@@ -178,7 +178,6 @@ func TestLoadGenForCoordinator(t *testing.T) {
 					ChunkSize:                 500,
 				},
 				ChannelBufferSizePerGoroutine: 10,
-				QueueMonitorSamplingTime:      100 * time.Millisecond,
 			}
 
 			service := coordinator.NewCoordinatorService(cConf)

--- a/service/coordinator/config.go
+++ b/service/coordinator/config.go
@@ -7,8 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 package coordinator
 
 import (
-	"time"
-
 	"github.com/hyperledger/fabric-x-committer/utils/connection"
 )
 
@@ -19,8 +17,6 @@ type Config struct {
 	DependencyGraph    *DependencyGraphConfig       `mapstructure:"dependency-graph" validate:"required"`
 	// ChannelBufferSizePerGoroutine defines the buffer size per go-routine.
 	ChannelBufferSizePerGoroutine int `mapstructure:"per-channel-buffer-size-per-goroutine" default:"10" validate:"gt=0"` //nolint:lll,revive
-	// QueueMonitorSamplingTime defines the sampling interval for monitoring queue sizes.
-	QueueMonitorSamplingTime time.Duration `mapstructure:"queue-monitor-sampling-time" default:"100ms" validate:"gt=0"`
 }
 
 // DependencyGraphConfig is the configuration for dependency graph manager. It contains resource limits.

--- a/service/coordinator/coordinator.go
+++ b/service/coordinator/coordinator.go
@@ -136,7 +136,6 @@ func NewCoordinatorService(c *Config) *Service {
 			IncomingValidatedTxsNode:  queues.vcServiceToDepGraphValidatedTxs,
 			NumOfLocalDepConstructors: c.DependencyGraph.NumOfLocalDepConstructors,
 			WaitingTxsLimit:           c.DependencyGraph.WaitingTxsLimit,
-			QueueMonitorSamplingTime:  c.QueueMonitorSamplingTime,
 			PrometheusMetricsProvider: metrics.Provider,
 		},
 	)

--- a/service/coordinator/coordinator_test.go
+++ b/service/coordinator/coordinator_test.go
@@ -110,7 +110,6 @@ func newCoordinatorTestEnv(t *testing.T, tConfig *testConfig) *coordinatorTestEn
 			ChunkSize:                 500,
 		},
 		ChannelBufferSizePerGoroutine: 2000,
-		QueueMonitorSamplingTime:      100 * time.Millisecond,
 	}
 	return &coordinatorTestEnv{
 		coordinator:            NewCoordinatorService(c),

--- a/service/coordinator/dependencygraph/dependency_graph_test.go
+++ b/service/coordinator/dependencygraph/dependency_graph_test.go
@@ -25,7 +25,10 @@ func TestDependencyGraph(t *testing.T) {
 	localDepIncomingTxs := make(chan *TransactionBatch, 10)
 	localDepOutgoingTxs := make(chan *transactionNodeBatch, 10)
 
-	metrics := newPerformanceMetrics(monitoring.NewProvider())
+	metrics := newPerformanceMetrics(monitoring.NewProvider(), &managerQueues{
+		ldgInput: localDepIncomingTxs,
+		gdgInput: localDepOutgoingTxs,
+	})
 	ldc := newLocalDependencyConstructor(localDepIncomingTxs, localDepOutgoingTxs, metrics)
 
 	globalDepOutgoingTxs := make(chan TxNodeBatch, 10)
@@ -51,7 +54,7 @@ func TestDependencyGraph(t *testing.T) {
 	t.Log("check reads and writes dependency tracking")
 	keys := makeTestKeys(t, 10)
 
-	test.RequireIntMetricValue(t, 0, metrics.dependentTransactionsQueueSize)
+	test.RequireIntMetricValue(t, 0, metrics.dependentTxCount)
 
 	// t2 depends on t1
 	t1 := createTxForTest(
@@ -66,7 +69,7 @@ func TestDependencyGraph(t *testing.T) {
 		Txs: []*servicepb.TxWithRef{t1, t2},
 	}
 
-	test.EventuallyIntMetric(t, 1, metrics.dependentTransactionsQueueSize, 5*time.Second, 100*time.Millisecond)
+	test.EventuallyIntMetric(t, 1, metrics.dependentTxCount, 5*time.Second, 100*time.Millisecond)
 
 	// t3 depends on t2 and t1
 	t3 := createTxForTest(
@@ -82,7 +85,7 @@ func TestDependencyGraph(t *testing.T) {
 		Txs: []*servicepb.TxWithRef{t3, t4},
 	}
 
-	test.EventuallyIntMetric(t, 3, metrics.dependentTransactionsQueueSize, 5*time.Second, 100*time.Millisecond)
+	test.EventuallyIntMetric(t, 3, metrics.dependentTxCount, 5*time.Second, 100*time.Millisecond)
 
 	// only t1 is dependency free
 	depFreeTxs := <-globalDepOutgoingTxs
@@ -103,7 +106,7 @@ func TestDependencyGraph(t *testing.T) {
 	actualT2 := depFreeTxs[0]
 	test.RequireProtoEqual(t, t2.Ref, actualT2.VCTx.Ref)
 
-	test.RequireIntMetricValue(t, 2, metrics.dependentTransactionsQueueSize)
+	test.RequireIntMetricValue(t, 2, metrics.dependentTxCount)
 
 	// t2 has 2 dependent transactions, t3 and t4
 	require.Equal(t, 2, actualT2.dependentTxs.Count())
@@ -124,7 +127,7 @@ func TestDependencyGraph(t *testing.T) {
 	test.RequireProtoEqual(t, t3.Ref, actualT3.VCTx.Ref)
 	test.RequireProtoEqual(t, t4.Ref, actualT4.VCTx.Ref)
 
-	test.RequireIntMetricValue(t, 0, metrics.dependentTransactionsQueueSize)
+	test.RequireIntMetricValue(t, 0, metrics.dependentTxCount)
 
 	validatedTxs <- TxNodeBatch{actualT3, actualT4}
 

--- a/service/coordinator/dependencygraph/global_dependency_manager.go
+++ b/service/coordinator/dependencygraph/global_dependency_manager.go
@@ -142,7 +142,7 @@ func (dm *globalDependencyManager) constructDependencyGraph(ctx context.Context)
 			return
 		}
 
-		promutil.AddToGauge(m.gdgWaitingTxQueueSize, len(txsNode))
+		promutil.AddToGauge(m.gdgWaitingTxCount, len(txsNode))
 		depFreeTxs := make(TxNodeBatch, 0, len(txsNode))
 
 		start := time.Now()
@@ -158,7 +158,7 @@ func (dm *globalDependencyManager) constructDependencyGraph(ctx context.Context)
 		for _, txNode := range txsNode {
 			dependsOnTx := dm.dependencyDetector.getDependenciesOf(txNode)
 			if len(dependsOnTx) > 0 {
-				promutil.AddToGauge(m.dependentTransactionsQueueSize, 1)
+				promutil.AddToGauge(m.dependentTxCount, 1)
 				txNode.addDependenciesAndUpdateDependents(dependsOnTx)
 			} else if len(txNode.dependsOnTxs) == 0 {
 				depFreeTxs = append(depFreeTxs, txNode)
@@ -198,7 +198,7 @@ func (dm *globalDependencyManager) processValidatedTransactions(ctx context.Cont
 		}
 		processValidatedStart := time.Now()
 		dm.waitingTxsSlots.Release(int64(len(txsNode)))
-		promutil.SubFromGauge(m.gdgWaitingTxQueueSize, len(txsNode))
+		promutil.SubFromGauge(m.gdgWaitingTxCount, len(txsNode))
 
 		start := time.Now()
 		dm.mu.Lock()
@@ -219,7 +219,7 @@ func (dm *globalDependencyManager) processValidatedTransactions(ctx context.Cont
 		// Step 2: Send the fullyFreedDependents to the outgoingDepFreeTransactionsNode.
 		start = time.Now()
 		if len(fullyFreedDependents) > 0 {
-			promutil.SubFromGauge(m.dependentTransactionsQueueSize, len(fullyFreedDependents))
+			promutil.SubFromGauge(m.dependentTxCount, len(fullyFreedDependents))
 			dm.freedTransactionsSet.add(fullyFreedDependents)
 			fullyFreedDependents = nil
 		}

--- a/service/coordinator/dependencygraph/global_dependency_manager_test.go
+++ b/service/coordinator/dependencygraph/global_dependency_manager_test.go
@@ -27,11 +27,14 @@ type globalDependencyTestEnv struct {
 
 func newGlobalDependencyTestEnv(t *testing.T) *globalDependencyTestEnv {
 	t.Helper()
+	incomingTxs := make(chan *transactionNodeBatch, 10)
 	env := &globalDependencyTestEnv{
-		incomingTxs:  make(chan *transactionNodeBatch, 10),
+		incomingTxs:  incomingTxs,
 		outgoingTxs:  make(chan TxNodeBatch, 10),
 		validatedTxs: make(chan TxNodeBatch, 10),
-		metrics:      newPerformanceMetrics(monitoring.NewProvider()),
+		metrics: newPerformanceMetrics(monitoring.NewProvider(), &managerQueues{
+			gdgInput: incomingTxs,
+		}),
 	}
 
 	dm := newGlobalDependencyManager(
@@ -99,11 +102,11 @@ func TestGlobalDependencyManagerNoGlobalDependency(t *testing.T) {
 		// only dependency free tx is t1
 		require.Equal(t, TxNodeBatch{t1}, depFreeTxs)
 
-		test.RequireIntMetricValue(t, 3, env.metrics.gdgWaitingTxQueueSize)
+		test.RequireIntMetricValue(t, 3, env.metrics.gdgWaitingTxCount)
 
 		env.validatedTxs <- TxNodeBatch{t1}
 
-		test.EventuallyIntMetric(t, 2, env.metrics.gdgWaitingTxQueueSize, 2*time.Second, 200*time.Millisecond)
+		test.EventuallyIntMetric(t, 2, env.metrics.gdgWaitingTxCount, 2*time.Second, 200*time.Millisecond)
 
 		depFreeTxs = <-env.outgoingTxs
 		// after validating t1, t2 becomes dependency free

--- a/service/coordinator/dependencygraph/local_dependency_constructor.go
+++ b/service/coordinator/dependencygraph/local_dependency_constructor.go
@@ -115,7 +115,7 @@ func (p *localDependencyConstructor) construct(ctx context.Context) {
 			// of the next transaction.
 			dependsOnTxs := depDetector.getDependenciesOf(txNode)
 			if len(dependsOnTxs) > 0 {
-				promutil.AddToGauge(p.metrics.dependentTransactionsQueueSize, 1)
+				promutil.AddToGauge(p.metrics.dependentTxCount, 1)
 				txNode.addDependenciesAndUpdateDependents(dependsOnTxs)
 			}
 			depDetector.addWaitingTx(txNode)

--- a/service/coordinator/dependencygraph/local_dependency_constructor_test.go
+++ b/service/coordinator/dependencygraph/local_dependency_constructor_test.go
@@ -31,7 +31,10 @@ func newLocalDependencyConstructorTestEnv(t *testing.T) *localDependencyConstruc
 	inComingTxs := make(chan *TransactionBatch, 5)
 	outGoingTxs := make(chan *transactionNodeBatch, 5)
 
-	metrics := newPerformanceMetrics(monitoring.NewProvider())
+	metrics := newPerformanceMetrics(monitoring.NewProvider(), &managerQueues{
+		ldgInput: inComingTxs,
+		gdgInput: outGoingTxs,
+	})
 	ldc := newLocalDependencyConstructor(inComingTxs, outGoingTxs, metrics)
 	test.RunServiceForTest(t.Context(), t, func(ctx context.Context) error {
 		ldc.run(ctx, 5)
@@ -110,7 +113,7 @@ func TestLocalDependencyConstructorWithDependencies(t *testing.T) { //nolint:goc
 		}
 
 		test.EventuallyIntMetric(t, 5, env.metrics.ldgTxProcessedTotal, 2*time.Second, 200*time.Millisecond)
-		test.RequireIntMetricValue(t, 0, env.metrics.dependentTransactionsQueueSize)
+		test.RequireIntMetricValue(t, 0, env.metrics.dependentTxCount)
 	})
 
 	t.Run("linear dependency i and i+1 transaction", func(t *testing.T) {
@@ -151,7 +154,7 @@ func TestLocalDependencyConstructorWithDependencies(t *testing.T) { //nolint:goc
 				require.True(t, exist)
 			}
 		}
-		test.RequireIntMetricValue(t, 3, env.metrics.dependentTransactionsQueueSize)
+		test.RequireIntMetricValue(t, 3, env.metrics.dependentTxCount)
 	})
 
 	t.Run("all txs depends on the metaNamespace tx", func(t *testing.T) {
@@ -184,7 +187,7 @@ func TestLocalDependencyConstructorWithDependencies(t *testing.T) { //nolint:goc
 				require.Equal(t, TxNodeBatch{txsNode[0]}, txNode.dependsOnTxs)
 			}
 		}
-		test.RequireIntMetricValue(t, 3, env.metrics.dependentTransactionsQueueSize)
+		test.RequireIntMetricValue(t, 3, env.metrics.dependentTxCount)
 	})
 
 	t.Run("metaNamespace tx depends on all other txs", func(t *testing.T) {
@@ -218,7 +221,7 @@ func TestLocalDependencyConstructorWithDependencies(t *testing.T) { //nolint:goc
 				require.Empty(t, txNode.dependsOnTxs)
 			}
 		}
-		test.RequireIntMetricValue(t, 1, env.metrics.dependentTransactionsQueueSize)
+		test.RequireIntMetricValue(t, 1, env.metrics.dependentTxCount)
 	})
 }
 

--- a/service/coordinator/dependencygraph/manager.go
+++ b/service/coordinator/dependencygraph/manager.go
@@ -8,29 +8,39 @@ package dependencygraph
 
 import (
 	"context"
-	"time"
 
 	"golang.org/x/sync/errgroup"
-
-	"github.com/hyperledger/fabric-x-committer/utils/monitoring/promutil"
 )
 
 // Manager is the main component of the dependency graph module.
 // It is responsible for managing the local dependency constructor
 // and the global dependency manager.
 type Manager struct {
-	localDepConstructor         *localDependencyConstructor
-	globalDepManager            *globalDependencyManager
-	parameters                  *Parameters
-	outgoingTxsNodeWithLocalDep chan *transactionNodeBatch
-	metrics                     *perfMetrics
+	localDepConstructor *localDependencyConstructor
+	globalDepManager    *globalDependencyManager
+	parameters          *Parameters
+	metrics             *perfMetrics
+}
+
+// managerQueues are the queues a manager reports the size of on scrape. They are only ever
+// measured, never sent to, so they are receive-only, as in the coordinator's struct of the
+// same name. A nil queue reports zero, which SimpleManager relies on: its pre-processing queue
+// holds a different element type and is not reported.
+type managerQueues struct {
+	ldgInput <-chan *TransactionBatch
+	gdgInput <-chan *transactionNodeBatch
 }
 
 // NewManager creates a new dependency graph manager.
 func NewManager(p *Parameters) *Manager {
-	metrics := newPerformanceMetrics(p.PrometheusMetricsProvider)
-
 	outgoingTxsNodeWithLocalDep := make(chan *transactionNodeBatch, cap(p.IncomingTxs))
+
+	// The queues are reported on scrape, so they must exist before the metrics are registered.
+	metrics := newPerformanceMetrics(p.PrometheusMetricsProvider, &managerQueues{
+		ldgInput: p.IncomingTxs,
+		gdgInput: outgoingTxsNodeWithLocalDep,
+	})
+
 	ldp := newLocalDependencyConstructor(p.IncomingTxs, outgoingTxsNodeWithLocalDep, metrics)
 
 	gdConf := &globalDepConfig{
@@ -44,11 +54,10 @@ func NewManager(p *Parameters) *Manager {
 	gdp := newGlobalDependencyManager(gdConf)
 
 	return &Manager{
-		localDepConstructor:         ldp,
-		globalDepManager:            gdp,
-		parameters:                  p,
-		outgoingTxsNodeWithLocalDep: outgoingTxsNodeWithLocalDep,
-		metrics:                     metrics,
+		localDepConstructor: ldp,
+		globalDepManager:    gdp,
+		parameters:          p,
+		metrics:             metrics,
 	}
 }
 
@@ -56,11 +65,6 @@ func NewManager(p *Parameters) *Manager {
 // local dependency constructors and global dependency graph manager.
 func (m *Manager) Run(ctx context.Context) {
 	g, gCtx := errgroup.WithContext(ctx)
-
-	g.Go(func() error {
-		m.monitorQueues(gCtx)
-		return nil
-	})
 
 	g.Go(func() error {
 		m.localDepConstructor.run(gCtx, m.parameters.NumOfLocalDepConstructors)
@@ -73,19 +77,4 @@ func (m *Manager) Run(ctx context.Context) {
 	})
 
 	_ = g.Wait()
-}
-
-func (m *Manager) monitorQueues(ctx context.Context) {
-	ticker := time.NewTicker(m.parameters.QueueMonitorSamplingTime)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-ticker.C:
-		}
-
-		promutil.SetGauge(m.metrics.ldgInputTxBatchQueueSize, len(m.localDepConstructor.incomingTransactions))
-		promutil.SetGauge(m.metrics.gdgInputTxBatchQueueSize, len(m.globalDepManager.incomingTransactionsNode))
-	}
 }

--- a/service/coordinator/dependencygraph/manager_test.go
+++ b/service/coordinator/dependencygraph/manager_test.go
@@ -24,8 +24,6 @@ import (
 	"github.com/hyperledger/fabric-x-committer/utils/test"
 )
 
-const DefaultQueueMonitorSamplingTime = 100 * time.Millisecond
-
 // Manager kinds under test.
 const (
 	managerKindGlobalLocal = "global-local"
@@ -109,7 +107,6 @@ func BenchmarkDependencyGraph(b *testing.B) {
 						IncomingValidatedTxsNode:  val,
 						NumOfLocalDepConstructors: tc.workers,
 						WaitingTxsLimit:           20_000_000,
-						QueueMonitorSamplingTime:  DefaultQueueMonitorSamplingTime,
 						PrometheusMetricsProvider: monitoring.NewProvider(),
 					})
 
@@ -205,12 +202,11 @@ func TestDependencyGraphManager(t *testing.T) {
 				IncomingValidatedTxsNode:  validatedTxs,
 				NumOfLocalDepConstructors: 2,
 				WaitingTxsLimit:           waitingTXsLimit,
-				QueueMonitorSamplingTime:  DefaultQueueMonitorSamplingTime,
 				PrometheusMetricsProvider: monitoring.NewProvider(),
 			})
 
 			t.Log("check reads and writes dependency tracking")
-			test.RequireIntMetricValue(t, 0, metrics.dependentTransactionsQueueSize)
+			test.RequireIntMetricValue(t, 0, metrics.dependentTxCount)
 
 			// t2 depends on t1
 			t1 := createTxForTest(t, 0, nsID1ForTest, keys(0, 1), keys(2, 3), keys(4, 5))
@@ -221,7 +217,7 @@ func TestDependencyGraphManager(t *testing.T) {
 				Txs: []*servicepb.TxWithRef{t1, t2},
 			}
 
-			test.EventuallyIntMetric(t, 1, metrics.dependentTransactionsQueueSize, 5*time.Second, 100*time.Millisecond)
+			test.EventuallyIntMetric(t, 1, metrics.dependentTxCount, 5*time.Second, 100*time.Millisecond)
 
 			// t3 depends on t2 and t1
 			t3 := createTxForTest(t, 0, nsID1ForTest, keys(7), keys(2, 3), keys(8, 5))
@@ -233,7 +229,7 @@ func TestDependencyGraphManager(t *testing.T) {
 				Txs: []*servicepb.TxWithRef{t3, t4},
 			}
 
-			test.EventuallyIntMetric(t, 3, metrics.dependentTransactionsQueueSize, 5*time.Second, 100*time.Millisecond)
+			test.EventuallyIntMetric(t, 3, metrics.dependentTxCount, 5*time.Second, 100*time.Millisecond)
 
 			// only t1 is dependency free
 			depFreeTxs := <-outgoingTxs
@@ -251,7 +247,7 @@ func TestDependencyGraphManager(t *testing.T) {
 			test.RequireProtoEqual(t, t2.Ref, actualT2.VCTx.Ref)
 			ensureNoOutputs(t, outgoingTxs)
 
-			test.RequireIntMetricValue(t, 2, metrics.dependentTransactionsQueueSize)
+			test.RequireIntMetricValue(t, 2, metrics.dependentTxCount)
 
 			validatedTxs <- TxNodeBatch{actualT2}
 
@@ -270,7 +266,7 @@ func TestDependencyGraphManager(t *testing.T) {
 			test.RequireProtoEqual(t, t4.Ref, actualT4.VCTx.Ref)
 			ensureNoOutputs(t, outgoingTxs)
 
-			test.RequireIntMetricValue(t, 0, metrics.dependentTransactionsQueueSize)
+			test.RequireIntMetricValue(t, 0, metrics.dependentTxCount)
 
 			validatedTxs <- TxNodeBatch{actualT3, actualT4}
 
@@ -387,14 +383,14 @@ func TestDependencyGraphManager(t *testing.T) {
 func ensureWaitingTXsLimit(t *testing.T, metrics *perfMetrics, expectedValue int) {
 	t.Helper()
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
-		require.Equal(ct, expectedValue, test.GetIntMetricValue(t, metrics.gdgWaitingTxQueueSize))
+		require.Equal(ct, expectedValue, test.GetIntMetricValue(t, metrics.gdgWaitingTxCount))
 	}, 5*time.Second, 100*time.Millisecond)
 }
 
 func ensureNeverGreaterWaitingTXsLimit(t *testing.T, metrics *perfMetrics, expectedValue int) {
 	t.Helper()
 	require.Never(t, func() bool {
-		return test.GetIntMetricValue(t, metrics.gdgWaitingTxQueueSize) > expectedValue
+		return test.GetIntMetricValue(t, metrics.gdgWaitingTxCount) > expectedValue
 	}, 5*time.Second, 100*time.Millisecond)
 }
 

--- a/service/coordinator/dependencygraph/metrics.go
+++ b/service/coordinator/dependencygraph/metrics.go
@@ -27,10 +27,14 @@ var bucket = []float64{.0001, .001, .002, .003, .004, .005, .01, .03, .05, .1, .
 type perfMetrics struct {
 	provider *monitoring.Provider
 
-	// queue sizes
-	ldgInputTxBatchQueueSize prometheus.Gauge
-	gdgInputTxBatchQueueSize prometheus.Gauge
-	gdgWaitingTxQueueSize    prometheus.Gauge
+	// Input queue sizes.
+	ldgInputTxBatchQueueSize prometheus.GaugeFunc
+	gdgInputTxBatchQueueSize prometheus.GaugeFunc
+
+	// gdgWaitingTxCount is not a queue: it counts transactions held in the graph's maps under the
+	// manager's lock, so there is no channel to take a length of on demand. It stays maintained
+	// incrementally by the code that adds and frees those transactions.
+	gdgWaitingTxCount prometheus.Gauge
 
 	// processed transactions by each manager
 	ldgTxProcessedTotal          prometheus.Counter
@@ -52,30 +56,33 @@ type perfMetrics struct {
 	// performance of outputFreedExistingTransactions()
 	gdgOutputFreedTxSeconds prometheus.Histogram
 
-	dependentTransactionsQueueSize prometheus.Gauge
+	// dependentTxCount is not a queue either; it counts the transactions blocked on a dependency
+	// and is maintained incrementally, like gdgWaitingTxCount above, from
+	// globalDependencyManager.constructDependencyGraph and processValidatedTransactions,
+	// localDependencyConstructor.construct and SimpleManager.taskProcessing.
+	dependentTxCount prometheus.Gauge
 }
 
-func newPerformanceMetrics(p *monitoring.Provider) *perfMetrics {
+func newPerformanceMetrics(p *monitoring.Provider, q *managerQueues) *perfMetrics {
 	return &perfMetrics{
 		provider: p,
-		ldgInputTxBatchQueueSize: p.NewGauge(prometheus.GaugeOpts{
+		ldgInputTxBatchQueueSize: p.NewChannelLenGauge(prometheus.GaugeOpts{
 			Namespace: namespace,
 			Subsystem: subsystemLocalDependencyGraph,
 			Name:      nameInputTxBatchQueueSize,
 			Help:      "Size of the input transaction batch queue of the local dependency graph manager",
-		}),
-		gdgInputTxBatchQueueSize: p.NewGauge(prometheus.GaugeOpts{
+		}, q.ldgInput),
+		gdgInputTxBatchQueueSize: p.NewChannelLenGauge(prometheus.GaugeOpts{
 			Namespace: namespace,
 			Subsystem: subsystemGlobalDependencyGraph,
 			Name:      nameInputTxBatchQueueSize,
 			Help:      "Size of the input transaction batch queue of the global dependency graph manager",
-		}),
-		gdgWaitingTxQueueSize: p.NewGauge(prometheus.GaugeOpts{
+		}, q.gdgInput),
+		gdgWaitingTxCount: p.NewGauge(prometheus.GaugeOpts{
 			Namespace: namespace,
 			Subsystem: subsystemGlobalDependencyGraph,
 			Name:      "size",
-			Help: "Size of the global dependency graph manager in terms " +
-				"of the number of transactions waiting to be processed",
+			Help:      "Number of transactions held in the global dependency graph waiting to be processed",
 		}),
 		ldgTxProcessedTotal: p.NewCounter(prometheus.CounterOpts{
 			Namespace: namespace,
@@ -164,10 +171,10 @@ func newPerformanceMetrics(p *monitoring.Provider) *perfMetrics {
 			Help:      "Time spent outputting a freed transaction batch in the global dependency graph manager",
 			Buckets:   bucket,
 		}),
-		dependentTransactionsQueueSize: p.NewGauge(prometheus.GaugeOpts{
+		dependentTxCount: p.NewGauge(prometheus.GaugeOpts{
 			Namespace: namespace,
 			Subsystem: "dependency_graph",
-			Name:      "dependent_transactions_queue_size",
+			Name:      "dependent_transactions",
 			Help:      "The number of transactions currently waiting on dependencies.",
 		}),
 	}

--- a/service/coordinator/dependencygraph/metrics_test.go
+++ b/service/coordinator/dependencygraph/metrics_test.go
@@ -1,0 +1,58 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package dependencygraph
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/hyperledger/fabric-x-committer/utils/monitoring"
+	"github.com/hyperledger/fabric-x-committer/utils/test"
+)
+
+// TestQueueSizeMetricsAreWired fills each stage's input queue and asserts the gauge that reports
+// it follows. Both stages export a series named input_tx_batch_queue_size and differ only by
+// subsystem, so a gauge attached to the wrong queue would otherwise go unnoticed.
+func TestQueueSizeMetricsAreWired(t *testing.T) {
+	t.Parallel()
+
+	ldgInput := make(chan *TransactionBatch, 4)
+	gdgInput := make(chan *transactionNodeBatch, 4)
+	m := newPerformanceMetrics(monitoring.NewProvider(), &managerQueues{
+		ldgInput: ldgInput,
+		gdgInput: gdgInput,
+	})
+
+	test.RequireIntMetricValue(t, 0, m.ldgInputTxBatchQueueSize)
+	test.RequireIntMetricValue(t, 0, m.gdgInputTxBatchQueueSize)
+
+	ldgInput <- &TransactionBatch{}
+	gdgInput <- &transactionNodeBatch{}
+	gdgInput <- &transactionNodeBatch{}
+
+	test.RequireIntMetricValue(t, 1, m.ldgInputTxBatchQueueSize)
+	test.RequireIntMetricValue(t, 2, m.gdgInputTxBatchQueueSize)
+
+	<-gdgInput
+	test.RequireIntMetricValue(t, 1, m.ldgInputTxBatchQueueSize)
+	test.RequireIntMetricValue(t, 1, m.gdgInputTxBatchQueueSize)
+}
+
+// TestQueueSizeMetricsUnsetQueue covers SimpleManager's construction, which leaves the global
+// dependency graph queue unset because its pre-processing queue holds a different element type.
+// A nil queue must report zero rather than panic on the scrape path.
+func TestQueueSizeMetricsUnsetQueue(t *testing.T) {
+	t.Parallel()
+
+	m := newPerformanceMetrics(monitoring.NewProvider(), &managerQueues{})
+
+	require.NotPanics(t, func() {
+		test.RequireIntMetricValue(t, 0, m.ldgInputTxBatchQueueSize)
+		test.RequireIntMetricValue(t, 0, m.gdgInputTxBatchQueueSize)
+	})
+}

--- a/service/coordinator/dependencygraph/parameters.go
+++ b/service/coordinator/dependencygraph/parameters.go
@@ -7,8 +7,6 @@ SPDX-License-Identifier: Apache-2.0
 package dependencygraph
 
 import (
-	"time"
-
 	"github.com/hyperledger/fabric-x-committer/utils/monitoring"
 )
 
@@ -29,8 +27,6 @@ type Parameters struct {
 	// WaitingTxsLimit defines the maximum number of transactions
 	// that can be waiting at the dependency manager.
 	WaitingTxsLimit int
-	// QueueMonitorSamplingTime defines the sampling interval for monitoring queue sizes.
-	QueueMonitorSamplingTime time.Duration
 	// PrometheusMetricsProvider is the provider for Prometheus metrics.
 	PrometheusMetricsProvider *monitoring.Provider
 }

--- a/service/coordinator/dependencygraph/simple.go
+++ b/service/coordinator/dependencygraph/simple.go
@@ -56,7 +56,9 @@ func NewSimpleManager(p *Parameters) *SimpleManager {
 		preProcessedTxBatchQueue:        make(chan TxNodeBatch, cap(p.IncomingTxs)),
 		preProcessedValidatedBatchQueue: make(chan validatedBatch, cap(p.IncomingValidatedTxsNode)),
 		keyToWaitingTXs:                 make(map[string]*waiting),
-		metrics:                         newPerformanceMetrics(p.PrometheusMetricsProvider),
+		metrics: newPerformanceMetrics(p.PrometheusMetricsProvider, &managerQueues{
+			ldgInput: p.IncomingTxs,
+		}),
 	}
 }
 
@@ -139,13 +141,13 @@ func (m *SimpleManager) taskProcessing(ctx context.Context) {
 		case batch := <-batchQueue:
 			depFree = m.processTxBatch(batch)
 			promutil.AddToCounter(m.metrics.gdgTxProcessedTotal, len(batch))
-			promutil.AddToGauge(m.metrics.dependentTransactionsQueueSize, len(batch)-len(depFree))
+			promutil.AddToGauge(m.metrics.dependentTxCount, len(batch)-len(depFree))
 		case batch := <-m.preProcessedValidatedBatchQueue:
 			depFree = m.processValidatedBatch(batch)
 			promutil.AddToCounter(m.metrics.gdgValidatedTxProcessedTotal, batch.txCount)
-			promutil.SubFromGauge(m.metrics.dependentTransactionsQueueSize, len(depFree))
+			promutil.SubFromGauge(m.metrics.dependentTxCount, len(depFree))
 		}
-		promutil.SetGauge(m.metrics.gdgWaitingTxQueueSize, m.waitingTXs)
+		promutil.SetGauge(m.metrics.gdgWaitingTxCount, m.waitingTXs)
 		if len(depFree) > 0 {
 			out.Write(depFree)
 		}


### PR DESCRIPTION
#### Type of change

- Improvement (improvement to code, performance, etc)

#### Description

- Replace the dependency graph manager's ticker-based queue monitor with gauges read on scrape, and
  delete the sampler goroutine.
- Gather the two input queues into a receive-only `managerQueues` struct in `manager.go`, built
  before the metrics that observe them.
- Rename `gdgWaitingTxQueueSize` and `dependentTransactionsQueueSize` to `gdgWaitingTxCount` and
  `dependentTxCount`, since neither is a queue: both count transactions held in the graph's maps and
  stay maintained incrementally.
- Rename the exported `coordinator_dependency_graph_dependent_transactions_queue_size` to
  `coordinator_dependency_graph_dependent_transactions`, for the same reason.
- Reword `coordinator_global_dependency_graph_size`'s help to lead with what it counts.
- Remove the `queue-monitor-sampling-time` config key, whose only reader was the sampler.

#### Additional details (Optional)

Deployed YAML that still sets `queue-monitor-sampling-time` keeps loading, as `v.Unmarshal` ignores
unknown keys.

Dashboard-breaking: `coordinator_dependency_graph_dependent_transactions_queue_size` becomes
`coordinator_dependency_graph_dependent_transactions`. `coordinator_global_dependency_graph_size`
keeps its name, as it never claimed to be a queue.

One of the per-service PRs split out of #736.

#### Related issues

- resolves #771
- related to #730
