### PR TITLE
[loadgen] Stop block preparation from capping the generator at small block sizes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -187,3 +187,10 @@ require (
 	moul.io/http2curl/v2 v2.3.0 // indirect
 	mvdan.cc/gofumpt v0.10.0 // indirect
 )
+
+// Pending hyperledger/fabric-x-common#186, which adds the BlockPrepareParameters options the mock
+// orderer's prepare-in-place path needs. This points at that same commit rebased onto the revision
+// required above, because fabric-x-common's main also carries #179, a breaking change this repository
+// has not adopted yet. Drop the replace once #186 merges and this repository moves to a release
+// carrying it.
+replace github.com/hyperledger/fabric-x-common => github.com/liran-funaro/fabric-x-common v0.0.0-20260910144220-0240aee5a4f5

--- a/go.sum
+++ b/go.sum
@@ -184,8 +184,6 @@ github.com/hyperledger/fabric-lib-go v1.1.5-0.20260708100132-163bcc919208 h1:qA4
 github.com/hyperledger/fabric-lib-go v1.1.5-0.20260708100132-163bcc919208/go.mod h1:EKqTudBsC2yovZdcJq5ekWvkq3USF1mbau07I0y8zMs=
 github.com/hyperledger/fabric-protos-go-apiv2 v0.3.7 h1:sQ5qv8vQQfwewa1JlCiSCC8dLElmaU2/frLolpgibEY=
 github.com/hyperledger/fabric-protos-go-apiv2 v0.3.7/go.mod h1:bJnwzfv03oZQeCc863pdGTDgf5nmCy6Za3RAE7d2XsQ=
-github.com/hyperledger/fabric-x-common v0.2.9-0.20260723091942-e43f1af10c7e h1:1TiqmKe1L3/KnKXHHId+i1WHY/4hIaI8sCyLrhWFpsI=
-github.com/hyperledger/fabric-x-common v0.2.9-0.20260723091942-e43f1af10c7e/go.mod h1:f30Yws3c5Cg22yHLy2oT2XR0wwZI+JdqbUqB2fwFIsM=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imkira/go-interpol v1.1.0 h1:KIiKr0VSG2CUW1hl1jpiyuzuJeKUUpC8iM1AIE7N1Vk=
 github.com/imkira/go-interpol v1.1.0/go.mod h1:z0h2/2T3XF8kyEPpRgJ3kmNv+C43p+I/CoI+jC3w2iA=
@@ -218,6 +216,8 @@ github.com/leanovate/gopter v0.2.11 h1:vRjThO1EKPb/1NsDXuDrzldR28RLkBflWYcU9CvzW
 github.com/leanovate/gopter v0.2.11/go.mod h1:aK3tzZP/C+p1m3SPRE4SYZFGP7jjkuSI4f7Xvpt0S9c=
 github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
+github.com/liran-funaro/fabric-x-common v0.0.0-20260910144220-0240aee5a4f5 h1:3vaRJo0vVCRDZnZoC/YCkf2NQRiU2S+vInlcXXjWPao=
+github.com/liran-funaro/fabric-x-common v0.0.0-20260910144220-0240aee5a4f5/go.mod h1:f30Yws3c5Cg22yHLy2oT2XR0wwZI+JdqbUqB2fwFIsM=
 github.com/lithammer/dedent v1.1.0 h1:VNzHMVCBNG1j0fh3OrsFRkVUwStdDArbgBWoPAffktY=
 github.com/lithammer/dedent v1.1.0/go.mod h1:jrXYCQtgg0nJiN+StA2KgR7w6CiQNv9Fd/Z9BP0jIOc=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=

