### PR TITLE
[test] Hold the stopped verifier's port during the outage

### DIFF
--- a/service/coordinator/signature_verifier_manager_test.go
+++ b/service/coordinator/signature_verifier_manager_test.go
@@ -466,7 +466,10 @@ func TestSignatureVerifierManagerPolicyUpdateAndRecover(t *testing.T) {
 
 	t.Log("Stop the service")
 	env.grpcServers.ServersStop[0]()
-	test.CheckServerStopped(t, env.grpcServers.Configs[0].GRPC.Endpoint.Address())
+	// Hold the stopped server's ports until the restart below reclaims them, so no parallel test
+	// binary can bind them meanwhile: a foreign gRPC server on that port answers the verifier
+	// client with Unimplemented, which is retried without backoff and inflates the failure count.
+	test.ReserveWhileServerDown(t, env.grpcServers.Configs[0])
 	env.submitTxBatch(t, 1)
 	env.requireConnectionMetrics(t, 0, connection.Disconnected, 1)
 

--- a/utils/connection/client_test.go
+++ b/utils/connection/client_test.go
@@ -69,7 +69,7 @@ func TestGRPCRetry(t *testing.T) {
 
 	t.Log("Stopping the grpc server")
 	cancel()
-	reserveWhileServerDown(t, serverConfig)
+	test.ReserveWhileServerDown(t, serverConfig)
 
 	// Override the context so this restart and the client retrying against it run on a fresh budget.
 	ctx, cancel = context.WithTimeout(t.Context(), 2*time.Minute)
@@ -91,7 +91,7 @@ func TestGRPCRetry(t *testing.T) {
 
 	t.Log("Stopping the grpc server")
 	cancel()
-	reserveWhileServerDown(t, serverConfig)
+	test.ReserveWhileServerDown(t, serverConfig)
 
 	// Override the context so this restart and the client retrying against it run on a fresh budget.
 	ctx, cancel = context.WithTimeout(t.Context(), 2*time.Minute)
@@ -101,18 +101,6 @@ func TestGRPCRetry(t *testing.T) {
 	t.Log("Attempting to connect again with lower timeout")
 	_, err = client2.Check(ctx, nil)
 	require.Error(t, err)
-}
-
-// reserveWhileServerDown re-reserves the server's ports the moment it is stopped, so a parallel test
-// cannot grab the just-freed ephemeral ports while the server is down. The server is stopped
-// asynchronously (by canceling its context), so it may still hold the ports; the reservation retries
-// the bind until it releases them.
-func reserveWhileServerDown(t *testing.T, sc *serve.Config) {
-	t.Helper()
-	serve.PreAllocateListener(t, &sc.GRPC)
-	serve.PreAllocateListener(t, &sc.HTTP)
-	require.True(t, test.CheckServerStopped(t, sc.GRPC.Endpoint.Address()),
-		"a reservation-only port must not answer gRPC health checks")
 }
 
 // scheduleServerRestart brings the server back up after serverDownDuration, reusing the reserved

--- a/utils/test/connection.go
+++ b/utils/test/connection.go
@@ -61,6 +61,18 @@ func CheckServerStopped(t *testing.T, addr string) bool {
 	return false
 }
 
+// ReserveWhileServerDown re-reserves the server's ports the moment it is stopped, so a parallel test
+// binary cannot grab the just-freed ephemeral ports while the server is down. The server is stopped
+// asynchronously (by canceling its context), so it may still hold the ports; the reservation retries
+// the bind until it releases them. A later restart from the same config takes the reservation over.
+func ReserveWhileServerDown(t *testing.T, sc *serve.Config) {
+	t.Helper()
+	serve.PreAllocateListener(t, &sc.GRPC)
+	serve.PreAllocateListener(t, &sc.HTTP)
+	require.True(t, CheckServerStopped(t, sc.GRPC.Endpoint.Address()),
+		"a reservation-only port must not answer gRPC health checks")
+}
+
 // GrpcServiceToConnectionServerConfigs extracts gRPC server endpoints from serve configs.
 func GrpcServiceToConnectionServerConfigs(servers ...*serve.Config) []*serve.ServerConfig {
 	result := make([]*serve.ServerConfig, len(servers))


### PR DESCRIPTION
#### Type of change

- Test update

#### Description

- Reserve mock verifier 0's ports for the duration of the outage in
  `TestSignatureVerifierManagerPolicyUpdateAndRecover`, so a parallel test binary cannot bind them
  while the server is down. The restart takes the reservation over via `ServerConfig.Listener`.
- Promote `utils/connection`'s local `reserveWhileServerDown` to `test.ReserveWhileServerDown` and
  use it from both call sites, rather than duplicating it.
- The new call replaces the `test.CheckServerStopped` assertion it subsumes.

#### Additional details (Optional)

The test stops the server, spends ~4 s on further assertions, then restarts it on the same ephemeral
port. Because `make test-no-db` runs the package binaries in parallel, another binary can bind that
port meanwhile, and the verifier client — still dialing it — reaches a foreign gRPC server that
answers `Unimplemented: unknown service servicepb.Verifier`.

That error is not joined with `retry.ErrBackOff`, so `retry.Sustain` retries with no delay, and every
attempt records a `Connected` followed by a `Disconnected`, since `StartStream` succeeds lazily
against any listener. The connection `FailureTotal` therefore climbed to 12,968 in the observed run,
failing the post-restart assertion that it is exactly 1.

With a reservation-only listener on the port, `StartStream` fails fast and the client backs off, so
the counter stays at 1. Treating a server-returned `Unimplemented` as backoff-worthy in
`sendTransactionsAndForwardStatus` would cap the damage of any similar window in production too, but
that is a change to non-test code and is not needed to make this test deterministic.

Verified with `-race`: the target test 2/2 and `-run '^TestSignatureVerifierManager'` 3/3, plus
`TestGRPCRetry` 2/2 for the promoted helper. `make lint` passes.

#### Related issues

- resolves #819
- same family as #712, #738


🤖 Generated with [Claude Code](https://claude.com/claude-code)
