### PR TITLE
[monitoring] Record the size of messages received and sent by the server

### DIFF
--- a/docs/metrics_reference.md
+++ b/docs/metrics_reference.md
@@ -30,6 +30,8 @@ The following Sidecar metrics are exported for consumption by Prometheus.
 | sidecar_grpc_stream_duration_seconds                       | histogram | method status                    | The duration (seconds) a stream was active from start to end, by method and gRPC status code                                                             |
 | sidecar_grpc_active_streams                                | gauge     | method                           | Number of gRPC streams currently open on the server                                                                                                      |
 | sidecar_grpc_active_connections                            | gauge     |                                  | Number of client connections currently open on the server                                                                                                |
+| sidecar_grpc_message_received_size_bytes                   | histogram | method                           | Distribution of the wire sizes in bytes of messages received by the server.                                                                              |
+| sidecar_grpc_message_sent_size_bytes                       | histogram | method                           | Distribution of the wire sizes in bytes of messages sent by the server.                                                                                  |
 | sidecar_ledger_append_block_seconds                        | histogram |                                  | Time spent appending a block to the ledger.                                                                                                              |
 | sidecar_ledger_block_height                                | gauge     |                                  | The current block height of the ledger.                                                                                                                  |
 | sidecar_relay_transaction_in_total                         | counter   |                                  | Total number of transactions received from the orderer.                                                                                                  |
@@ -70,6 +72,8 @@ The following Coordinator metrics are exported for consumption by Prometheus.
 | coordinator_grpc_stream_duration_seconds                                               | histogram | method status | The duration (seconds) a stream was active from start to end, by method and gRPC status code                  |
 | coordinator_grpc_active_streams                                                        | gauge     | method        | Number of gRPC streams currently open on the server                                                           |
 | coordinator_grpc_active_connections                                                    | gauge     |               | Number of client connections currently open on the server                                                     |
+| coordinator_grpc_message_received_size_bytes                                           | histogram | method        | Distribution of the wire sizes in bytes of messages received by the server.                                   |
+| coordinator_grpc_message_sent_size_bytes                                               | histogram | method        | Distribution of the wire sizes in bytes of messages sent by the server.                                       |
 | coordinator_verifier_connection_status                                                 | gauge     | grpc_target   | Connection status to verifier service by grpc target (1 = connected, 0 = disconnected).                       |
 | coordinator_verifier_connection_failure_total                                          | counter   | grpc_target   | Total number of connection failures to verifier service. Short-lived failures may not always be captured.     |
 | coordinator_verifier_transaction_processed_total                                       | counter   |               | Total number of transactions processed by the manager.                                                        |
@@ -113,6 +117,8 @@ The following Verifier metrics are exported for consumption by Prometheus.
 | verifier_server_grpc_stream_duration_seconds      | histogram | method status | The duration (seconds) a stream was active from start to end, by method and gRPC status code |
 | verifier_server_grpc_active_streams               | gauge     | method        | Number of gRPC streams currently open on the server                                          |
 | verifier_server_grpc_active_connections           | gauge     |               | Number of client connections currently open on the server                                    |
+| verifier_server_grpc_message_received_size_bytes  | histogram | method        | Distribution of the wire sizes in bytes of messages received by the server.                  |
+| verifier_server_grpc_message_sent_size_bytes      | histogram | method        | Distribution of the wire sizes in bytes of messages sent by the server.                      |
 | verifier_server_parallel_executor_active_requests | gauge     |               | The total number of active requests                                                          |
 
 ## Validator-Committer Metrics
@@ -128,6 +134,8 @@ The following Validator-Committer metrics are exported for consumption by Promet
 | vcservice_grpc_stream_duration_seconds                                       | histogram | method status | The duration (seconds) a stream was active from start to end, by method and gRPC status code                |
 | vcservice_grpc_active_streams                                                | gauge     | method        | Number of gRPC streams currently open on the server                                                         |
 | vcservice_grpc_active_connections                                            | gauge     |               | Number of client connections currently open on the server                                                   |