--- a/loadgen/adapters/sidecar.go
+++ b/loadgen/adapters/sidecar.go
@@ -43,6 +43,9 @@ func (c *SidecarAdapter) RunWorkload(ctx context.Context, txStream *workload.Str
 		ArtifactsPath: c.res.Profile.Policy.ArtifactsPath,
 		// The sidecar adapter submits a config block manually.
 		SendGenesisBlock: true,
+		// This adapter builds a block per batch and never touches it again, and MapToOrdererBlock
+		// leaves the data hash in its header, so the orderer needs neither a clone nor a rehash.
+		PrepareInPlace: true,
 	})
 	if err != nil {
 		return err

--- a/loadgen/workload/mappers.go
+++ b/loadgen/workload/mappers.go
@@ -9,6 +9,7 @@ package workload
 import (
 	"github.com/hyperledger/fabric-protos-go-apiv2/common"
 	"github.com/hyperledger/fabric-x-common/api/committerpb"
+	"github.com/hyperledger/fabric-x-common/protoutil"
 
 	"github.com/hyperledger/fabric-x-committer/api/servicepb"
 )
@@ -64,14 +65,21 @@ func MapToEnvelopeBatch(_ uint64, txs []*servicepb.LoadGenTx) []*common.Envelope
 }
 
 // MapToOrdererBlock creates a Fabric's Orderer output block.
+//
+// The data hash is computed here, on the caller's goroutine, rather than left to whoever prepares the
+// block's header. It covers the block's own data and nothing else, so unlike the number and the
+// previous hash it does not depend on the chain and need not be computed in chain order -- and hashing
+// is the whole per-transaction cost of preparing a block, which a single block-preparing goroutine
+// would otherwise pay for every block in sequence.
 func MapToOrdererBlock(blockNum uint64, txs []*servicepb.LoadGenTx) *common.Block {
 	data := make([][]byte, len(txs))
 	for i, tx := range txs {
 		data[i] = tx.SerializedEnvelope
 	}
+	blockData := &common.BlockData{Data: data}
 	return &common.Block{
-		Header: &common.BlockHeader{Number: blockNum},
-		Data:   &common.BlockData{Data: data},
+		Header: &common.BlockHeader{Number: blockNum, DataHash: protoutil.ComputeBlockDataHash(blockData)},
+		Data:   blockData,
 	}
 }
 

