### PR TITLE
[sidecar] Stop allocating per transaction in key validation and TX references

### DIFF
--- a/service/sidecar/mapping.go
+++ b/service/sidecar/mapping.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 package sidecar
 
 import (
+	"bytes"
 	"fmt"
 	"sync/atomic"
 	"unicode/utf8"
@@ -50,6 +51,13 @@ type (
 		// added to it, which mapBlock hands to the set as the block's eviction unit.
 		txIDDedup *txIDDedup
 		txIDs     []string
+		// refs and txWithRefs back every TxRef and TxWithRef the block needs, one entry per
+		// message, allocated once for the block instead of once per transaction. Mapping is on the
+		// path that decides how fast the sidecar allocates, and these were two of its allocations
+		// per transaction. Nothing may copy an element out of them — they are proto messages, and
+		// only their addresses are ever handed on — which go vet's copylocks check enforces.
+		refs       []committerpb.TxRef
+		txWithRefs []servicepb.TxWithRef
 	}
 
 	blockWithStatus struct {
@@ -66,6 +74,11 @@ type (
 const (
 	statusNotYetValidated = committerpb.Status_STATUS_UNSPECIFIED
 	statusIdx             = int(common.BlockMetadataIndex_TRANSACTIONS_FILTER)
+
+	// maxKeysForPairwiseCheck is the largest number of keys in one namespace that checkKeys
+	// compares pairwise before it switches to building a set. At this count the comparison is a few
+	// hundred short byte-slice compares, well under the cost of the map it replaces.
+	maxKeysForPairwiseCheck = 24
 )
 
 // mapBlock maps an orderer block into the batch the relay submits to the coordinator. It records
@@ -110,8 +123,10 @@ func mapBlock(block *common.Block, dedup *txIDDedup) (*blockMappingResult, error
 				blockNumber: blockNumber,
 			},
 		},
-		txIDDedup: dedup,
-		txIDs:     make([]string, 0, txCount),
+		txIDDedup:  dedup,
+		txIDs:      make([]string, 0, txCount),
+		refs:       make([]committerpb.TxRef, txCount),
+		txWithRefs: make([]servicepb.TxWithRef, txCount),
 	}
 	mapper.withStatus.pendingCount.Store(int32(txCount)) //nolint:gosec // int -> int32
 
@@ -138,7 +153,9 @@ func (m *blockMapper) mapMessage(msgIndex uint32, msg []byte) error {
 	// those fields will go undetected. This is acceptable because the committer
 	// does not use them, and for the same reason, they are not validated in the
 	// sidecar. TODO: remove unused fields from the ChannelHeader proto.
-	ref := committerpb.NewTxRef("", m.blockNumber, msgIndex)
+	ref := &m.refs[msgIndex]
+	ref.BlockNum = m.blockNumber
+	ref.TxNum = msgIndex
 	envLite, envErr := serialization.UnwrapEnvelopeLite(msg)
 	if envErr != nil {
 		return m.rejectNonDBStatusTx(ref, committerpb.Status_MALFORMED_BAD_ENVELOPE, envErr.Error())
@@ -292,7 +309,9 @@ func (m *blockMapper) prepareTx(
 	if idAlreadyExists, err := m.addTxIDMapping(ref); idAlreadyExists || err != nil {
 		return nil, err
 	}
-	txWithRef := &servicepb.TxWithRef{Ref: ref, Content: tx}
+	txWithRef := &m.txWithRefs[ref.TxNum]
+	txWithRef.Ref = ref
+	txWithRef.Content = tx
 	m.withStatus.txs[ref.TxNum] = txWithRef
 	debugTx(ref, "included: %s", ref.TxId)
 	return txWithRef, nil
@@ -306,7 +325,8 @@ func (m *blockMapper) rejectTx(ref *committerpb.TxRef, status committerpb.Status
 		return err
 	}
 	m.block.Rejected = append(m.block.Rejected, &committerpb.TxStatus{Ref: ref, Status: status})
-	m.withStatus.txs[ref.TxNum] = &servicepb.TxWithRef{Ref: ref}
+	m.txWithRefs[ref.TxNum].Ref = ref
+	m.withStatus.txs[ref.TxNum] = &m.txWithRefs[ref.TxNum]
 	debugTx(ref, "rejected: %s (%s)", &status, reason)
 	return nil
 }
@@ -325,7 +345,8 @@ func (m *blockMapper) rejectNonDBStatusTx(
 	if err != nil {
 		return err
 	}
-	m.withStatus.txs[ref.TxNum] = &servicepb.TxWithRef{Ref: ref}
+	m.txWithRefs[ref.TxNum].Ref = ref
+	m.withStatus.txs[ref.TxNum] = &m.txWithRefs[ref.TxNum]
 	debugTx(ref, "excluded: %s (%s)", &status, reason)
 	return nil
 }
@@ -511,17 +532,7 @@ func checkNamespaceReadsWrites(ns *applicationpb.TxNamespace) committerpb.Status
 		return committerpb.Status_MALFORMED_NO_WRITES
 	}
 
-	keys := make([][]byte, 0, len(ns.ReadsOnly)+len(ns.ReadWrites)+len(ns.BlindWrites))
-	for _, r := range ns.ReadsOnly {
-		keys = append(keys, r.Key)
-	}
-	for _, r := range ns.ReadWrites {
-		keys = append(keys, r.Key)
-	}
-	for _, r := range ns.BlindWrites {
-		keys = append(keys, r.Key)
-	}
-	return checkKeys(keys)
+	return checkKeys(ns)
 }
 
 func checkMetaNamespace(txNs *applicationpb.TxNamespace) committerpb.Status {
@@ -559,17 +570,53 @@ func checkMetaNamespace(txNs *applicationpb.TxNamespace) committerpb.Status {
 	return statusNotYetValidated
 }
 
-// checkKeys verifies there are no duplicate keys and no nil keys.
-func checkKeys(keys [][]byte) committerpb.Status {
-	uniqueKeys := make(map[string]any, len(keys))
-	for _, k := range keys {
-		if len(k) == 0 {
+// checkKeys verifies that a namespace has no empty key and no duplicate key.
+//
+// Duplicates are found by comparing the keys pairwise rather than by collecting them into a set.
+// The set cost two allocations per namespace — the map, and the slice the keys were first copied
+// into — which measured 2.8 allocations per transaction, on a path where the sidecar is bound by
+// how fast it allocates rather than by CPU. Comparing pairwise costs nothing and is faster for the
+// handful of keys a transaction carries, but it is quadratic, so a namespace with more keys than
+// maxKeysForPairwiseCheck still builds a set.
+func checkKeys(ns *applicationpb.TxNamespace) committerpb.Status {
+	keyCount := len(ns.ReadsOnly) + len(ns.ReadWrites) + len(ns.BlindWrites)
+	for i := range keyCount {
+		if len(nsKey(ns, i)) == 0 {
 			return committerpb.Status_MALFORMED_EMPTY_KEY
 		}
-		uniqueKeys[string(k)] = nil
 	}
-	if len(uniqueKeys) != len(keys) {
-		return committerpb.Status_MALFORMED_DUPLICATE_KEY_IN_READ_WRITE_SET
+
+	if keyCount > maxKeysForPairwiseCheck {
+		uniqueKeys := make(map[string]struct{}, keyCount)
+		for i := range keyCount {
+			uniqueKeys[string(nsKey(ns, i))] = struct{}{}
+		}
+		if len(uniqueKeys) != keyCount {
+			return committerpb.Status_MALFORMED_DUPLICATE_KEY_IN_READ_WRITE_SET
+		}
+		return statusNotYetValidated
+	}
+
+	for i := range keyCount {
+		for j := i + 1; j < keyCount; j++ {
+			if bytes.Equal(nsKey(ns, i), nsKey(ns, j)) {
+				return committerpb.Status_MALFORMED_DUPLICATE_KEY_IN_READ_WRITE_SET
+			}
+		}
 	}
 	return statusNotYetValidated
+}
+
+// nsKey returns the i-th key of a namespace, counting the reads-only keys first, then the
+// read-writes, then the blind writes. It lets checkKeys walk every key of a namespace without
+// first copying them into one slice, which was an allocation per namespace.
+func nsKey(ns *applicationpb.TxNamespace, i int) []byte {
+	if i < len(ns.ReadsOnly) {
+		return ns.ReadsOnly[i].Key
+	}
+	i -= len(ns.ReadsOnly)
+	if i < len(ns.ReadWrites) {
+		return ns.ReadWrites[i].Key
+	}
+	return ns.BlindWrites[i-len(ns.ReadWrites)].Key
 }

--- a/service/sidecar/mapping_test.go
+++ b/service/sidecar/mapping_test.go
@@ -21,15 +21,34 @@ import (
 	"github.com/hyperledger/fabric-x-committer/api/servicepb"
 	"github.com/hyperledger/fabric-x-committer/loadgen/workload"
 	"github.com/hyperledger/fabric-x-committer/utils/retry"
+	"github.com/hyperledger/fabric-x-committer/utils/signature"
 	"github.com/hyperledger/fabric-x-committer/utils/test"
 )
 
 // testChannelID is a shared channel ID used by sidecar mapping/relay tests.
 const testChannelID = "chan"
 
+// benchTxProfile is the workload the mapping benchmarks measure. It differs from
+// workload.DefaultProfile in the one way that decides which path through mapping is measured: the
+// default policy uses signature.NoScheme, which leaves each transaction with a nil endorsement per
+// namespace, and mapping rejects those with MALFORMED_MISSING_SIGNATURE before it validates a
+// single key or builds a TxWithRef. A benchmark on that workload measures the rejection path only.
+//
+// EDDSA is the cheapest scheme to generate whose transactions mapping accepts. The scheme only has
+// to be present: the sidecar checks that each namespace carries a non-empty endorsement and leaves
+// verifying it to the signature verifier, which has the policy context to know what the
+// namespace's rule requires.
+func benchTxProfile() *workload.Profile {
+	profile := workload.DefaultProfile(1)
+	profile.Policy.NamespacePolicies[workload.DefaultGeneratedNamespaceID] = &workload.Policy{
+		Scheme: signature.Eddsa,
+	}
+	return profile
+}
+
 func BenchmarkMapOneBlock(b *testing.B) {
 	flogging.ActivateSpec("fatal")
-	txs := workload.GenerateTransactions(b, nil, b.N)
+	txs := workload.GenerateTransactions(b, benchTxProfile(), b.N)
 	block := workload.MapToOrdererBlock(1, txs)
 
 	var dedup txIDDedup
@@ -49,7 +68,7 @@ func BenchmarkMapBlockSize(b *testing.B) {
 			// granularity. We split b.N transactions into blocks of at most
 			// blockSize (the final block may be smaller), so ns/op and tx/s are
 			// reported per transaction, independent of the block size.
-			allTxs := workload.GenerateTransactions(b, nil, b.N)
+			allTxs := workload.GenerateTransactions(b, benchTxProfile(), b.N)
 			blocks := make([]*common.Block, 0, (b.N+blockSize-1)/blockSize)
 			for off := 0; off < b.N; off += blockSize {
 				blocks = append(blocks, workload.MapToOrdererBlock(
@@ -632,4 +651,161 @@ func TestBlockWithStatusHolds(t *testing.T) {
 			require.Equal(t, tc.expected, blk.holds(tc.ref))
 		})
 	}
+}
+
+// TestKeyFormValidation covers the namespace key checks: no key may be empty, and no key may
+// repeat within a namespace, whichever of the three read/write sets each occurrence sits in.
+//
+// checkKeys detects duplicates two different ways — pairwise up to maxKeysForPairwiseCheck keys,
+// and with a set above it — so the cases below exercise both sides of that threshold. A duplicate
+// found by one and missed by the other would let a transaction the sidecar must reject through.
+func TestKeyFormValidation(t *testing.T) {
+	t.Parallel()
+	// Well-formed namespaces.
+	for _, tc := range []struct {
+		name string
+		ns   *applicationpb.TxNamespace
+	}{
+		{
+			name: "one blind write",
+			ns:   keysNamespace(nil, nil, [][]byte{[]byte("k1")}),
+		},
+		{
+			name: "distinct keys across all three sets",
+			ns: keysNamespace(
+				[][]byte{[]byte("r1"), []byte("r2")},
+				[][]byte{[]byte("rw1")},
+				[][]byte{[]byte("bw1")},
+			),
+		},
+		{
+			name: "keys up to the pairwise threshold",
+			ns:   keysNamespace(nil, nil, distinctKeys(maxKeysForPairwiseCheck)),
+		},
+		{
+			name: "more keys than the pairwise threshold uses the set",
+			ns:   keysNamespace(nil, nil, distinctKeys(maxKeysForPairwiseCheck+1)),
+		},
+		{
+			name: "many keys spread across the three sets",
+			ns: keysNamespace(
+				distinctKeys(maxKeysForPairwiseCheck)[:10],
+				distinctKeys(maxKeysForPairwiseCheck)[10:20],
+				distinctKeys(maxKeysForPairwiseCheck + 20)[20:],
+			),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, statusNotYetValidated, verifyKeysNamespace(tc.ns))
+		})
+	}
+	// Malformed namespaces.
+	for _, tc := range []struct {
+		name     string
+		ns       *applicationpb.TxNamespace
+		expected committerpb.Status
+	}{
+		{
+			name:     "no writes at all",
+			ns:       keysNamespace([][]byte{[]byte("r1")}, nil, nil),
+			expected: committerpb.Status_MALFORMED_NO_WRITES,
+		},
+		{
+			name:     "empty blind write key",
+			ns:       keysNamespace(nil, nil, [][]byte{[]byte("k1"), {}}),
+			expected: committerpb.Status_MALFORMED_EMPTY_KEY,
+		},
+		{
+			name:     "empty read-only key",
+			ns:       keysNamespace([][]byte{{}}, nil, [][]byte{[]byte("k1")}),
+			expected: committerpb.Status_MALFORMED_EMPTY_KEY,
+		},
+		{
+			name:     "empty read-write key",
+			ns:       keysNamespace(nil, [][]byte{{}}, nil),
+			expected: committerpb.Status_MALFORMED_EMPTY_KEY,
+		},
+		{
+			name:     "empty key beyond the pairwise threshold",
+			ns:       keysNamespace(nil, nil, append(distinctKeys(maxKeysForPairwiseCheck+1), nil)),
+			expected: committerpb.Status_MALFORMED_EMPTY_KEY,
+		},
+		{
+			name:     "duplicate within blind writes",
+			ns:       keysNamespace(nil, nil, [][]byte{[]byte("k1"), []byte("k1")}),
+			expected: committerpb.Status_MALFORMED_DUPLICATE_KEY_IN_READ_WRITE_SET,
+		},
+		{
+			name:     "duplicate across read-only and blind writes",
+			ns:       keysNamespace([][]byte{[]byte("k1")}, nil, [][]byte{[]byte("k1")}),
+			expected: committerpb.Status_MALFORMED_DUPLICATE_KEY_IN_READ_WRITE_SET,
+		},
+		{
+			name:     "duplicate across read-writes and blind writes",
+			ns:       keysNamespace(nil, [][]byte{[]byte("k1")}, [][]byte{[]byte("k1")}),
+			expected: committerpb.Status_MALFORMED_DUPLICATE_KEY_IN_READ_WRITE_SET,
+		},
+		{
+			name:     "duplicate across read-only and read-writes",
+			ns:       keysNamespace([][]byte{[]byte("k1")}, [][]byte{[]byte("k1")}, nil),
+			expected: committerpb.Status_MALFORMED_DUPLICATE_KEY_IN_READ_WRITE_SET,
+		},
+		{
+			name: "duplicate beyond the pairwise threshold uses the set",
+			ns: keysNamespace(nil, nil, append(
+				distinctKeys(maxKeysForPairwiseCheck+1), []byte("key-0"),
+			)),
+			expected: committerpb.Status_MALFORMED_DUPLICATE_KEY_IN_READ_WRITE_SET,
+		},
+		{
+			name: "duplicate beyond the threshold spanning two sets",
+			ns: keysNamespace(
+				distinctKeys(maxKeysForPairwiseCheck+1),
+				nil,
+				[][]byte{[]byte("key-0")},
+			),
+			expected: committerpb.Status_MALFORMED_DUPLICATE_KEY_IN_READ_WRITE_SET,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			require.Equal(t, tc.expected, verifyKeysNamespace(tc.ns))
+		})
+	}
+}
+
+// keysNamespace builds a user namespace holding the given read-only, read-write and blind-write
+// keys, so a test case can name only the keys it cares about.
+func keysNamespace(readsOnly, readWrites, blindWrites [][]byte) *applicationpb.TxNamespace {
+	ns := &applicationpb.TxNamespace{NsId: "1"}
+	for _, k := range readsOnly {
+		ns.ReadsOnly = append(ns.ReadsOnly, &applicationpb.Read{Key: k})
+	}
+	for _, k := range readWrites {
+		ns.ReadWrites = append(ns.ReadWrites, &applicationpb.ReadWrite{Key: k})
+	}
+	for _, k := range blindWrites {
+		ns.BlindWrites = append(ns.BlindWrites, &applicationpb.Write{Key: k})
+	}
+	return ns
+}
+
+// distinctKeys returns n distinct keys, named so a test can reuse one of them ("key-0") to build a
+// duplicate that spans two of a namespace's read/write sets.
+func distinctKeys(n int) [][]byte {
+	keys := make([][]byte, n)
+	for i := range keys {
+		keys[i] = []byte(fmt.Sprintf("key-%d", i))
+	}
+	return keys
+}
+
+// verifyKeysNamespace runs the whole form validation over a transaction holding just this
+// namespace, so the cases go through the same path a mapped transaction does.
+func verifyKeysNamespace(ns *applicationpb.TxNamespace) committerpb.Status {
+	return verifyTxForm(&applicationpb.Tx{
+		Namespaces:   []*applicationpb.TxNamespace{ns},
+		Endorsements: dummyEndorsements(1),
+	})
 }


### PR DESCRIPTION
#### Type of change

- Improvement (improvement to code, performance, etc)
- Test update

#### Description

- `checkKeys` now takes the namespace and walks its three read/write sets through `nsKey`,
  instead of the caller copying every key into one slice for it. It finds duplicates by
  comparing pairs, falling back to a set above `maxKeysForPairwiseCheck` keys where the
  quadratic comparison would cost more than the map does.
- `mapBlock` allocates the block's `TxRef` and `TxWithRef` values as two slabs, one entry per
  message, instead of one of each per transaction. Only their addresses are handed on; nothing
  copies an element out, which `go vet`'s copylocks check enforces.
- The mapping benchmarks now generate their transactions with an EDDSA policy
  (`benchTxProfile`) instead of `workload.DefaultProfile`'s `NoScheme`. With no scheme every
  namespace carries a nil endorsement, so mapping rejected all of them with
  `MALFORMED_MISSING_SIGNATURE` before validating a single key or building a `TxWithRef`:
  the benchmarks measured the rejection path, not the path this change touches.
- Adds `TestKeyFormValidation`, covering empty and duplicate keys on both sides of the
  pairwise/set threshold and duplicates that span two of a namespace's read/write sets. Neither
  `MALFORMED_EMPTY_KEY` nor `MALFORMED_DUPLICATE_KEY_IN_READ_WRITE_SET` had any coverage before.

#### Additional details (Optional)

On the fixed workload described above, `BenchmarkMapBlockSize` drops from 24 to 19 allocations
and 1,359 to 1,246 bytes per transaction:

    go test ./service/sidecar/ -run '^$' -bench '^BenchmarkMapBlockSize$' -benchmem

Of that, `checkKeys` accounted for three allocations for the two-key namespace this workload
generates — the map, the slice the keys were copied into, and the string conversion per key —
and now allocates none at any key count. The remaining two are the per-transaction `TxRef` and
`TxWithRef`.

#### Related issues

- resolves #787