+| vcservice_grpc_message_received_size_bytes                                   | histogram | method        | Distribution of the wire sizes in bytes of messages received by the server.                                 |
+| vcservice_grpc_message_sent_size_bytes                                       | histogram | method        | Distribution of the wire sizes in bytes of messages sent by the server.                                     |
 | vcservice_committed_transaction_total                                        | counter   |               | The total number of transactions committed                                                                  |
 | vcservice_mvcc_conflict_total                                                | counter   |               | The total number of transactions that failed due to MVCC conflict                                           |
 | vcservice_duplicate_transaction_total                                        | counter   |               | The total number of duplicate transactions                                                                  |
@@ -157,6 +165,8 @@ The following Query Service metrics are exported for consumption by Prometheus.
 | queryservice_grpc_stream_duration_seconds                | histogram | method status | The duration (seconds) a stream was active from start to end, by method and gRPC status code |
 | queryservice_grpc_active_streams                         | gauge     | method        | Number of gRPC streams currently open on the server                                          |
 | queryservice_grpc_active_connections                     | gauge     |               | Number of client connections currently open on the server                                    |
+| queryservice_grpc_message_received_size_bytes            | histogram | method        | Distribution of the wire sizes in bytes of messages received by the server.                  |
+| queryservice_grpc_message_sent_size_bytes                | histogram | method        | Distribution of the wire sizes in bytes of messages sent by the server.                      |
 | queryservice_grpc_key_requested_total                    | counter   |               | Number of keys requested by the service                                                      |
 | queryservice_grpc_key_responded_total                    | counter   |               | Number of keys responded by the service                                                      |
 | queryservice_database_processing_sessions                | gauge     | session       | Number of processing sessions in the service                                                 |
@@ -170,18 +180,20 @@ The following Query Service metrics are exported for consumption by Prometheus.
 
 The following Snapshot Hasher metrics are exported for consumption by Prometheus.
 
-| Name                                         | Type      | Labels        | Description                                                                                                                     |
-|----------------------------------------------|-----------|---------------|---------------------------------------------------------------------------------------------------------------------------------|
-| snapshothasher_hash_jobs_completed_total     | counter   |               | Number of snapshot hash jobs that published a digest.                                                                           |
-| snapshothasher_hash_jobs_failed_total        | counter   |               | Number of snapshot hash jobs that ended without publishing a digest.                                                            |
-| snapshothasher_hash_started_total            | counter   |               | Number of snapshot hash attempts that began; its gap against duration_seconds_count plus jobs_failed_total is a hash in flight. |
-| snapshothasher_poll_errors_total             | counter   |               | Number of polls that failed before a hash job could be started or skipped.                                                      |
-| snapshothasher_hash_duration_seconds         | histogram |               | Time taken to hash a snapshot clone database.                                                                                   |
-| snapshothasher_grpc_requests_total           | counter   | method        | Number of RPCs started by the service                                                                                           |
-| snapshothasher_grpc_requests_latency_seconds | histogram | method status | The latency (seconds) of requests by the service, by method and gRPC status code                                                |
-| snapshothasher_grpc_stream_duration_seconds  | histogram | method status | The duration (seconds) a stream was active from start to end, by method and gRPC status code                                    |
-| snapshothasher_grpc_active_streams           | gauge     | method        | Number of gRPC streams currently open on the server                                                                             |
-| snapshothasher_grpc_active_connections       | gauge     |               | Number of client connections currently open on the server                                                                       |
+| Name                                            | Type      | Labels        | Description                                                                                                                     |
+|-------------------------------------------------|-----------|---------------|---------------------------------------------------------------------------------------------------------------------------------|
+| snapshothasher_hash_jobs_completed_total        | counter   |               | Number of snapshot hash jobs that published a digest.                                                                           |
+| snapshothasher_hash_jobs_failed_total           | counter   |               | Number of snapshot hash jobs that ended without publishing a digest.                                                            |
+| snapshothasher_hash_started_total               | counter   |               | Number of snapshot hash attempts that began; its gap against duration_seconds_count plus jobs_failed_total is a hash in flight. |
+| snapshothasher_poll_errors_total                | counter   |               | Number of polls that failed before a hash job could be started or skipped.                                                      |
+| snapshothasher_hash_duration_seconds            | histogram |               | Time taken to hash a snapshot clone database.                                                                                   |
+| snapshothasher_grpc_requests_total              | counter   | method        | Number of RPCs started by the service                                                                                           |
+| snapshothasher_grpc_requests_latency_seconds    | histogram | method status | The latency (seconds) of requests by the service, by method and gRPC status code                                                |
+| snapshothasher_grpc_stream_duration_seconds     | histogram | method status | The duration (seconds) a stream was active from start to end, by method and gRPC status code                                    |
+| snapshothasher_grpc_active_streams              | gauge     | method        | Number of gRPC streams currently open on the server                                                                             |
+| snapshothasher_grpc_active_connections          | gauge     |               | Number of client connections currently open on the server                                                                       |
+| snapshothasher_grpc_message_received_size_bytes | histogram | method        | Distribution of the wire sizes in bytes of messages received by the server.                                                     |
+| snapshothasher_grpc_message_sent_size_bytes     | histogram | method        | Distribution of the wire sizes in bytes of messages sent by the server.                                                         |
 
 ## Load Generator Metrics
 