--- a/mock/orderer.go
+++ b/mock/orderer.go
@@ -42,11 +42,16 @@ import (
 type (
 	// OrdererConfig configuration for the mock orderer.
 	OrdererConfig struct {
-		Servers                 []*serve.ServerConfig         `mapstructure:"servers"`
-		BlockSize               int                           `mapstructure:"block-size"`
-		BlockTimeout            time.Duration                 `mapstructure:"block-timeout"`
-		OutBlockCapacity        int                           `mapstructure:"out-block-capacity"`
-		PayloadCacheSize        int                           `mapstructure:"payload-cache-size"`
+		Servers          []*serve.ServerConfig `mapstructure:"servers"`
+		BlockSize        int                   `mapstructure:"block-size"`
+		BlockTimeout     time.Duration         `mapstructure:"block-timeout"`
+		OutBlockCapacity int                   `mapstructure:"out-block-capacity"`
+		PayloadCacheSize int                   `mapstructure:"payload-cache-size"`
+		// PrepareInPlace declares that blocks submitted with SubmitBlock belong to this orderer, so it
+		// writes their header into the block it was given and reuses the data hash the submitter
+		// filled in. Only safe when the submitter builds a block per call and never touches it again.
+		// Does not apply to the genesis and config blocks, which may be shared.
+		PrepareInPlace          bool                          `mapstructure:"prepare-in-place"`
 		ArtifactsPath           string                        `mapstructure:"artifacts-path"`
 		GenesisBlockPath        string                        `mapstructure:"genesis-block-path"`
 		ConsentersMSPIdentities []*ordererdial.IdentityConfig `mapstructure:"consenter-msp-identities"`
@@ -428,6 +433,14 @@ func (o *Orderer) Run(ctx context.Context) error {
 	// Submit the config block.
 	if o.config.Load().SendGenesisBlock {
 		sendBlockWithConsenters(&o.genesisBlock)
+	}
+
+	// After the genesis block, and only after it: the genesis block may be the package-level default,
+	// which is shared, and preparing that one in place would rewrite it for every orderer in the
+	// process.
+	if o.config.Load().PrepareInPlace {
+		blockParams.InPlace = true
+		blockParams.ReuseDataHash = true
 	}
 
 	data := make([][]byte, 0, o.config.Load().BlockSize)

--- a/mock/orderer_bench_test.go
+++ b/mock/orderer_bench_test.go
@@ -1,0 +1,123 @@
+/*
+Copyright IBM Corp. All Rights Reserved.
+
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package mock
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/hyperledger/fabric-protos-go-apiv2/common"
+	"github.com/hyperledger/fabric-x-common/protoutil"
+	"github.com/hyperledger/fabric-x-common/utils/testcrypto"
+	"github.com/stretchr/testify/require"
+)
+
+// BenchmarkOrdererBlockRate measures how fast the mock orderer can serve blocks that were cut for it,
+// which is the rate the load generator's sidecar adapter is bounded by.
+//
+// It is the generator, not the committer, that this bounds: at 500 transactions a block the adapter
+// stalled near 850 blocks a second, so a committer that could take more was never asked to. The cost is
+// all in preparing the block on one goroutine -- deep-cloning it and hashing its data -- and
+// PrepareInPlace removes the clone and takes the hash from the header the submitter already filled in.
+//
+// Both block sizes are measured because the trade is between them: the same per-block cost is spread
+// over twenty times as many transactions in a 10,000-transaction block.
+func BenchmarkOrdererBlockRate(b *testing.B) {
+	// The crypto material is generated once and shared: generating it per case costs far more than the
+	// measurement, and it is identical for all of them. The orderer needs only the consenter signing
+	// identities from it, since nothing here serves gRPC.
+	artifactsPath := b.TempDir()
+	_, err := testcrypto.CreateOrExtendConfigBlockWithCrypto(artifactsPath, &testcrypto.ConfigBlock{
+		ChannelID:             "channel",
+		PeerOrganizationCount: 1,
+	})
+	require.NoError(b, err)
+
+	for _, txCount := range []int{500, 10_000} {
+		for _, inPlace := range []bool{false, true} {
+			b.Run(fmt.Sprintf("prepare-in-place=%v/tx=%d", inPlace, txCount), func(b *testing.B) {
+				orderer, err := NewMockOrderer(&OrdererConfig{
+					ArtifactsPath:    artifactsPath,
+					SendGenesisBlock: false,
+					BlockSize:        1,
+					// Two blocks, deliberately: SubmitBlock only hands the block to the preparing
+					// goroutine, so a deep buffer would measure the channel write and never the
+					// preparation behind it. At a depth of two the submitter can run at most one block
+					// ahead and is paced by the stage under test.
+					OutBlockCapacity: 2,
+					PrepareInPlace:   inPlace,
+				})
+				require.NoError(b, err)
+
+				// A ring of distinct blocks, not one block submitted repeatedly. In-place preparation
+				// writes the header into the block it was given, so a submitter that reuses one block
+				// hands the orderer's cache several entries that are all the same object, and a consumer
+				// asking for block n can wait for a number that has already been overwritten. That is
+				// the contract PrepareInPlace documents.
+				blocks := make([]*common.Block, 8)
+				for i := range blocks {
+					blocks[i] = benchBlock(txCount)
+					if inPlace {
+						// The work the adapter's mapper stage does one stage ahead of the orderer.
+						blocks[i].Header.DataHash = protoutil.ComputeBlockDataHash(blocks[i].Data)
+					}
+				}
+				benchmarkBlockRate(b, orderer, blocks)
+			})
+		}
+	}
+}
+
+// benchmarkBlockRate submits blocks in a ring as fast as the orderer accepts them, reporting the rate
+// it serves them at. txCount is taken from the blocks, which the caller built.
+func benchmarkBlockRate(b *testing.B, orderer *Orderer, blocks []*common.Block) {
+	b.Helper()
+	txCount := len(blocks[0].Data.Data)
+
+	ctx, cancel := context.WithCancel(b.Context())
+	defer cancel()
+	go func() { _ = orderer.Run(ctx) }()
+	// The block cache holds OutBlockCapacity blocks, so without a consumer the submitter would measure
+	// the cache filling once and then block forever.
+	go func() {
+		for n := uint64(0); ctx.Err() == nil; n++ {
+			if _, err := orderer.GetBlock(ctx, n); err != nil {
+				return
+			}
+		}
+	}()
+
+	i := 0
+	b.ResetTimer()
+	for b.Loop() {
+		require.NoError(b, orderer.SubmitBlock(ctx, blocks[i%len(blocks)]))
+		i++
+	}
+	b.StopTimer()
+	perBlock := b.Elapsed().Seconds() / float64(b.N)
+	b.ReportMetric(1/perBlock, "blocks/s")
+	b.ReportMetric(float64(txCount)/perBlock/1000, "Ktx/s")
+}
+
+// benchBlock builds one block of txCount serialized envelopes of 300 bytes each, the transaction size
+// the evaluation generates.
+func benchBlock(txCount int) *common.Block {
+	data := make([][]byte, txCount)
+	for i := range data {
+		payload := make([]byte, 300)
+		for j := range payload {
+			payload[j] = byte(i + j)
+		}
+		data[i] = protoutil.MarshalOrPanic(&common.Envelope{Payload: payload})
+	}
+	block := &common.Block{
+		Header: &common.BlockHeader{},
+		Data:   &common.BlockData{Data: data},
+	}
+	return block
+}


### PR DESCRIPTION
#### Type of change

- Improvement (improvement to code, performance, etc)
- Test update

#### Description

- `workload.MapToOrdererBlock` now computes the block's data hash. The hash covers the block's own
  data, so unlike the number and the previous hash it does not depend on the chain and need not be
  computed in chain order — and it is the whole per-transaction cost of preparing a block, which a
  single block-preparing goroutine would otherwise pay for every block in sequence.
- `prepare-in-place` on the mock orderer declares that blocks submitted to it are its own, so it
  writes their header into the block it was given and reuses the data hash the submitter filled in
  rather than deep-cloning and rehashing. Applied only after the genesis block, which may be the
  package-level default and would otherwise be rewritten for every orderer in the process.
- The sidecar adapter turns it on, since it builds a block per batch and never touches it again. What
  the committer receives is unchanged; only the cost of producing it is.
- Adds `BenchmarkOrdererBlockRate`, which measures the rate the adapter is bounded by, at both block
  sizes the evaluation used. It pins the buffer between submitter and preparer to two blocks, because
  `SubmitBlock` only hands the block over and a deep buffer measures the channel write instead of the
  work behind it. Its floor excludes the consenter signature, roughly 45 µs, which a deployment pays
  and this configuration does not exercise.
- `go.mod` temporarily replaces `fabric-x-common` with the branch of
  hyperledger/fabric-x-common#186, which adds the two `BlockPrepareParameters` options this uses. It
  points at that same commit rebased onto the revision this repository already requires, because
  fabric-x-common's `main` also carries #179, a breaking change this repository has not adopted yet.

#### Additional details (Optional)

> [!WARNING]
> **Merging is blocked until hyperledger/fabric-x-common#186 is merged.** Until then this branch
> builds against a fork, through the `replace` directive at the bottom of `go.mod`. Once #186 is
> merged and this repository moves to a fabric-x-common revision carrying it, drop the `replace` and
> bump the `require`; nothing else in this change depends on it.

Preparation becomes independent of block size, which is the point — the clone and the hash were the
only costs that scaled with it:

    go test ./mock/ -run '^$' -bench '^BenchmarkOrdererBlockRate$' -benchtime=30x

#### Related issues

- resolves #824
