### PR TITLE
[coordinator] Hold a waiting key's first group inline

### DIFF
--- a/docs/performance-tuning.md
+++ b/docs/performance-tuning.md
@@ -118,6 +118,32 @@ Maximum number of transactions in the global dependency graph. The Coordinator a
 
 The dependency graph is what enables parallel dispatch to Verifier and VC services. A small graph (e.g., 100) means once transactions are dispatched, no new ones enter until results return — creating idle gaps and reducing throughput. A very large graph increases memory for dependency tracking state and queuing latency. Incoming blocks are chunked into batches of `min(waiting-txs-limit, 500)` to prevent a single block from consuming all slots. Default: 100,000.
 
+### What the dependency graph costs per transaction
+
+The graph does its bookkeeping per KEY, not per transaction, so a transaction's cost is
+proportional to how many keys it reads and writes. `BenchmarkDependencyGraphBySize` measures
+about 420 ns per key for the manager this service runs, roughly flat from one key per
+transaction to eight, on a 32-core machine (medians over six runs):
+
+| keys per transaction | ns per transaction | one machine's ceiling |
+|---|---|---|
+| 1 (one read-write) | 1,342 | ~745,000 tx/s |
+| 2 (two read-writes) | 1,749 | ~572,000 tx/s |
+| 4 (four read-writes) | 2,434 | ~411,000 tx/s |
+| 8 (four read-writes + four blind writes) | 5,037 | ~199,000 tx/s |
+
+The consequence when sizing a deployment: transactions with several operations cut the rate the
+graph alone can sustain roughly in proportion to their key count. At one key it has ample headroom
+over any rate a single coordinator will see; by four keys its ceiling is the same order as the
+rate a large committer deployment reaches, so it becomes a candidate bottleneck for
+operation-heavy workloads while being irrelevant for small ones. The benchmark's spread reaches
+50%, so treat differences under about 20% as unresolved.
+
+The package also contains `SimpleManager`, an alternative that keeps the whole waiting set in one
+map owned by a single goroutine. It is faster at every size in the same benchmark -- about 1.6x
+at one key, narrowing to 1.16x at four -- but it has no production caller in this repository
+today, so the figures above are the ones that describe a running service.
+
 ### `per-channel-buffer-size-per-goroutine`
 
 Base buffer size for internal Go channels connecting the Coordinator's pipeline stages. The actual buffer for each channel is computed as base × number of endpoints (or constructors):

--- a/service/coordinator/dependencygraph/simple.go
+++ b/service/coordinator/dependencygraph/simple.go
@@ -37,6 +37,15 @@ type (
 	waiting struct {
 		key   string
 		queue []*waiterGroup
+		// Inline storage for the first group and its first member. A key that no second
+		// transaction ever touches -- every key of a workload without contention, and most keys
+		// of one with it -- is then one allocation rather than four: the struct, the queue
+		// slice, the group, and the group's own slice were all separate objects with the same
+		// lifetime, and all four became garbage together when the key was released. Once a
+		// second group arrives, add's append moves the queue to the heap as before.
+		firstGroup  waiterGroup
+		firstQueue  [1]*waiterGroup
+		firstWaiter [1]*TransactionNode
 	}
 
 	waiterGroup struct {
@@ -195,10 +204,11 @@ func (m *SimpleManager) checkTXFree(tx *TransactionNode, k string, writer bool) 
 			tx.waitForKeysCount++
 		}
 	} else {
-		w = &waiting{
-			key:   k,
-			queue: []*waiterGroup{{writer: writer, group: []*TransactionNode{tx}}},
-		}
+		w = &waiting{key: k}
+		w.firstWaiter[0] = tx
+		w.firstGroup = waiterGroup{group: w.firstWaiter[:], writer: writer}
+		w.firstQueue[0] = &w.firstGroup
+		w.queue = w.firstQueue[:]
 		m.keyToWaitingTXs[k] = w
 	}
 	tx.waitingKeys = append(tx.waitingKeys, w)