--- a/integration/test/server_stats_metrics_test.go
+++ b/integration/test/server_stats_metrics_test.go
@@ -25,6 +25,8 @@ const (
 	queryRequestsTotalMetric   = "queryservice_grpc_requests_total"
 	queryRequestsLatencyMetric = "queryservice_grpc_requests_latency_seconds"
 	queryActiveConnsMetric     = "queryservice_grpc_active_connections"
+	queryMessageRecvSizeMetric = "queryservice_grpc_message_received_size_bytes"
+	queryMessageSentSizeMetric = "queryservice_grpc_message_sent_size_bytes"
 
 	sidecarActiveStreamsMetric  = "sidecar_grpc_active_streams"
 	sidecarStreamDurationMetric = "sidecar_grpc_stream_duration_seconds"
@@ -54,30 +56,52 @@ func TestServerStatsMetricsFullSystem(t *testing.T) {
 		t, c.SystemConfig.ClientTLS, c.SystemConfig.Services.Sidecar.HTTPEndpoint,
 	)
 
-	t.Run("Unary RPC Value And Latency", func(t *testing.T) {
+	t.Run("Unary RPC Value Latency And Messages", func(t *testing.T) {
 		t.Parallel()
+		methodLabel := map[string]string{method: getTransactionStatusMethod}
 		requestsTotal := test.GetMetricValueParameters{
 			MetricsConnectionParameters: queryMetrics,
 			MetricName:                  queryRequestsTotalMetric,
-			Labels:                      map[string]string{method: getTransactionStatusMethod},
+			Labels:                      methodLabel,
 		}
 		requestsLatency := test.GetMetricValueParameters{
 			MetricsConnectionParameters: queryMetrics,
 			MetricName:                  queryRequestsLatencyMetric,
 			Labels:                      map[string]string{method: getTransactionStatusMethod, "status": "OK"},
 		}
+		messageRecvSize := test.GetMetricValueParameters{
+			MetricsConnectionParameters: queryMetrics,
+			MetricName:                  queryMessageRecvSizeMetric,
+			Labels:                      methodLabel,
+		}
+		messageSentSize := test.GetMetricValueParameters{
+			MetricsConnectionParameters: queryMetrics,
+			MetricName:                  queryMessageSentSizeMetric,
+			Labels:                      methodLabel,
+		}
 		preRequests := test.GetCounterOrGaugeValueFromURL(t, requestsTotal)
 		preLatencyCount, _ := test.GetHistogramCountAndSumValueFromURL(t, requestsLatency)
+		preRecvSizeCount, preRecvSizeSum := test.GetHistogramCountAndSumValueFromURL(t, messageRecvSize)
+		preSentSizeCount, preSentSizeSum := test.GetHistogramCountAndSumValueFromURL(t, messageSentSize)
 
 		_, err := c.QueryServiceClient.GetTransactionStatus(ctx, &committerpb.TxStatusQuery{
 			TxIds: []string{"non-existent-tx"},
 		})
 		require.NoError(t, err)
 
+		// A unary RPC is exactly one message in and one message out, each of a non-zero wire size:
+		// the size histograms' observation counts are the per-direction message counts.
 		require.EventuallyWithT(t, func(ct *assert.CollectT) {
 			latencyCount, _ := test.GetHistogramCountAndSumValueFromURL(ct, requestsLatency)
+			recvSizeCount, recvSizeSum := test.GetHistogramCountAndSumValueFromURL(ct, messageRecvSize)
+			sentSizeCount, sentSizeSum := test.GetHistogramCountAndSumValueFromURL(ct, messageSentSize)
+
 			require.Equal(ct, preRequests+1, test.GetCounterOrGaugeValueFromURL(ct, requestsTotal))
 			require.Equal(ct, preLatencyCount+1, latencyCount)
+			require.Equal(ct, preRecvSizeCount+1, recvSizeCount)
+			require.Equal(ct, preSentSizeCount+1, sentSizeCount)
+			require.Positive(ct, recvSizeSum-preRecvSizeSum)
+			require.Positive(ct, sentSizeSum-preSentSizeSum)
 		}, 30*time.Second, 200*time.Millisecond)
 	})
 

--- a/utils/monitoring/metrics.go
+++ b/utils/monitoring/metrics.go
@@ -37,18 +37,28 @@ type (
 	}
 )
 
-// LatencyBuckets are the shared histogram bucket boundaries (seconds) for the gRPC request-latency
-// metric, so those histograms are comparable across services. It reaches 10s to cover slow RPCs;
-// components timing shorter internal work (e.g. VC and dependency-graph batches) keep their own
-// narrower buckets.
-var LatencyBuckets = []float64{.0001, .001, .002, .003, .004, .005, .01, .03, .05, .1, .3, .5, 1, 2, 3, 4, 5, 10}
+var (
+	// LatencyBuckets are the shared histogram bucket boundaries (seconds) for the gRPC request-latency
+	// metric, so those histograms are comparable across services. It reaches 10s to cover slow RPCs;
+	// components timing shorter internal work (e.g. VC and dependency-graph batches) keep their own
+	// narrower buckets.
+	LatencyBuckets = []float64{.0001, .001, .002, .003, .004, .005, .01, .03, .05, .1, .3, .5, 1, 2, 3, 4, 5, 10}
 
-// StreamDurationBuckets are the histogram bucket boundaries (seconds) for the gRPC stream-duration
-// metric. Streams (notification subscriptions, verification streams, health watches) stay open from
-// well under a second to hours, so the buckets span that range rather than reusing LatencyBuckets,
-// whose 10s ceiling would collapse every long-lived stream into the +Inf bucket. The range is 0.1s
-// to 6h.
-var StreamDurationBuckets = []float64{.1, .5, 1, 5, 15, 30, 60, 120, 300, 600, 1800, 3600, 10800, 21600}
+	// StreamDurationBuckets are the histogram bucket boundaries (seconds) for the gRPC stream-duration
+	// metric. Streams (notification subscriptions, verification streams, health watches) stay open from
+	// well under a second to hours, so the buckets span that range rather than reusing LatencyBuckets,
+	// whose 10s ceiling would collapse every long-lived stream into the +Inf bucket. The range is 0.1s
+	// to 6h.
+	StreamDurationBuckets = []float64{.1, .5, 1, 5, 15, 30, 60, 120, 300, 600, 1800, 3600, 10800, 21600}
+
+	// MessageSizeBuckets defines boundaries for gRPC wire-size histograms (in bytes).
+	// They range from 8B (which covers the 5-byte minimum gRPC header) up to 100MiB,
+	// matching the explicit connection.MaxMsgSize limit.
+	MessageSizeBuckets = []float64{
+		8, 32, 128, 512, 2 << 10, 8 << 10, 32 << 10, 128 << 10,
+		512 << 10, 2 << 20, 8 << 20, 32 << 20, 64 << 20, 100 << 20,
+	}
+)
 
 // NewThroughputMetrics creates a new prometheus throughput counter.
 func NewThroughputMetrics(p *Provider, params MetricsParameters) *ThroughputMetrics {

--- a/utils/serve/metrics.go
+++ b/utils/serve/metrics.go
@@ -29,6 +29,14 @@ type ServerMetrics struct {
 	// ActiveConnections is incremented when the server accepts a connection and decremented
 	// when it is torn down, so it reflects the number of connections currently open.
 	ActiveConnections prometheus.Gauge
+	// MessageReceivedSizeBytes observes the wire size of each message that arrived and decoded
+	// successfully: the compressed payload plus gRPC framing, excluding HTTP/2 framing.
+	// Its "_count" time series acts as a throughput counter for successfully received messages.
+	MessageReceivedSizeBytes *prometheus.HistogramVec
+	// MessageSentSizeBytes observes the wire size of each message successfully written to the
+	// transport, on the same basis as MessageReceivedSizeBytes. Its "_count" time series
+	// acts as a throughput counter for successfully sent messages.
+	MessageSentSizeBytes *prometheus.HistogramVec
 }
 
 const method = "method"
@@ -68,5 +76,19 @@ func NewServerMetrics(p *monitoring.Provider, params monitoring.MetricsParameter
 			Name:      "active_connections",
 			Help:      "Number of client connections currently open on the server",
 		}),
+		MessageReceivedSizeBytes: p.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: params.Namespace,
+			Subsystem: params.Subsystem,
+			Name:      "message_received_size_bytes",
+			Help:      "Distribution of the wire sizes in bytes of messages received by the server.",
+			Buckets:   monitoring.MessageSizeBuckets,
+		}, []string{method}),
+		MessageSentSizeBytes: p.NewHistogramVec(prometheus.HistogramOpts{
+			Namespace: params.Namespace,
+			Subsystem: params.Subsystem,
+			Name:      "message_sent_size_bytes",
+			Help:      "Distribution of the wire sizes in bytes of messages sent by the server.",
+			Buckets:   monitoring.MessageSizeBuckets,
+		}, []string{method}),
 	}
 }

--- a/utils/serve/server_stats.go
+++ b/utils/serve/server_stats.go
@@ -12,6 +12,8 @@ import (
 
 	"google.golang.org/grpc/stats"
 	"google.golang.org/grpc/status"
+
+	"github.com/hyperledger/fabric-x-committer/utils/monitoring/promutil"
 )
 
 type (
@@ -56,7 +58,8 @@ func (*ServerStatsHandler) TagRPC(ctx context.Context, info *stats.RPCTagInfo) c
 	})
 }
 
-// HandleRPC records RPC-level metrics on RPC beginning and completion.
+// HandleRPC records RPC-level metrics on RPC beginning and completion, and per-message metrics as
+// each message crosses the wire.
 func (h *ServerStatsHandler) HandleRPC(ctx context.Context, s stats.RPCStats) {
 	m := h.metrics.Load()
 	if m == nil {
@@ -76,14 +79,18 @@ func (h *ServerStatsHandler) HandleRPC(ctx context.Context, s stats.RPCStats) {
 	case *stats.End:
 		// If the error is nil, the result is "OK"; if it is not a gRPC error, the result is "Unknown".
 		statusCode := status.Code(st.Error).String()
-		duration := st.EndTime.Sub(st.BeginTime).Seconds()
+		duration := st.EndTime.Sub(st.BeginTime)
 
 		if rm.isStream {
 			m.ActiveStreams.WithLabelValues(rm.fullMethodName).Dec()
-			m.StreamDurationSeconds.WithLabelValues(rm.fullMethodName, statusCode).Observe(duration)
+			promutil.Observe(m.StreamDurationSeconds.WithLabelValues(rm.fullMethodName, statusCode), duration)
 		} else {
-			m.LatencySeconds.WithLabelValues(rm.fullMethodName, statusCode).Observe(duration)
+			promutil.Observe(m.LatencySeconds.WithLabelValues(rm.fullMethodName, statusCode), duration)
 		}
+	case *stats.InPayload:
+		promutil.ObserveSize(m.MessageReceivedSizeBytes.WithLabelValues(rm.fullMethodName), st.WireLength)
+	case *stats.OutPayload:
+		promutil.ObserveSize(m.MessageSentSizeBytes.WithLabelValues(rm.fullMethodName), st.WireLength)
 	default:
 	}
 }

--- a/utils/serve/server_stats_test.go
+++ b/utils/serve/server_stats_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
+	promgo "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
@@ -111,7 +112,8 @@ func TestServerConnStatsHandler(t *testing.T) {
 }
 
 // TestServerStatsHandlerUnaryRPC verifies the handler's unary workflow: a completed unary RPC
-// increments requestsTotal and records its latency, and is never counted as an active stream.
+// increments requestsTotal, records its latency, and observes one received and one sent message with
+// its wire size, and is never counted as an active stream.
 func TestServerStatsHandlerUnaryRPC(t *testing.T) {
 	t.Parallel()
 
@@ -129,8 +131,26 @@ func TestServerStatsHandlerUnaryRPC(t *testing.T) {
 	)
 
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
-		require.Positive(ct, metricVecValue(ct,
-			env.metrics.LatencySeconds.MetricVec, healthCheckMethod, statusOK))
+		require.Positive(
+			ct,
+			getMetricValueByLabels(ct,
+				env.metrics.LatencySeconds.MetricVec, healthCheckMethod, statusOK),
+		)
+		require.Equal(ct, uint64(1), getHistogramVecCountByLabels(ct,
+			env.metrics.MessageReceivedSizeBytes, healthCheckMethod))
+		require.Equal(ct, uint64(1), getHistogramVecCountByLabels(ct,
+			env.metrics.MessageSentSizeBytes, healthCheckMethod))
+		require.Positive(
+			ct,
+			getMetricValueByLabels(ct,
+				env.metrics.MessageReceivedSizeBytes.MetricVec, healthCheckMethod),
+		)
+		require.Positive(
+			ct,
+			getMetricValueByLabels(ct,
+				env.metrics.MessageSentSizeBytes.MetricVec, healthCheckMethod),
+		)
+		require.Equal(ct, 0, testutil.CollectAndCount(env.metrics.StreamDurationSeconds))
 	}, 30*time.Second, 100*time.Millisecond)
 
 	// A unary RPC must never be treated as a stream.