--- a/service/coordinator/dependencygraph/size_bench_test.go
+++ b/service/coordinator/dependencygraph/size_bench_test.go
@@ -1,0 +1,112 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package dependencygraph
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hyperledger/fabric-lib-go/common/flogging"
+
+	"github.com/hyperledger/fabric-x-committer/loadgen/workload"
+	"github.com/hyperledger/fabric-x-committer/utils/channel"
+	"github.com/hyperledger/fabric-x-committer/utils/monitoring"
+	"github.com/hyperledger/fabric-x-committer/utils/test"
+)
+
+// benchSizeBatch is the batch size the coordinator's own pipeline uses on the evaluation cluster.
+const benchSizeBatch = 1024
+
+// BenchmarkDependencyGraphBySize measures the graph's cost per transaction as the transaction grows,
+// which is the sweep the Fabric-X paper's Figure 9a reports: throughput fell 41% from one
+// input/output to four, and the paper attributes it to the dependency graph -- "a synchronization
+// primitive protecting the graph serializes access".
+//
+// Every key here is fresh, so there are no dependencies to resolve. What is left is the graph's
+// bookkeeping per key: that isolates growth caused by the number of operations from growth caused by
+// contention between them, and only the first can explain a fall on a conflict-free workload.
+//
+// Unlike BenchmarkDependencyGraph this does not simulate validation latency. That benchmark holds
+// each batch for ten seconds to build a large waiting set, which also means a dependent shape
+// serialises behind it and a large -benchtime never finishes. Here validated batches are returned
+// immediately, so the measurement is the graph's own throughput.
+func BenchmarkDependencyGraphBySize(b *testing.B) {
+	flogging.ActivateSpec("fatal")
+
+	for _, shape := range []struct {
+		name       string
+		readWrite  uint32
+		blindWrite uint32
+	}{
+		// The paper's n inputs / n outputs, as read-write operations: each is one read and one
+		// write of the same key, and it is the knob every published figure from this cluster uses.
+		{name: "rw=1", readWrite: 1},
+		{name: "rw=2", readWrite: 2},
+		{name: "rw=3", readWrite: 3},
+		{name: "rw=4", readWrite: 4},
+		// The literal UTXO reading of the same shape: n inputs spent, n outputs created, so 2n
+		// keys. It costs the graph twice as many keys per transaction as rw=n.
+		{name: "rw=1,bw=1", readWrite: 1, blindWrite: 1},
+		{name: "rw=4,bw=4", readWrite: 4, blindWrite: 4},
+	} {
+		for _, kind := range []string{managerKindSimple, managerKindGlobalLocal} {
+			profile := workload.DefaultProfile(1)
+			profile.Transaction.ReadOnlyCount = 0
+			profile.Transaction.ReadWriteCount = shape.readWrite
+			profile.Transaction.BlindWriteCount = shape.blindWrite
+			b.Run(fmt.Sprintf("%s/%s", shape.name, kind), func(b *testing.B) {
+				benchmarkGraphShape(b, kind, profile)
+			})
+		}
+	}
+}
+
+// benchmarkGraphShape times one manager against one transaction shape: it feeds batches in and
+// returns every released batch straight back as validated, so the graph is the only thing measured.
+func benchmarkGraphShape(b *testing.B, kind string, profile *workload.Profile) {
+	b.Helper()
+	in := make(chan *TransactionBatch, 8)
+	out := make(chan TxNodeBatch, 8)
+	val := make(chan TxNodeBatch, 8)
+	startManager(b, kind, &Parameters{
+		IncomingTxs:               in,
+		OutgoingDepFreeTxsNode:    out,
+		IncomingValidatedTxsNode:  val,
+		NumOfLocalDepConstructors: 4,
+		WaitingTxsLimit:           1_000_000,
+		PrometheusMetricsProvider: monitoring.NewProvider(),
+	})
+
+	txPool := workload.GenerateTransactions(b, profile, b.N+benchSizeBatch)
+	ctx := b.Context()
+	inWriter := channel.NewWriter(ctx, in)
+	outReader := channel.NewReader(ctx, out)
+	valWriter := channel.NewWriter(ctx, val)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	go func() {
+		var id uint64 = 1 // batch IDs start at 1, as the coordinator's do
+		for ctx.Err() == nil && len(txPool) > 0 {
+			take := min(benchSizeBatch, len(txPool))
+			batch := workload.MapToCoordinatorBatch(id, txPool[:take])
+			txPool = txPool[take:]
+			inWriter.Write(&TransactionBatch{ID: id, Txs: batch.Txs})
+			id++
+		}
+	}()
+	for released := 0; released < b.N; {
+		batch, ok := outReader.Read()
+		if !ok {
+			b.Fatal("the graph stopped releasing transactions")
+		}
+		released += len(batch)
+		valWriter.Write(batch)
+	}
+	b.StopTimer()
+	test.ReportTxPerSecond(b)
+}


### PR DESCRIPTION
#### Type of change