@@ -141,22 +161,30 @@ func TestServerStatsHandlerUnaryRPC(t *testing.T) {
 	)
 }
 
-// TestServerStatsHandlerStreamingRPC verifies the handler's streaming workflow: an open stream is
-// counted in activeStreams, and tearing it down decrements the gauge, increments requestsTotal,
-// and records the stream's duration.
+// TestServerStatsHandlerStreamingRPC verifies that the handler tracks the complete lifecycle of a
+// streaming RPC. It checks that the active-stream gauge is incremented while the stream is open,
+// received and sent messages are recorded separately, and canceling the stream decrements the gauge
+// and records the stream duration with a canceled status.
 func TestServerStatsHandlerStreamingRPC(t *testing.T) {
 	t.Parallel()
 
 	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Minute)
 	t.Cleanup(cancel)
-	env := newServerStatsTestEnv(ctx, t, serve.DefaultHealthCheckService())
+	healthServer := serve.DefaultHealthCheckService()
+	env := newServerStatsTestEnv(ctx, t, healthServer)
 
 	streamCtx, cancelStream := context.WithCancel(ctx)
 	t.Cleanup(cancelStream)
 
+	// Watch consumes a single request and then pushes one message per status change, the first one
+	// immediately, so the status flip drives a second message out.
 	stream, err := env.health.Watch(streamCtx, &healthgrpc.HealthCheckRequest{})
 	require.NoError(t, err)
 	_, err = stream.Recv()
+	require.NoError(t, err)
+	healthServer.SetServingStatus("", healthgrpc.HealthCheckResponse_NOT_SERVING)
+	resp, err := stream.Recv()
+	require.NotNil(t, resp)
 	require.NoError(t, err)
 
 	test.EventuallyIntMetric(
@@ -172,6 +200,13 @@ func TestServerStatsHandlerStreamingRPC(t *testing.T) {
 		30*time.Second, 100*time.Millisecond,
 	)
 
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		require.Equal(ct, uint64(1), getHistogramVecCountByLabels(ct,
+			env.metrics.MessageReceivedSizeBytes, healthWatchMethod))
+		require.Equal(ct, uint64(2), getHistogramVecCountByLabels(ct,
+			env.metrics.MessageSentSizeBytes, healthWatchMethod))
+	}, 30*time.Second, 100*time.Millisecond)
+
 	// Tearing the stream down completes the RPC: the gauge returns to zero and the stream duration is recorded.
 	cancelStream()
 
@@ -181,8 +216,9 @@ func TestServerStatsHandlerStreamingRPC(t *testing.T) {
 		30*time.Second, 100*time.Millisecond,
 	)
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
-		require.Positive(ct, metricVecValue(ct,
-			env.metrics.StreamDurationSeconds.MetricVec, healthWatchMethod, statusCanceled))
+		require.Positive(ct,
+			getMetricValueByLabels(ct,
+				env.metrics.StreamDurationSeconds.MetricVec, healthWatchMethod, statusCanceled))
 	}, 30*time.Second, 100*time.Millisecond)
 }
 