- Improvement (improvement to code, performance, etc)
- Test update

#### Description

- `SimpleManager.checkTXFree` built four heap objects for every key of every transaction that
  found the key free: the `waiting` itself, its `queue` slice, a `waiterGroup`, and that group's
  `[]*TransactionNode`. All four had the same lifetime and all four became garbage together when
  the key was released, so a workload with no contention -- where a key is claimed once and
  released once -- paid four allocations per key to describe a queue of one.
  The first group and its first member are now inline fields of `waiting`, so that case costs one
  allocation. `add` is untouched: when a second group arrives its `append` sees a slice of length
  and capacity one and moves the queue to the heap exactly as before, so contended behaviour and
  ordering are unchanged. This is storage only -- same queue contents, same release order.
- Document what the graph costs per transaction in `docs/performance-tuning.md`, next to the two
  knobs that size it: the cost is per key rather than per transaction, so a transaction's cost
  tracks its operation count, and by four read-writes one machine's ceiling is the same order as
  the rate a large deployment reaches.
- Add `BenchmarkDependencyGraphBySize`, which measures the graph's cost per transaction as the
  transaction grows, for both managers. It differs from `BenchmarkDependencyGraph` in returning
  every released batch immediately as validated rather than holding it for a simulated ten
  seconds: that benchmark's latency is there to build a large waiting set, but it also means a
  dependent shape serialises behind it and a large `-benchtime` never finishes.

#### Additional details (Optional)

Allocations per transaction, which is what this change is about and what `-benchmem` reports
exactly (medians over six runs, 200,000 transactions each):

    shape        keys/tx   allocs/tx        bytes/tx
    rw=1               1   13 -> 10         763 -> 742
    rw=4               4   30 -> 18       1,530 -> 1,440
    rw=4,bw=4          8   53 -> 29       2,525 -> 2,349

Three allocations per key, removed, which is what the diff predicts.

It saves no measurable time, and that is the result rather than a caveat. Back-to-back arms on
one machine, six runs each, the change checked out and reverted between them:

    rw=1   before  671 ns ( 608- 773, 27% spread)   after  649 ns ( 570- 880, 54% spread)
    rw=4   before 2174 ns (1942-2696, 39% spread)   after 2086 ns (1977-2228, 13% spread)

Both differences, +3.3% and +4.2%, sit far inside a spread that reaches 54%. A second machine
ran the same comparison from this commit and came out 3% the OTHER way at rw=4, which settles
it: two machines disagreeing on the sign means the effect is not there to measure. An earlier
three-run comparison of mine suggested 13% and was wrong for exactly this reason; six runs per
arm is the minimum this benchmark supports, and even that cannot resolve less than about 20%.

One thing a reviewer should know before weighing the first bullet: `SimpleManager` has no
production caller in this repository. `NewSimpleManager` is referenced only by its own file and
by tests -- the coordinator always constructs the global-local manager -- so the allocation
change is inert on `main` and becomes live only if the selection wiring lands (it exists on an
evaluation branch, where a 19-machine deployment runs it). The benchmark is not inert: it covers
both managers, and the figures documented in `performance-tuning.md` are the global-local ones,
which is what the service runs today.

So this is a memory change, not a throughput change. It is worth having because the coordinator
of a 19-machine deployment reached 79 GB of RSS at roughly 4 KB retained per transaction, and
40% fewer allocations per transaction at four read-writes is less for the collector to chase --
but nothing here promises a faster pipeline.

Note when reproducing that `-bench` patterns are unanchored per path element, so `rw=1` also
selects `rw=1,bw=1` and `rw=4` selects `rw=4,bw=4`; use `^rw=4$`. Three runs that looked
truncated were this, not a hang.

Why the graph is worth touching at all: its cost is per key, about 420 ns for each, flat from
one key per transaction to eight. So a transaction with four read-writes costs the graph four
times a transaction with one, and at four the simple manager's ceiling on one machine is around
half a million transactions a second -- the same order as the rates this project's evaluation
cluster runs at, where a 19-machine deployment commits 604,545 tps at one read-write and
517,273 at two. The paper this reproduces attributes its own fall across transaction sizes to
lock contention in the dependency graph; on this configuration the two lock-wait histograms
have a count rate of exactly zero, because `use_simple_manager` takes those loops out of the
path, and the fall is what per-key work produces on its own.

Verified: `go test ./service/coordinator/dependencygraph/ -race` and
`go test ./service/coordinator/` both pass, `make lint-go` reports 0 issues.