@@ -246,12 +282,14 @@ func requireRPCStatusRecorded(t *testing.T, rpcErr error, wantStatus string) {
 		require.Equal(ct, 1, testutil.CollectAndCount(env.metrics.LatencySeconds))
 		require.Positive(
 			ct,
-			metricVecValue(ct, env.metrics.LatencySeconds.MetricVec, healthCheckMethod, wantStatus),
+			getMetricValueByLabels(ct,
+				env.metrics.LatencySeconds.MetricVec, healthCheckMethod, wantStatus),
 		)
 		require.Equal(ct, 1, testutil.CollectAndCount(env.metrics.StreamDurationSeconds))
 		require.Positive(
 			ct,
-			metricVecValue(ct, env.metrics.StreamDurationSeconds.MetricVec, healthWatchMethod, wantStatus),
+			getMetricValueByLabels(ct,
+				env.metrics.StreamDurationSeconds.MetricVec, healthWatchMethod, wantStatus),
 		)
 	}, 30*time.Second, 100*time.Millisecond)
 }
@@ -276,9 +314,20 @@ func newServerStatsTestEnv(
 	}
 }
 
-func metricVecValue(t test.TestingT, mv *prometheus.MetricVec, lvs ...string) float64 {
+func getMetricValueByLabels(t test.TestingT, mv *prometheus.MetricVec, lvs ...string) float64 {
 	t.Helper()
 	m, err := mv.GetMetricWithLabelValues(lvs...)
 	require.NoError(t, err)
 	return test.GetMetricValue(t, m)
+}
+
+func getHistogramVecCountByLabels(t test.TestingT, hv *prometheus.HistogramVec, lvs ...string) uint64 {
+	t.Helper()
+	// HistogramVec.GetMetricWithLabelValues yields an Observer, which cannot be written to a dto;
+	// the embedded MetricVec returns the same child as a Metric, which can.
+	m, err := hv.MetricVec.GetMetricWithLabelValues(lvs...)
+	require.NoError(t, err)
+	gm := promgo.Metric{}
+	require.NoError(t, m.Write(&gm))
+	return gm.Histogram.GetSampleCount()
 }


### PR DESCRIPTION
#### Type of change

- Improvement (improvement to code, performance, etc)
- Test update

#### Description

This PR includes the implementation of phaste two of #709  

- Add two method-labeled server histograms for received and sent message wire sizes.
- Use each histogram's `_count` as the per-direction message counter, including streaming throughput.
- Add shared size buckets from 8 B to 100 MiB, covering empty frames through `connection.MaxMsgSize`.
- Route latency and stream-duration observations through `promutil.Observe`.
- Extend the existing unit and full-system integration tests to cover the new metrics.

#### Additional details (Optional)

Both directions are recorded only for messages gRPC actually completed: `InPayload` fires
after a message decodes successfully, and `OutPayload` only once the transport write
returns without error, so a malformed or undelivered message is not observed.

#### Related issues

- resolves #709 